### PR TITLE
Add `zcashd`-compatible JSON-RPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -129,6 +129,23 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -150,6 +167,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "basic-toml"
@@ -180,6 +203,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "canonical-path"
@@ -233,7 +268,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -318,7 +353,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -366,7 +401,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "self_cell 0.10.3",
  "smallvec",
  "unic-langid",
@@ -391,12 +426,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -410,10 +540,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -432,6 +592,88 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "i18n-config"
@@ -486,7 +728,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.85",
+ "syn 2.0.96",
  "unic-langid",
 ]
 
@@ -500,7 +742,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -549,6 +791,101 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jsonrpsee"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot",
+ "rand",
+ "rustc-hash 2.1.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06c01ae0007548e73412c08e2285ffe5d723195bf268bce67b1b77c3bb2a14d"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
+dependencies = [
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
+dependencies = [
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "lazy_static"
@@ -622,6 +959,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -714,10 +1062,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -738,14 +1130,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -757,6 +1149,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -813,6 +1235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
 name = "rust-embed"
 version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,7 +1260,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.85",
+ "syn 2.0.96",
  "walkdir",
 ]
 
@@ -857,6 +1285,18 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -924,7 +1364,19 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -934,6 +1386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -963,10 +1426,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+]
 
 [[package]]
 name = "strsim"
@@ -987,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1034,7 +1532,7 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1063,8 +1561,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1075,7 +1578,33 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1122,11 +1651,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1140,7 +1697,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1188,7 +1745,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -1266,6 +1823,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,7 +1850,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1295,6 +1858,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1385,12 +1957,40 @@ dependencies = [
  "abscissa_core",
  "abscissa_tokio",
  "clap",
+ "futures",
+ "http-body-util",
+ "hyper",
  "i18n-embed",
  "i18n-embed-fl",
+ "jsonrpsee",
  "once_cell",
+ "rand",
  "rust-embed",
  "serde",
+ "serde_json",
  "tokio",
+ "tower",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
 # Async
+futures = "0.3"
 tokio = "1"
 
 # Localization
@@ -24,10 +25,20 @@ i18n-embed = { version = "0.15", features = ["fluent-system"] }
 i18n-embed-fl = "0.9"
 rust-embed = "8"
 
-# Parsing
+# Parsing and serialization
 serde = { version = "1", features = ["serde_derive"] }
+serde_json = "1"
+
+# Randomness
+rand = "0.8"
 
 # CLI
 abscissa_core = "0.8"
 abscissa_tokio = "0.8"
 clap = { version = "4.5", features = ["derive"] }
+
+# RPC
+http-body-util = "0.1"
+hyper = "1"
+jsonrpsee = "0.24"
+tower = "0.4"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -12,11 +12,18 @@ categories.workspace = true
 abscissa_core.workspace = true
 abscissa_tokio.workspace = true
 clap = { workspace = true, features = ["string", "unstable-styles"] }
+futures.workspace = true
+http-body-util.workspace = true
+hyper.workspace = true
 i18n-embed = { workspace = true, features = ["desktop-requester"] }
 i18n-embed-fl.workspace = true
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+rand.workspace = true
 rust-embed.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower.workspace = true
 
 [dev-dependencies]
 abscissa_core = { workspace = true, features = ["testing"] }

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -20,7 +20,7 @@ flags-header = Options
 
 ## General errors
 
-err-discombobulated = Discombobulated
+err-init = Failed to initialize {-zallet}
 
 err-ux-A = Did {-zallet} not do what you expected? Could the error be more useful?
 err-ux-B = Tell us

--- a/zallet/src/commands/start.rs
+++ b/zallet/src/commands/start.rs
@@ -1,18 +1,60 @@
 //! `start` subcommand - example of how to write a subcommand
 
-use abscissa_core::{config, FrameworkError, Runnable, Shutdown};
+use abscissa_core::{config, tracing::Instrument, FrameworkError, Runnable, Shutdown};
+use tokio::{pin, select};
 
-use crate::{
-    cli::StartCmd,
-    config::ZalletConfig,
-    error::{Error, ErrorKind},
-    prelude::*,
-};
+use crate::{cli::StartCmd, components::json_rpc, config::ZalletConfig, error::Error, prelude::*};
 
 impl StartCmd {
     async fn start(&self) -> Result<(), Error> {
-        println!("run");
-        Err(ErrorKind::Discombobulated.into())
+        let config = APP.config();
+
+        // Launch RPC server.
+        let rpc_task_handle = if let Some(listen_addr) = config.rpc.listen_addr {
+            info!("Spawning RPC server");
+            info!("Trying to open RPC endpoint at {}...", listen_addr);
+            json_rpc::server::spawn(config.rpc.clone()).await?
+        } else {
+            warn!("Configure a listen_addr to start the RPC server");
+            // Emulate a normally-operating ongoing task to simplify subsequent logic.
+            tokio::spawn(std::future::pending().in_current_span())
+        };
+
+        info!("Spawned Zallet tasks");
+
+        // ongoing tasks.
+        pin!(rpc_task_handle);
+
+        // Wait for tasks to finish.
+        let res = loop {
+            let mut exit_when_task_finishes = true;
+
+            let result = select! {
+                rpc_join_result = &mut rpc_task_handle => {
+                    let rpc_server_result = rpc_join_result
+                        .expect("unexpected panic in the RPC task");
+                    info!(?rpc_server_result, "RPC task exited");
+                    Ok(())
+                }
+            };
+
+            // Stop Zallet if a task finished and returned an error, or if an ongoing task
+            // exited.
+            match result {
+                Err(_) => break result,
+                Ok(()) if exit_when_task_finishes => break result,
+                Ok(()) => (),
+            }
+        };
+
+        info!("Exiting Zallet because an ongoing task exited; asking other tasks to stop");
+
+        // ongoing tasks
+        rpc_task_handle.abort();
+
+        info!("All tasks have been asked to stop, waiting for remaining tasks to finish");
+
+        res
     }
 }
 

--- a/zallet/src/components.rs
+++ b/zallet/src/components.rs
@@ -1,0 +1,3 @@
+//! Components of Zallet.
+
+pub(crate) mod json_rpc;

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -1,0 +1,10 @@
+//! JSON-RPC endpoint.
+//!
+//! This provides JSON-RPC methods that are (mostly) compatible with the `zcashd` wallet
+//! RPCs:
+//! - Some methods are exactly compatible.
+//! - Some methods have the same name but slightly different semantics.
+//! - Some methods from the `zcashd` wallet are unsupported.
+
+pub(crate) mod methods;
+pub(crate) mod server;

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -1,0 +1,24 @@
+use jsonrpsee::proc_macros::rpc;
+
+mod get_wallet_info;
+
+#[rpc(server)]
+pub(crate) trait Rpc {
+    #[method(name = "getwalletinfo")]
+    fn get_wallet_info(&self) -> get_wallet_info::Response;
+}
+
+pub(crate) struct RpcImpl {}
+
+impl RpcImpl {
+    /// Creates a new instance of the RPC handler.
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl RpcServer for RpcImpl {
+    fn get_wallet_info(&self) -> get_wallet_info::Response {
+        get_wallet_info::call()
+    }
+}

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -1,11 +1,27 @@
 use jsonrpsee::proc_macros::rpc;
 
+mod get_notes_count;
 mod get_wallet_info;
+mod list_accounts;
+mod list_unified_receivers;
 
 #[rpc(server)]
 pub(crate) trait Rpc {
     #[method(name = "getwalletinfo")]
     fn get_wallet_info(&self) -> get_wallet_info::Response;
+
+    #[method(name = "z_listaccounts")]
+    fn list_accounts(&self) -> list_accounts::Response;
+
+    #[method(name = "z_listunifiedreceivers")]
+    fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response;
+
+    #[method(name = "z_getnotescount")]
+    fn get_notes_count(
+        &self,
+        minconf: Option<u32>,
+        as_of_height: Option<i32>,
+    ) -> get_notes_count::Response;
 }
 
 pub(crate) struct RpcImpl {}
@@ -20,5 +36,21 @@ impl RpcImpl {
 impl RpcServer for RpcImpl {
     fn get_wallet_info(&self) -> get_wallet_info::Response {
         get_wallet_info::call()
+    }
+
+    fn list_accounts(&self) -> list_accounts::Response {
+        list_accounts::call()
+    }
+
+    fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response {
+        list_unified_receivers::call(unified_address)
+    }
+
+    fn get_notes_count(
+        &self,
+        minconf: Option<u32>,
+        as_of_height: Option<i32>,
+    ) -> get_notes_count::Response {
+        get_notes_count::call(minconf, as_of_height)
     }
 }

--- a/zallet/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet/src/components/json_rpc/methods/get_notes_count.rs
@@ -1,0 +1,32 @@
+use jsonrpsee::{core::RpcResult, tracing::warn};
+use serde::{Deserialize, Serialize};
+
+/// Response to a `z_getnotescount` RPC request.
+pub(crate) type Response = RpcResult<GetNotesCount>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct GetNotesCount {
+    /// The number of Sprout notes in the wallet.
+    ///
+    /// Always zero, because Sprout is not supported.
+    sprout: u32,
+
+    /// The number of Sapling notes in the wallet.
+    sapling: u32,
+
+    /// The number of Orchard notes in the wallet.
+    orchard: u32,
+}
+
+pub(crate) fn call(minconf: Option<u32>, as_of_height: Option<i32>) -> Response {
+    warn!(
+        "TODO: Implement z_getnotescount({:?}, {:?})",
+        minconf, as_of_height
+    );
+
+    Ok(GetNotesCount {
+        sprout: 0,
+        sapling: 0,
+        orchard: 0,
+    })
+}

--- a/zallet/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_info.rs
@@ -1,0 +1,65 @@
+use jsonrpsee::{core::RpcResult, tracing::warn};
+use serde::{Deserialize, Serialize};
+
+/// Response to a `getwalletinfo` RPC request.
+pub(crate) type Response = RpcResult<GetWalletInfo>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct GetWalletInfo {
+    /// The wallet version, in its "Bitcoin client version" form.
+    walletversion: u64,
+
+    /// The total confirmed transparent balance of the wallet in ZEC.
+    balance: f64,
+
+    /// The total unconfirmed transparent balance of the wallet in ZEC.
+    ///
+    /// Not included if `asOfHeight` is specified.
+    unconfirmed_balance: Option<f64>,
+
+    /// The total immature transparent balance of the wallet in ZEC.
+    immature_balance: f64,
+
+    /// The total confirmed shielded balance of the wallet in ZEC.
+    shielded_balance: String,
+
+    /// The total unconfirmed shielded balance of the wallet in ZEC.
+    ///
+    /// Not included if `asOfHeight` is specified.
+    shielded_unconfirmed_balance: Option<String>,
+
+    /// The total number of transactions in the wallet
+    txcount: u64,
+
+    /// The timestamp (seconds since GMT epoch) of the oldest pre-generated key in the
+    /// key pool.
+    keypoololdest: u64,
+
+    /// How many new keys are pre-generated.
+    keypoolsize: u32,
+
+    /// The timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is
+    /// unlocked for transfers, or 0 if the wallet is locked.
+    unlocked_until: u32,
+
+    /// The BLAKE2b-256 hash of the HD seed derived from the wallet's emergency recovery phrase.
+    mnemonic_seedfp: String,
+}
+
+pub(crate) fn call() -> Response {
+    warn!("TODO: Implement getwalletinfo");
+
+    Ok(GetWalletInfo {
+        walletversion: 0,
+        balance: 0.0,
+        unconfirmed_balance: Some(0.0),
+        immature_balance: 0.0,
+        shielded_balance: "0.00".into(),
+        shielded_unconfirmed_balance: Some("0.00".into()),
+        txcount: 0,
+        keypoololdest: 0,
+        keypoolsize: 0,
+        unlocked_until: 0,
+        mnemonic_seedfp: "TODO".into(),
+    })
+}

--- a/zallet/src/components/json_rpc/methods/list_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/list_accounts.rs
@@ -1,0 +1,27 @@
+use jsonrpsee::{core::RpcResult, tracing::warn};
+use serde::{Deserialize, Serialize};
+
+/// Response to a `z_listaccounts` RPC request.
+pub(crate) type Response = RpcResult<Vec<Account>>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Account {
+    /// The ZIP 32 account ID.
+    account: u64,
+    addresses: Vec<Address>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Address {
+    /// A diversifier index used in the account.
+    diversifier_index: u128,
+
+    /// The unified address corresponding to the diversifier.
+    ua: String,
+}
+
+pub(crate) fn call() -> Response {
+    warn!("TODO: Implement z_listaccounts");
+
+    Ok(vec![])
+}

--- a/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
+++ b/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
@@ -1,0 +1,34 @@
+use jsonrpsee::{core::RpcResult, tracing::warn, types::ErrorCode};
+use serde::{Deserialize, Serialize};
+
+/// Response to a `z_listunifiedreceivers` RPC request.
+pub(crate) type Response = RpcResult<ListUnifiedReceivers>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ListUnifiedReceivers {
+    /// The legacy P2PKH transparent address.
+    ///
+    /// Omitted if `p2sh` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    p2pkh: Option<String>,
+
+    /// The legacy P2SH transparent address.
+    ///
+    /// Omitted if `p2pkh` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    p2sh: Option<String>,
+
+    /// The legacy Sapling address.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sapling: Option<String>,
+
+    /// A single-receiver Unified Address containing the Orchard receiver.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    orchard: Option<String>,
+}
+
+pub(crate) fn call(unified_address: &str) -> Response {
+    warn!("TODO: Implement z_listunifiedreceivers({unified_address})");
+
+    Err(ErrorCode::MethodNotFound.into())
+}

--- a/zallet/src/components/json_rpc/server.rs
+++ b/zallet/src/components/json_rpc/server.rs
@@ -1,0 +1,58 @@
+//! JSON-RPC server that is compatible with `zcashd`.
+
+use jsonrpsee::{
+    server::{RpcServiceBuilder, Server},
+    tracing::info,
+};
+use tokio::task::JoinHandle;
+
+use crate::{
+    config::RpcSection,
+    error::{Error, ErrorKind},
+};
+
+use super::methods::{RpcImpl, RpcServer as _};
+
+mod error;
+mod http_request_compatibility;
+mod rpc_call_compatibility;
+
+type ServerTask = JoinHandle<Result<(), Error>>;
+
+pub(crate) async fn spawn(config: RpcSection) -> Result<ServerTask, Error> {
+    let listen_addr = config
+        .listen_addr
+        .expect("caller should make sure listen_addr is set");
+
+    // Initialize the RPC methods.
+    let rpc_impl = RpcImpl::new();
+
+    let http_middleware_layer = http_request_compatibility::HttpRequestMiddlewareLayer::new();
+
+    let http_middleware = tower::ServiceBuilder::new().layer(http_middleware_layer);
+
+    let rpc_middleware = RpcServiceBuilder::new()
+        .rpc_logger(1024)
+        .layer_fn(rpc_call_compatibility::FixRpcResponseMiddleware::new);
+
+    let server_instance = Server::builder()
+        .http_only()
+        .set_http_middleware(http_middleware)
+        .set_rpc_middleware(rpc_middleware)
+        .build(listen_addr)
+        .await
+        .map_err(|e| ErrorKind::Init.context(e))?;
+    let addr = server_instance
+        .local_addr()
+        .map_err(|e| ErrorKind::Init.context(e))?;
+    info!("Opened RPC endpoint at {}", addr);
+
+    let rpc_module = rpc_impl.into_rpc();
+
+    let server_task = tokio::spawn(async move {
+        server_instance.start(rpc_module).stopped().await;
+        Ok(())
+    });
+
+    Ok(server_task)
+}

--- a/zallet/src/components/json_rpc/server/error.rs
+++ b/zallet/src/components/json_rpc/server/error.rs
@@ -1,0 +1,66 @@
+//! RPC error codes & their handling.
+
+use jsonrpsee::types::ErrorCode;
+
+/// Bitcoin RPC error codes
+///
+/// Drawn from <https://github.com/zcash/zcash/blob/99ad6fdc3a549ab510422820eea5e5ce9f60a5fd/src/rpc/protocol.h#L32-L80>.
+///
+/// ## Notes
+///
+/// - All explicit discriminants fit within `i64`.
+#[derive(Default, Debug)]
+pub enum LegacyCode {
+    // General application defined errors
+    /// `std::exception` thrown in command handling
+    #[default]
+    Misc = -1,
+    /// Server is in safe mode, and command is not allowed in safe mode
+    ForbiddenBySafeMode = -2,
+    /// Unexpected type was passed as parameter
+    Type = -3,
+    /// Invalid address or key
+    InvalidAddressOrKey = -5,
+    /// Ran out of memory during operation
+    OutOfMemory = -7,
+    /// Invalid, missing or duplicate parameter
+    InvalidParameter = -8,
+    /// Database error
+    Database = -20,
+    /// Error parsing or validating structure in raw format
+    Deserialization = -22,
+    /// General error during transaction or block submission
+    Verify = -25,
+    /// Transaction or block was rejected by network rules
+    VerifyRejected = -26,
+    /// Transaction already in chain
+    VerifyAlreadyInChain = -27,
+    /// Client still warming up
+    InWarmup = -28,
+
+    // P2P client errors
+    /// Bitcoin is not connected
+    ClientNotConnected = -9,
+    /// Still downloading initial blocks
+    ClientInInitialDownload = -10,
+    /// Node is already added
+    ClientNodeAlreadyAdded = -23,
+    /// Node has not been added before
+    ClientNodeNotAdded = -24,
+    /// Node to disconnect not found in connected nodes
+    ClientNodeNotConnected = -29,
+    /// Invalid IP/Subnet
+    ClientInvalidIpOrSubnet = -30,
+}
+
+impl From<LegacyCode> for ErrorCode {
+    fn from(code: LegacyCode) -> Self {
+        Self::ServerError(code as i32)
+    }
+}
+
+impl From<LegacyCode> for i32 {
+    fn from(code: LegacyCode) -> Self {
+        code as i32
+    }
+}

--- a/zallet/src/components/json_rpc/server/http_request_compatibility.rs
+++ b/zallet/src/components/json_rpc/server/http_request_compatibility.rs
@@ -7,11 +7,12 @@ use std::pin::Pin;
 
 use futures::FutureExt;
 use http_body_util::BodyExt;
-use hyper::{body::Bytes, header};
+use hyper::header;
 use jsonrpsee::{
     core::BoxError,
     server::{HttpBody, HttpRequest, HttpResponse},
 };
+use serde::{Deserialize, Serialize};
 use tower::Service;
 
 /// HTTP [`HttpRequestMiddleware`] with compatibility workarounds.
@@ -94,24 +95,60 @@ impl<S> HttpRequestMiddleware<S> {
         }
     }
 
-    /// Remove any "jsonrpc: 1.0" fields in `data`, and return the resulting string.
-    pub fn remove_json_1_fields(data: String) -> String {
-        // Replace "jsonrpc = 1.0":
-        // - at the start or middle of a list, and
-        // - at the end of a list;
-        // with no spaces (lightwalletd format), and spaces after separators (example format).
-        //
-        // TODO: if we see errors from lightwalletd, make this replacement more accurate:
-        //     - use a partial JSON fragment parser
-        //     - combine the whole request into a single buffer, and use a JSON parser
-        //     - use a regular expression
-        //
-        // We could also just handle the exact lightwalletd format,
-        // by replacing `{"jsonrpc":"1.0",` with `{"jsonrpc":"2.0`.
-        data.replace("\"jsonrpc\":\"1.0\",", "\"jsonrpc\":\"2.0\",")
-            .replace("\"jsonrpc\": \"1.0\",", "\"jsonrpc\": \"2.0\",")
-            .replace(",\"jsonrpc\":\"1.0\"", ",\"jsonrpc\":\"2.0\"")
-            .replace(", \"jsonrpc\": \"1.0\"", ", \"jsonrpc\": \"2.0\"")
+    /// Maps whatever JSON-RPC version the client is using to JSON-RPC 2.0.
+    async fn request_to_json_rpc_2(
+        request: HttpRequest<HttpBody>,
+    ) -> (JsonRpcVersion, HttpRequest<HttpBody>) {
+        let (parts, body) = request.into_parts();
+        let bytes = body
+            .collect()
+            .await
+            .expect("Failed to collect body data")
+            .to_bytes();
+
+        let (version, bytes) =
+            if let Ok(request) = serde_json::from_slice::<'_, JsonRpcRequest>(bytes.as_ref()) {
+                let version = request.version();
+                if matches!(version, JsonRpcVersion::Unknown) {
+                    (version, bytes)
+                } else {
+                    (
+                        version,
+                        serde_json::to_vec(&request.to_2()).expect("valid").into(),
+                    )
+                }
+            } else {
+                (JsonRpcVersion::Unknown, bytes)
+            };
+
+        (
+            version,
+            HttpRequest::from_parts(parts, HttpBody::from(bytes.as_ref().to_vec())),
+        )
+    }
+
+    /// Maps JSON-2.0 to whatever JSON-RPC version the client is using.
+    async fn response_from_json_rpc_2(
+        version: JsonRpcVersion,
+        response: HttpResponse<HttpBody>,
+    ) -> HttpResponse<HttpBody> {
+        let (parts, body) = response.into_parts();
+        let bytes = body
+            .collect()
+            .await
+            .expect("Failed to collect body data")
+            .to_bytes();
+
+        let bytes =
+            if let Ok(response) = serde_json::from_slice::<'_, JsonRpcResponse>(bytes.as_ref()) {
+                serde_json::to_vec(&response.to_version(version))
+                    .expect("valid")
+                    .into()
+            } else {
+                bytes
+            };
+
+        HttpResponse::from_parts(parts, HttpBody::from(bytes.as_ref().to_vec()))
     }
 }
 
@@ -157,25 +194,98 @@ where
         Self::insert_or_replace_content_type_header(request.headers_mut());
 
         let mut service = self.service.clone();
-        let (parts, body) = request.into_parts();
 
         async move {
-            let bytes = body
-                .collect()
-                .await
-                .expect("Failed to collect body data")
-                .to_bytes();
-
-            let data = String::from_utf8_lossy(bytes.as_ref()).to_string();
-
-            // Fix JSON-RPC 1.0 requests.
-            let data = Self::remove_json_1_fields(data);
-            let body = HttpBody::from(Bytes::from(data).as_ref().to_vec());
-
-            let request = HttpRequest::from_parts(parts, body);
-
-            service.call(request).await.map_err(Into::into)
+            let (version, request) = Self::request_to_json_rpc_2(request).await;
+            let response = service.call(request).await.map_err(Into::into)?;
+            Ok(Self::response_from_json_rpc_2(version, response).await)
         }
         .boxed()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum JsonRpcVersion {
+    /// bitcoind used a mishmash of 1.0, 1.1, and 2.0 for its JSON-RPC.
+    Bitcoind,
+    /// lightwalletd uses the above mishmash, but also breaks spec to include a
+    /// `"jsonrpc": "1.0"` key.
+    Lightwalletd,
+    /// The client is indicating strict 2.0 handling.
+    TwoPointZero,
+    /// On parse errors we don't modify anything, and let the `jsonrpsee` crate handle it.
+    Unknown,
+}
+
+/// A version-agnostic JSON-RPC request.
+#[derive(Debug, Deserialize, Serialize)]
+struct JsonRpcRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jsonrpc: Option<String>,
+    method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<serde_json::Value>,
+}
+
+impl JsonRpcRequest {
+    fn version(&self) -> JsonRpcVersion {
+        match (self.jsonrpc.as_deref(), &self.params, &self.id) {
+            (
+                Some("2.0"),
+                _,
+                None
+                | Some(
+                    serde_json::Value::Null
+                    | serde_json::Value::String(_)
+                    | serde_json::Value::Number(_),
+                ),
+            ) => JsonRpcVersion::TwoPointZero,
+            (Some("1.0"), Some(_), Some(_)) => JsonRpcVersion::Lightwalletd,
+            (None, Some(_), Some(_)) => JsonRpcVersion::Bitcoind,
+            _ => JsonRpcVersion::Unknown,
+        }
+    }
+
+    fn to_2(mut self) -> Self {
+        self.jsonrpc = Some("2.0".into());
+        self
+    }
+}
+
+/// A version-agnostic JSON-RPC response.
+#[derive(Debug, Deserialize, Serialize)]
+struct JsonRpcResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jsonrpc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<serde_json::Value>,
+    id: serde_json::Value,
+}
+
+impl JsonRpcResponse {
+    fn to_version(mut self, version: JsonRpcVersion) -> Self {
+        match version {
+            JsonRpcVersion::Bitcoind => {
+                self.jsonrpc = None;
+                self.result = self.result.or(Some(serde_json::Value::Null));
+                self.error = self.error.or(Some(serde_json::Value::Null));
+            }
+            JsonRpcVersion::Lightwalletd => {
+                self.jsonrpc = Some("1.0".into());
+                self.result = self.result.or(Some(serde_json::Value::Null));
+                self.error = self.error.or(Some(serde_json::Value::Null));
+            }
+            JsonRpcVersion::TwoPointZero => {
+                // `jsonrpsee` should be returning valid JSON-RPC 2.0 responses.
+                assert_eq!(self.jsonrpc.as_deref(), Some("2.0"));
+                assert_eq!(self.result.is_some(), self.error.is_none());
+            }
+            JsonRpcVersion::Unknown => (),
+        }
+        self
     }
 }

--- a/zallet/src/components/json_rpc/server/http_request_compatibility.rs
+++ b/zallet/src/components/json_rpc/server/http_request_compatibility.rs
@@ -1,0 +1,181 @@
+//! Compatibility fixes for JSON-RPC HTTP requests.
+//!
+//! These fixes are applied at the HTTP level, before the RPC request is parsed.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use futures::FutureExt;
+use http_body_util::BodyExt;
+use hyper::{body::Bytes, header};
+use jsonrpsee::{
+    core::BoxError,
+    server::{HttpBody, HttpRequest, HttpResponse},
+};
+use tower::Service;
+
+/// HTTP [`HttpRequestMiddleware`] with compatibility workarounds.
+///
+/// This middleware makes the following changes to HTTP requests:
+///
+/// ### Map between the client's JSON-RPC version and JSON-RPC 2.0.
+///
+/// [`jsonrpsee`] only supports JSON-RPC 2.0, while the existing Zcash ecosystem is used
+/// to communicating with `zcashd`'s "Bitcoin JSON-RPC" (a mix of 1.0, 1.1, and 2.0).
+///
+/// ### Add missing `content-type` HTTP header
+///
+/// Some RPC clients don't include a `content-type` HTTP header. But unlike web browsers,
+/// [`jsonrpsee`] does not do content sniffing.
+///
+/// If there is no `content-type` header, we assume the content is JSON, and let the
+/// parser error if we are incorrect.
+///
+/// ## Security
+///
+/// Any user-specified data in RPC requests is hex or base58check encoded. We assume the
+/// client validates data encodings before sending it on to Zallet. So any fixes Zallet
+/// performs won't change user-specified data.
+#[derive(Clone, Debug)]
+pub struct HttpRequestMiddleware<S> {
+    service: S,
+}
+
+impl<S> HttpRequestMiddleware<S> {
+    /// Create a new `HttpRequestMiddleware` with the given service.
+    pub fn new(service: S) -> Self {
+        Self { service }
+    }
+
+    /// Conditionally sets the `content-type` HTTP header to `application/json`.
+    ///
+    /// The header is inserted or replaced in the following cases:
+    /// - no `content-type` supplied.
+    /// - supplied `content-type` starts with `text/plain`, for example:
+    ///   - `text/plain`
+    ///   - `text/plain;`
+    ///   - `text/plain; charset=utf-8`
+    ///
+    /// `application/json` is the only `content-type` accepted by the Zallet RPC endpoint,
+    /// [as enforced by the `jsonrpsee` crate].
+    ///
+    /// [as enforced by the `jsonrpsee` crate]: https://github.com/paritytech/jsonrpsee/blob/656f8bb0793c8e992d20b47c3d17e7a6c396fb8b/server/src/transport/http.rs#L14-L29
+    ///
+    /// # Security
+    ///
+    /// - `content-type` headers exist so that applications know they are speaking the
+    ///   correct protocol with the correct format. We can be a bit flexible, but there
+    ///   are some types (such as binary) we shouldn't allow. In particular, the
+    ///   `application/x-www-form-urlencoded` header should be rejected, so browser forms
+    ///   can't be used to attack a local RPC port. This is handled by `jsonrpsee` as
+    ///   mentioned above. See ["The Role of Routers in the CSRF Attack"].
+    /// - Checking all the headers is secure, but only because `hyper` has custom code
+    ///   that [just reads the first content-type header].
+    ///
+    /// ["The Role of Routers in the CSRF Attack"]: https://www.invicti.com/blog/web-security/importance-content-type-header-http-requests/
+    /// [just reads the first content-type header]: https://github.com/hyperium/headers/blob/f01cc90cf8d601a716856bc9d29f47df92b779e4/src/common/content_type.rs#L102-L108
+    pub fn insert_or_replace_content_type_header(headers: &mut header::HeaderMap) {
+        if !headers.contains_key(header::CONTENT_TYPE)
+            || headers
+                .get(header::CONTENT_TYPE)
+                .filter(|value| {
+                    value
+                        .to_str()
+                        .ok()
+                        .unwrap_or_default()
+                        .starts_with("text/plain")
+                })
+                .is_some()
+        {
+            headers.insert(
+                header::CONTENT_TYPE,
+                header::HeaderValue::from_static("application/json"),
+            );
+        }
+    }
+
+    /// Remove any "jsonrpc: 1.0" fields in `data`, and return the resulting string.
+    pub fn remove_json_1_fields(data: String) -> String {
+        // Replace "jsonrpc = 1.0":
+        // - at the start or middle of a list, and
+        // - at the end of a list;
+        // with no spaces (lightwalletd format), and spaces after separators (example format).
+        //
+        // TODO: if we see errors from lightwalletd, make this replacement more accurate:
+        //     - use a partial JSON fragment parser
+        //     - combine the whole request into a single buffer, and use a JSON parser
+        //     - use a regular expression
+        //
+        // We could also just handle the exact lightwalletd format,
+        // by replacing `{"jsonrpc":"1.0",` with `{"jsonrpc":"2.0`.
+        data.replace("\"jsonrpc\":\"1.0\",", "\"jsonrpc\":\"2.0\",")
+            .replace("\"jsonrpc\": \"1.0\",", "\"jsonrpc\": \"2.0\",")
+            .replace(",\"jsonrpc\":\"1.0\"", ",\"jsonrpc\":\"2.0\"")
+            .replace(", \"jsonrpc\": \"1.0\"", ", \"jsonrpc\": \"2.0\"")
+    }
+}
+
+/// Implements [`tower::Layer`] for [`HttpRequestMiddleware`].
+#[derive(Clone)]
+pub struct HttpRequestMiddlewareLayer {}
+
+impl HttpRequestMiddlewareLayer {
+    /// Creates a new `HttpRequestMiddlewareLayer`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<S> tower::Layer<S> for HttpRequestMiddlewareLayer {
+    type Service = HttpRequestMiddleware<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        HttpRequestMiddleware::new(service)
+    }
+}
+
+impl<S> Service<HttpRequest<HttpBody>> for HttpRequestMiddleware<S>
+where
+    S: Service<HttpRequest, Response = HttpResponse> + Clone + Send + 'static,
+    S::Error: Into<BoxError> + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, mut request: HttpRequest<HttpBody>) -> Self::Future {
+        // Fix the request headers.
+        Self::insert_or_replace_content_type_header(request.headers_mut());
+
+        let mut service = self.service.clone();
+        let (parts, body) = request.into_parts();
+
+        async move {
+            let bytes = body
+                .collect()
+                .await
+                .expect("Failed to collect body data")
+                .to_bytes();
+
+            let data = String::from_utf8_lossy(bytes.as_ref()).to_string();
+
+            // Fix JSON-RPC 1.0 requests.
+            let data = Self::remove_json_1_fields(data);
+            let body = HttpBody::from(Bytes::from(data).as_ref().to_vec());
+
+            let request = HttpRequest::from_parts(parts, body);
+
+            service.call(request).await.map_err(Into::into)
+        }
+        .boxed()
+    }
+}

--- a/zallet/src/components/json_rpc/server/rpc_call_compatibility.rs
+++ b/zallet/src/components/json_rpc/server/rpc_call_compatibility.rs
@@ -1,0 +1,70 @@
+//! Compatibility fixes for JSON-RPC remote procedure calls.
+//!
+//! These fixes are applied at the JSON-RPC call level,
+//! after the RPC request is parsed and split into calls.
+
+use futures::future::BoxFuture;
+use jsonrpsee::{
+    server::middleware::rpc::{layer::ResponseFuture, RpcService, RpcServiceT},
+    tracing::debug,
+    types::ErrorObject,
+    MethodResponse,
+};
+
+use crate::components::json_rpc::server::error::LegacyCode;
+
+/// JSON-RPC [`FixRpcResponseMiddleware`] with compatibility workarounds.
+///
+/// This middleware makes the following changes to JSON-RPC calls:
+///
+/// ## Make RPC framework response codes match `zcashd`
+///
+/// [`jsonrpsee::types`] returns specific error codes while parsing requests:
+/// <https://docs.rs/jsonrpsee-types/latest/jsonrpsee_types/error/enum.ErrorCode.html>
+///
+/// But these codes are different from `zcashd`, and some RPC clients rely on the exact code.
+/// Specifically, the [`jsonrpsee::types::error::INVALID_PARAMS_CODE`] is different:
+/// <https://docs.rs/jsonrpsee-types/latest/jsonrpsee_types/error/constant.INVALID_PARAMS_CODE.html>
+pub struct FixRpcResponseMiddleware {
+    service: RpcService,
+}
+
+impl FixRpcResponseMiddleware {
+    /// Create a new `FixRpcResponseMiddleware` with the given `service`.
+    pub fn new(service: RpcService) -> Self {
+        Self { service }
+    }
+}
+
+impl<'a> RpcServiceT<'a> for FixRpcResponseMiddleware {
+    type Future = ResponseFuture<BoxFuture<'a, MethodResponse>>;
+
+    fn call(&self, request: jsonrpsee::types::Request<'a>) -> Self::Future {
+        let service = self.service.clone();
+        ResponseFuture::future(Box::pin(async move {
+            let response = service.call(request).await;
+            if response.is_error() {
+                let original_error_code = response
+                    .as_error_code()
+                    .expect("response should have an error code");
+                if original_error_code == jsonrpsee::types::ErrorCode::InvalidParams.code() {
+                    let new_error_code = LegacyCode::Misc.into();
+                    debug!("Replacing RPC error: {original_error_code} with {new_error_code}");
+                    let json: serde_json::Value =
+                        serde_json::from_str(response.into_parts().0.as_str())
+                            .expect("response string should be valid json");
+                    let id = json["id"]
+                        .as_str()
+                        .expect("response json should have an id")
+                        .to_string();
+
+                    return MethodResponse::error(
+                        jsonrpsee::types::Id::Str(id.into()),
+                        ErrorObject::borrowed(new_error_code, "Invalid params", None),
+                    );
+                }
+            }
+            response
+        }))
+    }
+}

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -1,15 +1,50 @@
 //! Zallet Config
 
+use std::net::SocketAddr;
+
 use serde::{Deserialize, Serialize};
 
 /// Zallet Configuration
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct ZalletConfig {}
+pub struct ZalletConfig {
+    pub rpc: RpcSection,
+}
 
 /// Default configuration settings.
 impl Default for ZalletConfig {
     fn default() -> Self {
-        Self {}
+        Self {
+            rpc: RpcSection::default(),
+        }
+    }
+}
+
+/// RPC configuration section.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RpcSection {
+    /// IP address and port for the RPC server.
+    ///
+    /// Note: The RPC server is disabled by default. To enable the RPC server, set a
+    /// listen address in the config:
+    /// ```toml
+    /// [rpc]
+    /// listen_addr = '127.0.0.1:28232'
+    /// ```
+    ///
+    /// # Security
+    ///
+    /// If you bind Zallet's RPC port to a public IP address, anyone on the internet can
+    /// view your transactions and spend your funds.
+    pub listen_addr: Option<SocketAddr>,
+}
+
+impl Default for RpcSection {
+    fn default() -> Self {
+        Self {
+            // Disable RPCs by default.
+            listen_addr: None,
+        }
     }
 }

--- a/zallet/src/error.rs
+++ b/zallet/src/error.rs
@@ -25,13 +25,13 @@ macro_rules! wlnfl {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ErrorKind {
-    Discombobulated,
+    Init,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ErrorKind::Discombobulated => wlnfl!(f, "err-discombobulated")?,
+            ErrorKind::Init => wlnfl!(f, "err-init")?,
         }
         writeln!(f)?;
         writeln!(f, "[ {} ]", crate::fl!("err-ux-A"))?;

--- a/zallet/src/lib.rs
+++ b/zallet/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod application;
 mod cli;
 mod commands;
+mod components;
 pub mod config;
 mod error;
 mod i18n;


### PR DESCRIPTION
`jsonrpsee` logic adapted from `zebra-rpc` and `zebrad` crates.