### PR TITLE
Functional alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "fs-err",
  "once_cell",
  "regex",
- "secrecy",
+ "secrecy 0.10.3",
  "semver",
  "serde",
  "termcolor",
@@ -65,6 +65,39 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -125,10 +158,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "async-trait"
@@ -152,6 +225,53 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -184,10 +304,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "bellman"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
+dependencies = [
+ "bitvec",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "ff",
+ "group",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "pairing",
+ "rand_core",
+ "rayon",
+ "subtle",
+]
+
+[[package]]
+name = "bip32"
+version = "0.6.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143f5327f23168716be068f8e1014ba2ea16a6c91e8777bc8927da7b51e1df1f"
+dependencies = [
+ "bs58",
+ "hmac",
+ "rand_core",
+ "ripemd 0.2.0-pre.4",
+ "secp256k1",
+ "sha2 0.11.0-pre.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block"
@@ -202,6 +399,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd016a0ddc7cb13661bf5576073ce07330a693f8608a1320b4e20561cc12cdc"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2 0.10.8",
+ "tinyvec",
 ]
 
 [[package]]
@@ -223,6 +452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +474,41 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
+ "zeroize",
+]
 
 [[package]]
 name = "clap"
@@ -297,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,10 +594,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -328,6 +641,24 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b8ce8218c97789f16356e7896b3714f26c2ee1079b79c0b7ae7064bb9089fa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "daggy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a9304e55e9d601a39ae4deaba85406d5c0980e106f65afcf0460e9af1e7602"
+dependencies = [
+ "petgraph",
 ]
 
 [[package]]
@@ -345,13 +676,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656f14fc1ab819c65f332045ea7cb38841bbe551f3b2bc7e3abefb559af4155c"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "rusqlite",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
+dependencies = [
+ "block-buffer 0.11.0-rc.3",
+ "crypto-common 0.2.0-rc.1",
+ "subtle",
 ]
 
 [[package]]
@@ -375,10 +766,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "equihash"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "blake2b_simd",
+ "core2",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "eyre"
@@ -391,6 +807,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +851,12 @@ checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
  "toml 0.5.11",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fluent"
@@ -450,6 +909,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fpe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
+dependencies = [
+ "cbc",
+ "cipher",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +930,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -565,7 +1044,31 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded738faa0e88d3abc9d1a13cb11adc2073c400969eeb8793cf7132589959fc"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -573,6 +1076,18 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "memuse",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -586,7 +1101,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -594,10 +1109,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "halo2_gadgets"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "lazy_static",
+ "pasta_curves",
+ "rand",
+ "sinsemilla",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_legacy_pdqsort"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
+
+[[package]]
+name = "halo2_poseidon"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "pasta_curves",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_legacy_pdqsort",
+ "maybe-rayon",
+ "pasta_curves",
+ "rand_core",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -606,16 +1184,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
+dependencies = [
+ "digest 0.11.0-pre.9",
+]
 
 [[package]]
 name = "home"
@@ -673,6 +1275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +1301,20 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -699,13 +1324,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -785,10 +1413,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "incrementalmerkletree"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216c71634ac6f6ed13c2102d64354c0a04dcbdc30e31692c5972d3974d8b6d97"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "indexmap"
@@ -798,6 +1445,15 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -824,6 +1480,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -904,7 +1569,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -921,16 +1586,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff",
+ "group",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litrs"
@@ -986,6 +1691,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1717,18 @@ name = "memuse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1013,9 +1746,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nonempty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1025,6 +1780,50 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1072,6 +1871,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "orchard"
+version = "0.10.1"
+source = "git+https://github.com/zcash/orchard.git?rev=c684e9185a0449efb00428f807d3bf286b5dae03#c684e9185a0449efb00428f807d3bf286b5dae03"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "core2",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1921,15 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1104,6 +1952,37 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -1139,12 +2018,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1188,6 +2100,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.96",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +2159,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1223,7 +2193,56 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reddsa"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "group",
+ "hex",
+ "jubjub",
+ "pasta_curves",
+ "rand_core",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "redjubjub"
+version = "0.7.0"
+source = "git+https://github.com/ZcashFoundation/redjubjub?rev=eae848c5c14d9c795d000dd9f4c4762d1aee7ee1#eae848c5c14d9c795d000dd9f4c4762d1aee7ee1"
+dependencies = [
+ "rand_core",
+ "reddsa",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1280,10 +2299,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48cf93482ea998ad1302c42739bc73ab3adc574890c373ec89710e219357579"
+dependencies = [
+ "digest 0.11.0-pre.9",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "time",
+ "uuid",
+]
 
 [[package]]
 name = "rust-embed"
@@ -1315,7 +2383,7 @@ version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -1338,6 +2406,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,10 +2481,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "sapling-crypto"
+version = "0.4.0"
+source = "git+https://github.com/zcash/sapling-crypto.git?rev=e607c52d13bb7ade66293f9ab8d07e311f4ad868#e607c52d13bb7ade66293f9ab8d07e311f4ad868"
+dependencies = [
+ "aes",
+ "bellman",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "core2",
+ "document-features",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "rand",
+ "rand_core",
+ "redjubjub",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "schemerz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e82960ac11ccabd77d53c933532612079e01205b5873ec5095f4b3426493434"
+dependencies = [
+ "daggy",
+ "indexmap 1.9.3",
+ "log",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "schemerz-rusqlite"
+version = "0.320.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ff99b7d9e8790fb20a7e52a482f66fddb3c28c3ce700c6c2665cacbf1b5529"
+dependencies = [
+ "rusqlite",
+ "schemerz",
+ "uuid",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"
@@ -1441,7 +2652,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1452,7 +2663,18 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -1465,10 +2687,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "shardtree"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f2390975ebfe8838f9e861f7a588123d49a7a7a0a08568ea831d8ad53fc9b4"
+dependencies = [
+ "bitflags",
+ "either",
+ "incrementalmerkletree",
+ "tracing",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sinsemilla"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
+dependencies = [
+ "group",
+ "pasta_curves",
+ "subtle",
+]
 
 [[package]]
 name = "slab"
@@ -1512,10 +2757,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1540,6 +2803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +2818,26 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1591,6 +2880,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +2918,21 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1624,6 +2959,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1688,11 +3033,58 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-pemfile",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1703,12 +3095,30 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1786,6 +3196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "type-map"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +3215,18 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unic-langid"
@@ -1832,10 +3260,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "valuable"
@@ -1844,10 +3297,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -1869,10 +3339,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
 
 [[package]]
 name = "winapi"
@@ -1997,12 +3506,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zallet"
 version = "0.0.0"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
+ "async-trait",
  "clap",
+ "deadpool",
+ "deadpool-sqlite",
+ "deadpool-sync",
  "futures",
  "home",
  "http-body-util",
@@ -2011,26 +3548,256 @@ dependencies = [
  "i18n-embed-fl",
  "jsonrpsee",
  "once_cell",
+ "orchard",
  "rand",
+ "rusqlite",
  "rust-embed",
+ "sapling-crypto",
+ "secrecy 0.8.0",
  "serde",
  "serde_json",
+ "shardtree",
  "tokio",
  "toml 0.8.19",
- "tower",
+ "tonic",
+ "tower 0.4.13",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
+ "zcash_primitives",
  "zcash_protocol",
+ "zcash_transparent",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.6.2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "bech32",
+ "bs58",
+ "core2",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol",
+]
+
+[[package]]
+name = "zcash_client_backend"
+version = "0.16.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bech32",
+ "bip32",
+ "bls12_381",
+ "bs58",
+ "byteorder",
+ "crossbeam-channel",
+ "document-features",
+ "futures-util",
+ "group",
+ "hex",
+ "hyper-util",
+ "incrementalmerkletree",
+ "memuse",
+ "nom",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "percent-encoding",
+ "prost",
+ "rand_core",
+ "rayon",
+ "sapling-crypto",
+ "secrecy 0.8.0",
+ "shardtree",
+ "subtle",
+ "time",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "which",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_keys",
+ "zcash_note_encryption",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_transparent",
+ "zip32",
+ "zip321",
+]
+
+[[package]]
+name = "zcash_client_sqlite"
+version = "0.14.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "bip32",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "group",
+ "incrementalmerkletree",
+ "jubjub",
+ "maybe-rayon",
+ "nonempty",
+ "orchard",
+ "prost",
+ "regex",
+ "rusqlite",
+ "sapling-crypto",
+ "schemerz",
+ "schemerz-rusqlite",
+ "secrecy 0.8.0",
+ "shardtree",
+ "static_assertions",
+ "subtle",
+ "time",
+ "tracing",
+ "uuid",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_encoding",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_transparent",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.2.2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "core2",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_keys"
+version = "0.6.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "bech32",
+ "bip32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "core2",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand_core",
+ "sapling-crypto",
+ "secrecy 0.8.0",
+ "subtle",
+ "tracing",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_transparent",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_note_encryption"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+dependencies = [
+ "chacha20",
+ "chacha20poly1305",
+ "cipher",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.21.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "bip32",
+ "blake2b_simd",
+ "bs58",
+ "core2",
+ "document-features",
+ "equihash",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand",
+ "rand_core",
+ "redjubjub",
+ "ripemd 0.1.3",
+ "sapling-crypto",
+ "secp256k1",
+ "sha2 0.10.8",
+ "subtle",
+ "tracing",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_spec",
+ "zcash_transparent",
+ "zip32",
 ]
 
 [[package]]
 name = "zcash_protocol"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cb36b15b5a1be70b30c32ce40372dead6561df8a467e297f96b892873a63a2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
 dependencies = [
  "core2",
  "document-features",
  "hex",
  "memuse",
+]
+
+[[package]]
+name = "zcash_spec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cede95491c2191d3e278cab76e097a44b17fde8d6ca0d4e3a22cf4807b2d857"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "bip32",
+ "blake2b_simd",
+ "bs58",
+ "core2",
+ "document-features",
+ "getset",
+ "hex",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha2 0.10.8",
+ "subtle",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_spec",
+ "zip32",
 ]
 
 [[package]]
@@ -2059,3 +3826,41 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zip32"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9943793abf9060b68e1889012dafbd5523ab5b125c0fcc24802d69182f2ac9"
+dependencies = [
+ "blake2b_simd",
+ "memuse",
+ "subtle",
+ "zcash_spec",
+]
+
+[[package]]
+name = "zip321"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=b106a89841c493c37bc269b6b5c490727f10ed91#b106a89841c493c37bc269b6b5c490727f10ed91"
+dependencies = [
+ "base64",
+ "nom",
+ "percent-encoding",
+ "zcash_address",
+ "zcash_protocol",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ dependencies = [
  "deadpool-sqlite",
  "deadpool-sync",
  "futures",
+ "hex",
  "home",
  "http-body-util",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "core2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +363,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -592,6 +610,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -909,6 +933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "locale_config"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +990,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memuse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "miniz_oxide"
@@ -1982,6 +2018,19 @@ dependencies = [
  "tokio",
  "toml 0.8.19",
  "tower",
+ "zcash_protocol",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb36b15b5a1be70b30c32ce40372dead6561df8a467e297f96b892873a63a2"
+dependencies = [
+ "core2",
+ "document-features",
+ "hex",
+ "memuse",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ i18n-embed-fl = "0.9"
 rust-embed = "8"
 
 # Parsing and serialization
+hex = "0.4"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
 # Async
+async-trait = "0.1"
 futures = "0.3"
 tokio = "1"
 
@@ -49,3 +50,33 @@ tower = "0.4"
 
 # Zcash consensus
 zcash_protocol = "0.4"
+
+# Zcash payment protocols
+orchard = "0.10"
+sapling = { package = "sapling-crypto", version = "0.4" }
+transparent = { package = "zcash_transparent", version = "0.1" }
+zcash_primitives = "0.21"
+
+# Zcash wallet
+deadpool = "0.12"
+deadpool-sqlite = "0.9"
+deadpool-sync = "0.1"
+rusqlite = "0.32"
+secrecy = "0.8"
+shardtree = "0.5"
+zcash_client_backend = "0.16"
+zcash_client_sqlite = "0.14"
+zip32 = "0.1"
+
+# lightwalletd (temporary)
+tonic = "0.12"
+
+[patch.crates-io]
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "c684e9185a0449efb00428f807d3bf286b5dae03" }
+redjubjub = { git = "https://github.com/ZcashFoundation/redjubjub", rev = "eae848c5c14d9c795d000dd9f4c4762d1aee7ee1" }
+sapling = { package = "sapling-crypto", git = "https://github.com/zcash/sapling-crypto.git", rev = "e607c52d13bb7ade66293f9ab8d07e311f4ad868" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "b106a89841c493c37bc269b6b5c490727f10ed91" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "b106a89841c493c37bc269b6b5c490727f10ed91" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "b106a89841c493c37bc269b6b5c490727f10ed91" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "b106a89841c493c37bc269b6b5c490727f10ed91" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "b106a89841c493c37bc269b6b5c490727f10ed91" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ http-body-util = "0.1"
 hyper = "1"
 jsonrpsee = "0.24"
 tower = "0.4"
+
+# Zcash consensus
+zcash_protocol = "0.4"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -17,6 +17,7 @@ deadpool.workspace = true
 deadpool-sqlite.workspace = true
 deadpool-sync.workspace = true
 futures.workspace = true
+hex.workspace = true
 home.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -23,12 +23,7 @@ rand.workspace = true
 rust-embed.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = [
-    "fs",
-    "io-util",
-    "macros",
-    "rt-multi-thread",
-] }
+tokio = { workspace = true, features = ["fs", "io-util", "rt-multi-thread"] }
 toml.workspace = true
 tower = { workspace = true, features = ["timeout"] }
 

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -11,7 +11,11 @@ categories.workspace = true
 [dependencies]
 abscissa_core.workspace = true
 abscissa_tokio.workspace = true
+async-trait.workspace = true
 clap = { workspace = true, features = ["string", "unstable-styles"] }
+deadpool.workspace = true
+deadpool-sqlite.workspace = true
+deadpool-sync.workspace = true
 futures.workspace = true
 home.workspace = true
 http-body-util.workspace = true
@@ -19,14 +23,33 @@ hyper.workspace = true
 i18n-embed = { workspace = true, features = ["desktop-requester"] }
 i18n-embed-fl.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
+orchard.workspace = true
 rand.workspace = true
+rusqlite.workspace = true
 rust-embed.workspace = true
+sapling.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+shardtree.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "rt-multi-thread"] }
 toml.workspace = true
+tonic.workspace = true
 tower = { workspace = true, features = ["timeout"] }
+transparent.workspace = true
+zcash_client_backend = { workspace = true, features = [
+    "lightwalletd-tonic-tls-webpki-roots",
+    "orchard",
+    "sync",
+    "transparent-inputs",
+] }
+zcash_client_sqlite = { workspace = true, features = [
+    "orchard",
+    "transparent-inputs",
+] }
+zcash_primitives.workspace = true
 zcash_protocol = { workspace = true, features = ["local-consensus"] }
+zip32.workspace = true
 
 [dev-dependencies]
 abscissa_core = { workspace = true, features = ["testing"] }

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "rt-multi-thread"] }
 toml.workspace = true
 tower = { workspace = true, features = ["timeout"] }
+zcash_protocol = { workspace = true, features = ["local-consensus"] }
 
 [dev-dependencies]
 abscissa_core = { workspace = true, features = ["testing"] }

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -77,6 +77,10 @@ err-migrate-duplicate-zcashd-option =
     then re-run this command.
 err-migrate-invalid-line = Invalid line '{$line}' in {$conf}
 err-migrate-invalid-zcashd-option = Invalid value '{$value}' for {-zcashd} option '{$option}'
+err-migrate-multiple-related-zcashd-options =
+    {-zcashd} option '{$option}' collides with '{$prev}', but both appear in
+    {$conf}
+    Remove one of the conflicting options, then re-run this command.
 err-migrate-unknown-zcashd-option = Unknown {-zcashd} option '{$option}'
 
 err-ux-A = Did {-zallet} not do what you expected? Could the error be more useful?

--- a/zallet/src/cli.rs
+++ b/zallet/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use abscissa_core::{Command, Runnable};
 use clap::{builder::Styles, Parser};
 
-use crate::fl;
+use crate::{fl, remote::Servers};
 
 #[derive(Debug, Parser, Command)]
 #[command(author, about, version)]
@@ -41,7 +41,12 @@ pub(crate) enum ZalletCmd {
 
 /// `start` subcommand
 #[derive(Debug, Parser, Command)]
-pub(crate) struct StartCmd {}
+pub(crate) struct StartCmd {
+    /// The lightwalletd server to sync with (default is \"ecc\")
+    #[arg(long)]
+    #[arg(default_value = "ecc", value_parser = Servers::parse)]
+    pub(crate) lwd_server: Servers,
+}
 
 /// `migrate-zcash-conf` subcommand
 #[derive(Debug, Parser, Command)]

--- a/zallet/src/commands/start.rs
+++ b/zallet/src/commands/start.rs
@@ -39,7 +39,7 @@ impl StartCmd {
             }
             info!("Spawning RPC server");
             info!("Trying to open RPC endpoint at {}...", config.rpc.bind[0]);
-            json_rpc::server::spawn(config.rpc.clone()).await?
+            json_rpc::server::spawn(config.rpc.clone(), wallet.clone()).await?
         } else {
             warn!("Configure `rpc.bind` to start the RPC server");
             // Emulate a normally-operating ongoing task to simplify subsequent logic.

--- a/zallet/src/components.rs
+++ b/zallet/src/components.rs
@@ -1,3 +1,4 @@
 //! Components of Zallet.
 
 pub(crate) mod json_rpc;
+pub(crate) mod wallet;

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -6,5 +6,12 @@
 //! - Some methods have the same name but slightly different semantics.
 //! - Some methods from the `zcashd` wallet are unsupported.
 
+use zcash_protocol::value::{Zatoshis, COIN};
+
 pub(crate) mod methods;
 pub(crate) mod server;
+
+// TODO: https://github.com/zcash/wallet/issues/15
+fn value_from_zatoshis(value: Zatoshis) -> f64 {
+    (u64::from(value) as f64) / (COIN as f64)
+}

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -20,7 +20,7 @@ pub(crate) trait Rpc {
     fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response;
 
     #[method(name = "z_getnotescount")]
-    fn get_notes_count(
+    async fn get_notes_count(
         &self,
         minconf: Option<u32>,
         as_of_height: Option<i32>,
@@ -59,11 +59,11 @@ impl RpcServer for RpcImpl {
         list_unified_receivers::call(unified_address)
     }
 
-    fn get_notes_count(
+    async fn get_notes_count(
         &self,
         minconf: Option<u32>,
         as_of_height: Option<i32>,
     ) -> get_notes_count::Response {
-        get_notes_count::call(minconf, as_of_height)
+        get_notes_count::call(self.wallet().await?.as_ref(), minconf, as_of_height)
     }
 }

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -1,4 +1,7 @@
-use jsonrpsee::proc_macros::rpc;
+use async_trait::async_trait;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+use crate::components::wallet::{Wallet, WalletHandle};
 
 mod get_notes_count;
 mod get_wallet_info;
@@ -11,7 +14,7 @@ pub(crate) trait Rpc {
     fn get_wallet_info(&self) -> get_wallet_info::Response;
 
     #[method(name = "z_listaccounts")]
-    fn list_accounts(&self) -> list_accounts::Response;
+    async fn list_accounts(&self) -> list_accounts::Response;
 
     #[method(name = "z_listunifiedreceivers")]
     fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response;
@@ -24,22 +27,32 @@ pub(crate) trait Rpc {
     ) -> get_notes_count::Response;
 }
 
-pub(crate) struct RpcImpl {}
+pub(crate) struct RpcImpl {
+    wallet: Wallet,
+}
 
 impl RpcImpl {
     /// Creates a new instance of the RPC handler.
-    pub(crate) fn new() -> Self {
-        Self {}
+    pub(crate) fn new(wallet: Wallet) -> Self {
+        Self { wallet }
+    }
+
+    async fn wallet(&self) -> RpcResult<WalletHandle> {
+        self.wallet
+            .handle()
+            .await
+            .map_err(|_| jsonrpsee::types::ErrorCode::InternalError.into())
     }
 }
 
+#[async_trait]
 impl RpcServer for RpcImpl {
     fn get_wallet_info(&self) -> get_wallet_info::Response {
         get_wallet_info::call()
     }
 
-    fn list_accounts(&self) -> list_accounts::Response {
-        list_accounts::call()
+    async fn list_accounts(&self) -> list_accounts::Response {
+        list_accounts::call(self.wallet().await?.as_ref())
     }
 
     fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response {

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -7,6 +7,7 @@ mod get_notes_count;
 mod get_wallet_info;
 mod list_accounts;
 mod list_unified_receivers;
+mod list_unspent;
 
 #[rpc(server)]
 pub(crate) trait Rpc {
@@ -18,6 +19,18 @@ pub(crate) trait Rpc {
 
     #[method(name = "z_listunifiedreceivers")]
     fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response;
+
+    /// Returns an array of unspent shielded notes with between minconf and maxconf
+    /// (inclusive) confirmations.
+    ///
+    /// Results may be optionally filtered to only include notes sent to specified
+    /// addresses. When `minconf` is 0, unspent notes with zero confirmations are
+    /// returned, even though they are not immediately spendable.
+    ///
+    /// # Arguments
+    /// - `minconf` (default = 1)
+    #[method(name = "z_listunspent")]
+    async fn list_unspent(&self) -> list_unspent::Response;
 
     #[method(name = "z_getnotescount")]
     async fn get_notes_count(
@@ -57,6 +70,10 @@ impl RpcServer for RpcImpl {
 
     fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response {
         list_unified_receivers::call(unified_address)
+    }
+
+    async fn list_unspent(&self) -> list_unspent::Response {
+        list_unspent::call(self.wallet().await?.as_ref())
     }
 
     async fn get_notes_count(

--- a/zallet/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet/src/components/json_rpc/methods/get_notes_count.rs
@@ -1,5 +1,12 @@
-use jsonrpsee::{core::RpcResult, tracing::warn};
+use jsonrpsee::{
+    core::RpcResult,
+    types::{ErrorCode as RpcErrorCode, ErrorObjectOwned as RpcError},
+};
 use serde::{Deserialize, Serialize};
+use zcash_client_backend::data_api::{InputSource, NoteFilter, WalletRead};
+use zcash_protocol::{value::Zatoshis, ShieldedProtocol};
+
+use crate::components::{json_rpc::server::LegacyCode, wallet::WalletConnection};
 
 /// Response to a `z_getnotescount` RPC request.
 pub(crate) type Response = RpcResult<GetNotesCount>;
@@ -18,15 +25,43 @@ pub(crate) struct GetNotesCount {
     orchard: u32,
 }
 
-pub(crate) fn call(minconf: Option<u32>, as_of_height: Option<i32>) -> Response {
-    warn!(
-        "TODO: Implement z_getnotescount({:?}, {:?})",
-        minconf, as_of_height
-    );
+pub(crate) fn call(
+    wallet: &WalletConnection,
+    minconf: Option<u32>,
+    as_of_height: Option<i32>,
+) -> Response {
+    // TODO: Switch to an approach that can respect `minconf` and `as_of_height`.
+    if minconf.is_some() || as_of_height.is_some() {
+        return Err(RpcError::borrowed(
+            LegacyCode::InvalidParameter.into(),
+            "minconf and as_of_height parameters are not yet supported",
+            None,
+        ));
+    }
+
+    let selector = NoteFilter::ExceedsMinValue(Zatoshis::ZERO);
+
+    let mut sapling = 0;
+    let mut orchard = 0;
+    for account_id in wallet
+        .get_account_ids()
+        .map_err(|_| RpcErrorCode::from(LegacyCode::Database))?
+    {
+        let account_metadata = wallet
+            .get_account_metadata(account_id, &selector, &[])
+            .map_err(|_| RpcErrorCode::from(LegacyCode::Database))?;
+
+        if let Some(note_count) = account_metadata.note_count(ShieldedProtocol::Sapling) {
+            sapling += note_count as u32;
+        }
+        if let Some(note_count) = account_metadata.note_count(ShieldedProtocol::Orchard) {
+            orchard += note_count as u32;
+        }
+    }
 
     Ok(GetNotesCount {
         sprout: 0,
-        sapling: 0,
-        orchard: 0,
+        sapling,
+        orchard,
     })
 }

--- a/zallet/src/components/json_rpc/methods/list_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/list_accounts.rs
@@ -1,13 +1,21 @@
-use jsonrpsee::{core::RpcResult, tracing::warn};
+use jsonrpsee::{core::RpcResult, types::ErrorCode as RpcErrorCode};
 use serde::{Deserialize, Serialize};
+use zcash_client_backend::data_api::{Account as _, WalletRead};
+
+use crate::components::{json_rpc::server::LegacyCode, wallet::WalletConnection};
 
 /// Response to a `z_listaccounts` RPC request.
 pub(crate) type Response = RpcResult<Vec<Account>>;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct Account {
+    /// The account's UUID within this Zallet instance.
+    uuid: String,
+
     /// The ZIP 32 account ID.
-    account: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account: Option<u64>,
+
     addresses: Vec<Address>,
 }
 
@@ -20,8 +28,42 @@ struct Address {
     ua: String,
 }
 
-pub(crate) fn call() -> Response {
-    warn!("TODO: Implement z_listaccounts");
+pub(crate) fn call(wallet: &WalletConnection) -> Response {
+    let mut accounts = vec![];
 
-    Ok(vec![])
+    for account_id in wallet
+        .get_account_ids()
+        .map_err(|_| RpcErrorCode::from(LegacyCode::Database))?
+    {
+        let account = wallet
+            .get_account(account_id)
+            .map_err(|_| RpcErrorCode::from(LegacyCode::Database))?
+            // This would be a race condition between this and account deletion.
+            .ok_or_else(|| RpcErrorCode::InternalError)?;
+
+        let address = wallet
+            .get_current_address(account_id)
+            .map_err(|_| RpcErrorCode::from(LegacyCode::Database))?
+            // This would be a race condition between this and account deletion.
+            .ok_or_else(|| RpcErrorCode::InternalError)?;
+
+        // `z_listaccounts` assumes a single HD seed.
+        // TODO: Fix this limitation.
+        let account = account
+            .source()
+            .key_derivation()
+            .map(|derivation| u32::from(derivation.account_index()).into());
+
+        accounts.push(Account {
+            uuid: account_id.expose_uuid().to_string(),
+            account,
+            addresses: vec![Address {
+                // TODO: Expose the real diversifier index.
+                diversifier_index: 0,
+                ua: address.encode(wallet.params()),
+            }],
+        });
+    }
+
+    Ok(accounts)
 }

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeMap;
+
+use jsonrpsee::{
+    core::RpcResult,
+    types::{ErrorCode as RpcErrorCode, ErrorObjectOwned as RpcError},
+};
+use serde::{Deserialize, Serialize};
+use zcash_client_backend::{
+    address::UnifiedAddress,
+    data_api::{Account, AccountPurpose, InputSource, NullifierQuery, WalletRead},
+    encoding::AddressCodec,
+    fees::{orchard::InputView as _, sapling::InputView as _},
+    wallet::NoteId,
+};
+use zcash_protocol::{
+    value::{Zatoshis, MAX_MONEY},
+    ShieldedProtocol,
+};
+use zip32::Scope;
+
+use crate::components::{
+    json_rpc::{server::LegacyCode, value_from_zatoshis},
+    wallet::WalletConnection,
+};
+
+/// Response to a `z_listunspent` RPC request.
+pub(crate) type Response = RpcResult<Vec<UnspentNote>>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct UnspentNote {
+    /// The transaction ID.
+    txid: String,
+
+    /// The shielded value pool.
+    ///
+    /// One of `["sapling", "orchard"]`.
+    pool: String,
+
+    /// The Sapling output or Orchard action index.
+    outindex: u16,
+
+    /// The number of confirmations.
+    confirmations: u32,
+
+    /// `true` if note can be spent by wallet, `false` if address is watchonly.
+    spendable: bool,
+
+    /// The unified account ID, if applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account: Option<u32>,
+
+    /// The shielded address.
+    ///
+    /// Omitted if this note was sent to an internal receiver.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address: Option<String>,
+
+    /// The amount of value in the note.
+    amount: f64,
+
+    /// Hexadecimal string representation of memo field.
+    memo: String,
+
+    /// UTF-8 string representation of memo field (if it contains valid UTF-8).
+    #[serde(rename = "memoStr")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memo_str: Option<String>,
+
+    /// `true` if the address that received the note is also one of the sending addresses.
+    ///
+    /// Omitted if the note is not spendable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    change: Option<bool>,
+}
+
+pub(crate) fn call(wallet: &WalletConnection) -> Response {
+    // Use the height of the maximum scanned block as the anchor height, to emulate a
+    // zero-conf transaction in order to select every note in the wallet.
+    let anchor_height = match wallet.block_max_scanned().map_err(|e| {
+        RpcError::owned(
+            LegacyCode::Database.into(),
+            "WalletDb::block_max_scanned failed",
+            Some(format!("{e}")),
+        )
+    })? {
+        Some(block) => block.block_height(),
+        None => return Ok(vec![]),
+    };
+
+    let mut unspent_notes = vec![];
+
+    for account_id in wallet.get_account_ids().map_err(|e| {
+        RpcError::owned(
+            LegacyCode::Database.into(),
+            "WalletDb::get_account_ids failed",
+            Some(format!("{e}")),
+        )
+    })? {
+        let account = wallet
+            .get_account(account_id)
+            .map_err(|e| {
+                RpcError::owned(
+                    LegacyCode::Database.into(),
+                    "WalletDb::get_account failed",
+                    Some(format!("{e}")),
+                )
+            })?
+            // This would be a race condition between this and account deletion.
+            .ok_or_else(|| RpcErrorCode::InternalError)?;
+
+        let spendable = matches!(account.purpose(), AccountPurpose::Spending { .. });
+
+        // `z_listunspent` assumes a single HD seed.
+        // TODO: Fix this limitation.
+        let account = account
+            .source()
+            .key_derivation()
+            .map(|derivation| u32::from(derivation.account_index()).into());
+
+        let notes = wallet
+            .select_spendable_notes(
+                account_id,
+                Zatoshis::const_from_u64(MAX_MONEY),
+                &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard],
+                anchor_height,
+                &[],
+            )
+            .map_err(|e| {
+                RpcError::owned(
+                    LegacyCode::Database.into(),
+                    "WalletDb::select_spendable_notes failed",
+                    Some(format!("{e}")),
+                )
+            })?;
+
+        let sapling_nullifiers = wallet
+            .get_sapling_nullifiers(NullifierQuery::All)
+            .map_err(|e| {
+                RpcError::owned(
+                    LegacyCode::Database.into(),
+                    "WalletDb::get_sapling_nullifiers failed",
+                    Some(format!("{e}")),
+                )
+            })?
+            .into_iter()
+            .map(|(account_uuid, nf)| (nf, account_uuid))
+            .collect::<BTreeMap<_, _>>();
+
+        let get_memo = |txid, protocol, output_index| -> RpcResult<_> {
+            Ok(wallet
+                .get_memo(NoteId::new(txid, protocol, output_index))
+                .map_err(|e| {
+                    RpcError::owned(
+                        LegacyCode::Database.into(),
+                        "WalletDb::get_memo failed",
+                        Some(format!("{e}")),
+                    )
+                })?
+                .map(|memo| {
+                    (
+                        hex::encode(memo.encode().as_slice()),
+                        match memo {
+                            zcash_protocol::memo::Memo::Text(text_memo) => Some(text_memo.into()),
+                            _ => None,
+                        },
+                    )
+                })
+                .unwrap_or(("TODO: Always enhance every note".into(), None)))
+        };
+
+        for note in notes.sapling() {
+            let confirmations = wallet
+                .get_tx_height(*note.txid())
+                .map_err(|e| {
+                    RpcError::owned(
+                        LegacyCode::Database.into(),
+                        "WalletDb::get_tx_height failed",
+                        Some(format!("{e}")),
+                    )
+                })?
+                .map(|h| anchor_height + 1 - h)
+                .unwrap_or(0);
+
+            let is_internal = note.spending_key_scope() == Scope::Internal;
+
+            let (memo, memo_str) =
+                get_memo(*note.txid(), ShieldedProtocol::Sapling, note.output_index())?;
+
+            let change = spendable
+                .then(|| {
+                    RpcResult::Ok(
+                        // Check against the wallet's change address for the associated
+                        // unified account.
+                        is_internal || {
+                            // A Note is marked as "change" if the address that received
+                            // it also spent Notes in the same transaction. This will
+                            // catch, for instance:
+                            // - Change created by spending fractions of Notes (because
+                            //   `z_sendmany` sends change to the originating z-address).
+                            // - Notes created by consolidation transactions (e.g. using
+                            //   `z_mergetoaddress`).
+                            // - Notes sent from one address to itself.
+                            wallet
+                                .get_transaction(*note.txid())
+                                // Can error if we haven't enhanced.
+                                // TODO: Improve this case so we can raise actual errors.
+                                .ok()
+                                .flatten()
+                                .as_ref()
+                                .and_then(|tx| tx.sapling_bundle())
+                                .map(|bundle| {
+                                    bundle.shielded_spends().iter().any(|spend| {
+                                        sapling_nullifiers.get(spend.nullifier())
+                                            == Some(&account_id)
+                                    })
+                                })
+                                .unwrap_or(false)
+                        },
+                    )
+                })
+                .transpose()?;
+
+            unspent_notes.push(UnspentNote {
+                txid: note.txid().to_string(),
+                pool: "sapling".into(),
+                outindex: note.output_index(),
+                confirmations,
+                spendable,
+                account,
+                // TODO: Ensure we generate the same kind of shielded address as `zcashd`.
+                address: (!is_internal).then(|| note.note().recipient().encode(wallet.params())),
+                amount: value_from_zatoshis(note.value()),
+                memo,
+                memo_str,
+                change,
+            })
+        }
+
+        for note in notes.orchard() {
+            let confirmations = wallet
+                .get_tx_height(*note.txid())
+                .map_err(|e| {
+                    RpcError::owned(
+                        LegacyCode::Database.into(),
+                        "WalletDb::get_tx_height failed",
+                        Some(format!("{e}")),
+                    )
+                })?
+                .map(|h| anchor_height + 1 - h)
+                .unwrap_or(0);
+
+            let is_internal = note.spending_key_scope() == Scope::Internal;
+
+            let (memo, memo_str) =
+                get_memo(*note.txid(), ShieldedProtocol::Orchard, note.output_index())?;
+
+            unspent_notes.push(UnspentNote {
+                txid: note.txid().to_string(),
+                pool: "orchard".into(),
+                outindex: note.output_index(),
+                confirmations,
+                spendable,
+                account,
+                // TODO: Ensure we generate the same kind of shielded address as `zcashd`.
+                address: (!is_internal).then(|| {
+                    UnifiedAddress::from_receivers(Some(note.note().recipient()), None, None)
+                        .expect("valid")
+                        .encode(wallet.params())
+                }),
+                amount: value_from_zatoshis(note.value()),
+                memo,
+                memo_str,
+                change: spendable.then_some(is_internal),
+            })
+        }
+    }
+
+    Ok(unspent_notes)
+}

--- a/zallet/src/components/json_rpc/server.rs
+++ b/zallet/src/components/json_rpc/server.rs
@@ -7,6 +7,7 @@ use jsonrpsee::{
 use tokio::task::JoinHandle;
 
 use crate::{
+    components::wallet::Wallet,
     config::RpcSection,
     error::{Error, ErrorKind},
 };
@@ -14,18 +15,20 @@ use crate::{
 use super::methods::{RpcImpl, RpcServer as _};
 
 mod error;
+pub(crate) use error::LegacyCode;
+
 mod http_request_compatibility;
 mod rpc_call_compatibility;
 
 type ServerTask = JoinHandle<Result<(), Error>>;
 
-pub(crate) async fn spawn(config: RpcSection) -> Result<ServerTask, Error> {
+pub(crate) async fn spawn(config: RpcSection, wallet: Wallet) -> Result<ServerTask, Error> {
     // Caller should make sure `bind` only contains a single address (for now).
     assert_eq!(config.bind.len(), 1);
     let listen_addr = config.bind[0];
 
     // Initialize the RPC methods.
-    let rpc_impl = RpcImpl::new();
+    let rpc_impl = RpcImpl::new(wallet);
 
     let http_middleware_layer = http_request_compatibility::HttpRequestMiddlewareLayer::new();
 

--- a/zallet/src/components/wallet.rs
+++ b/zallet/src/components/wallet.rs
@@ -1,0 +1,99 @@
+use std::fmt;
+use std::path::Path;
+use std::time::Duration;
+
+use abscissa_core::{Component, FrameworkError};
+use abscissa_tokio::TokioComponent;
+use tokio::{task::JoinHandle, time};
+use zcash_client_backend::sync;
+
+use crate::{
+    error::{Error, ErrorKind},
+    network::Network,
+    remote::Servers,
+};
+
+mod cache;
+mod connection;
+
+pub(crate) type WalletHandle = deadpool::managed::Object<connection::WalletManager>;
+
+#[derive(Clone, Component)]
+#[component(inject = "init_tokio(abscissa_tokio::TokioComponent)")]
+pub(crate) struct Wallet {
+    params: Network,
+    db_data_pool: connection::WalletPool,
+    lightwalletd_server: Servers,
+}
+
+impl fmt::Debug for Wallet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Wallet")
+            .field("params", &self.params)
+            .field("lightwalletd_server", &self.lightwalletd_server)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Wallet {
+    pub fn open(
+        path: impl AsRef<Path>,
+        params: Network,
+        lightwalletd_server: Servers,
+    ) -> Result<Self, Error> {
+        let db_data_pool = connection::pool(path, params)?;
+        Ok(Self {
+            params,
+            db_data_pool,
+            lightwalletd_server,
+        })
+    }
+
+    /// Called automatically after `TokioComponent` is initialized
+    pub fn init_tokio(&mut self, _tokio_cmp: &TokioComponent) -> Result<(), FrameworkError> {
+        Ok(())
+    }
+
+    pub(crate) async fn handle(&self) -> Result<WalletHandle, Error> {
+        self.db_data_pool
+            .get()
+            .await
+            .map_err(|e| ErrorKind::Generic.context(e).into())
+    }
+
+    pub async fn spawn_sync(&self) -> Result<JoinHandle<Result<(), Error>>, Error> {
+        let mut client = self
+            .lightwalletd_server
+            .pick(self.params)?
+            .connect_direct()
+            .await?;
+
+        let params = self.params.clone();
+
+        let mut db_cache = cache::MemoryCache::new();
+
+        let mut db_data = self.handle().await?;
+
+        let mut interval = time::interval(Duration::from_secs(30));
+
+        let task = tokio::spawn(async move {
+            loop {
+                // TODO: Move this inside `sync::run` so that we aren't querying subtree roots
+                // every interval.
+                interval.tick().await;
+
+                sync::run(
+                    &mut client,
+                    &params,
+                    &mut db_cache,
+                    db_data.as_mut(),
+                    10_000,
+                )
+                .await
+                .map_err(|e| ErrorKind::Generic.context(e))?;
+            }
+        });
+
+        Ok(task)
+    }
+}

--- a/zallet/src/components/wallet.rs
+++ b/zallet/src/components/wallet.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 mod cache;
+
 mod connection;
+pub(crate) use connection::WalletConnection;
 
 pub(crate) type WalletHandle = deadpool::managed::Object<connection::WalletManager>;
 

--- a/zallet/src/components/wallet/cache.rs
+++ b/zallet/src/components/wallet/cache.rs
@@ -1,0 +1,113 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use zcash_client_backend::{
+    data_api::{
+        chain::{error::Error as ChainError, BlockCache, BlockSource},
+        scanning::ScanRange,
+    },
+    proto::compact_formats::CompactBlock,
+};
+use zcash_protocol::consensus::BlockHeight;
+
+use crate::error::Error;
+
+#[derive(Debug)]
+pub(super) struct MemoryCache {
+    blocks: Arc<RwLock<BTreeMap<BlockHeight, CompactBlock>>>,
+}
+
+impl MemoryCache {
+    /// Constructs a new in-memory [`CompactBlock`] cache.
+    pub(super) fn new() -> Self {
+        Self {
+            blocks: Arc::new(RwLock::new(BTreeMap::new())),
+        }
+    }
+}
+
+impl BlockSource for MemoryCache {
+    type Error = Error;
+
+    fn with_blocks<F, WalletErrT>(
+        &self,
+        from_height: Option<BlockHeight>,
+        limit: Option<usize>,
+        mut with_block: F,
+    ) -> Result<(), ChainError<WalletErrT, Self::Error>>
+    where
+        F: FnMut(CompactBlock) -> Result<(), ChainError<WalletErrT, Self::Error>>,
+    {
+        tokio::task::block_in_place(|| {
+            for (i, (_, block)) in self
+                .blocks
+                .blocking_read()
+                .iter()
+                .skip_while(|(h, _)| from_height.map_or(false, |from_height| **h < from_height))
+                .enumerate()
+            {
+                if limit.map_or(true, |limit| i < limit) {
+                    // The `BlockSource` trait does not guarantee sequential blocks.
+                    with_block(block.clone())?;
+                } else {
+                    break;
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+#[async_trait]
+impl BlockCache for MemoryCache {
+    fn get_tip_height(
+        &self,
+        range: Option<&ScanRange>,
+    ) -> Result<Option<BlockHeight>, Self::Error> {
+        tokio::task::block_in_place(|| {
+            Ok(if let Some(range) = range {
+                self.blocks
+                    .blocking_read()
+                    .iter()
+                    .rev()
+                    .filter(|(height, _)| range.block_range().contains(height))
+                    .map(|(height, _)| *height)
+                    .next()
+            } else {
+                self.blocks
+                    .blocking_read()
+                    .last_key_value()
+                    .map(|(height, _)| *height)
+            })
+        })
+    }
+
+    async fn read(&self, range: &ScanRange) -> Result<Vec<CompactBlock>, Self::Error> {
+        Ok(self
+            .blocks
+            .read()
+            .await
+            .iter()
+            .filter(|(height, _)| range.block_range().contains(height))
+            .map(|(_, block)| block.clone())
+            .collect())
+    }
+
+    async fn insert(&self, compact_blocks: Vec<CompactBlock>) -> Result<(), Self::Error> {
+        for block in compact_blocks {
+            self.blocks.write().await.insert(block.height(), block);
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, range: ScanRange) -> Result<(), Self::Error> {
+        let mut height = range.block_range().start;
+        while height < range.block_range().end {
+            self.blocks.write().await.remove(&height);
+            height = height + 1;
+        }
+        Ok(())
+    }
+}

--- a/zallet/src/components/wallet/connection.rs
+++ b/zallet/src/components/wallet/connection.rs
@@ -85,6 +85,10 @@ pub(crate) struct WalletConnection {
 }
 
 impl WalletConnection {
+    pub(crate) fn params(&self) -> &Network {
+        &self.params
+    }
+
     fn with<T>(&self, f: impl FnOnce(WalletDb<&rusqlite::Connection, Network>) -> T) -> T {
         tokio::task::block_in_place(|| {
             f(WalletDb::from_connection(

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -4,13 +4,17 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use zcash_protocol::consensus::NetworkType;
+
+use crate::network::{Network, RegTestNuParam};
 
 /// Zallet Configuration
 ///
-/// All fields are `Option<T>` to enable distinguishing between a user relying on a
+/// Most fields are `Option<T>` to enable distinguishing between a user relying on a
 /// default value (which may change over time), and a user explicitly configuring an
-/// option with the current default value (which should be preserved).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// option with the current default value (which should be preserved). The sole exception
+/// to this is `network`, which cannot change for the lifetime of the wallet.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ZalletConfig {
     /// Whether the wallet should broadcast transactions.
@@ -19,10 +23,20 @@ pub struct ZalletConfig {
     /// Directory to be used when exporting data.
     pub export_dir: Option<String>,
 
+    /// Network type.
+    #[serde(with = "crate::network::kind")]
+    pub network: NetworkType,
+
     /// Execute command when a wallet transaction changes.
     ///
     /// `%s` in the command is replaced by TxID.
     pub notify: Option<String>,
+
+    /// The parameters for regtest mode.
+    ///
+    /// Ignored if `network` is not `NetworkType::Regtest`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub regtest_nuparams: Vec<RegTestNuParam>,
 
     /// By default, the wallet will not allow generation of new spending keys & addresses
     /// from the mnemonic seed until the backup of that seed has been confirmed with the
@@ -39,12 +53,33 @@ pub struct ZalletConfig {
     pub rpc: RpcSection,
 }
 
+impl Default for ZalletConfig {
+    fn default() -> Self {
+        Self {
+            broadcast: None,
+            export_dir: None,
+            network: NetworkType::Main,
+            notify: None,
+            regtest_nuparams: vec![],
+            require_backup: None,
+            builder: Default::default(),
+            limits: Default::default(),
+            rpc: Default::default(),
+        }
+    }
+}
+
 impl ZalletConfig {
     /// Whether the wallet should broadcast transactions.
     ///
     /// Default is `true`.
     pub fn broadcast(&self) -> bool {
         self.broadcast.unwrap_or(true)
+    }
+
+    /// Returns the network parameters for this wallet.
+    pub fn network(&self) -> Network {
+        Network::from_type(self.network, &self.regtest_nuparams)
     }
 
     /// Whether to require a confirmed wallet backup.

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -1,6 +1,7 @@
 //! Zallet Config
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -44,6 +45,12 @@ pub struct ZalletConfig {
     /// to allow generation of spending keys even if the backup has not yet been confirmed.
     pub require_backup: Option<bool>,
 
+    /// Path to the wallet database file.
+    ///
+    /// TODO: If we decide to support a data directory, allow this to have a relative path
+    /// within it as well as a default name.
+    pub wallet_db: Option<PathBuf>,
+
     /// Settings that affect transactions created by Zallet.
     pub builder: BuilderSection,
 
@@ -62,6 +69,7 @@ impl Default for ZalletConfig {
             notify: None,
             regtest_nuparams: vec![],
             require_backup: None,
+            wallet_db: None,
             builder: Default::default(),
             limits: Default::default(),
             rpc: Default::default(),

--- a/zallet/src/lib.rs
+++ b/zallet/src/lib.rs
@@ -20,6 +20,7 @@ mod components;
 pub mod config;
 mod error;
 mod i18n;
+pub mod network;
 mod prelude;
 
 #[macro_export]

--- a/zallet/src/lib.rs
+++ b/zallet/src/lib.rs
@@ -22,6 +22,7 @@ mod error;
 mod i18n;
 pub mod network;
 mod prelude;
+mod remote;
 
 #[macro_export]
 macro_rules! fl {

--- a/zallet/src/network.rs
+++ b/zallet/src/network.rs
@@ -1,0 +1,164 @@
+//! Zcash network parameters.
+
+use serde::{Deserialize, Serialize};
+use zcash_protocol::{
+    consensus::{self, BlockHeight},
+    local_consensus,
+};
+
+/// Chain parameters for a Zcash consensus network.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Network {
+    /// A public global consensus network.
+    Consensus(consensus::Network),
+    /// A local network used for integration testing.
+    RegTest(local_consensus::LocalNetwork),
+}
+
+impl Network {
+    pub(crate) fn from_type(
+        network_type: consensus::NetworkType,
+        nuparams: &[RegTestNuParam],
+    ) -> Self {
+        match network_type {
+            consensus::NetworkType::Main => Self::Consensus(consensus::Network::MainNetwork),
+            consensus::NetworkType::Test => Self::Consensus(consensus::Network::TestNetwork),
+            consensus::NetworkType::Regtest => {
+                let find_nu = |nu: consensus::BranchId| {
+                    nuparams
+                        .iter()
+                        .find(|p| p.consensus_branch_id == nu)
+                        .map(|p| p.activation_height)
+                };
+
+                // If a NU is omitted, ensure that it activates at the same height as the
+                // subsequent specified NU (if any).
+                let nu6 = find_nu(consensus::BranchId::Nu6);
+                let nu5 = find_nu(consensus::BranchId::Nu5).or(nu6);
+                let canopy = find_nu(consensus::BranchId::Canopy).or(nu5);
+                let heartwood = find_nu(consensus::BranchId::Heartwood).or(canopy);
+                let blossom = find_nu(consensus::BranchId::Blossom).or(heartwood);
+                let sapling = find_nu(consensus::BranchId::Sapling).or(blossom);
+                let overwinter = find_nu(consensus::BranchId::Overwinter).or(sapling);
+
+                Self::RegTest(local_consensus::LocalNetwork {
+                    overwinter,
+                    sapling,
+                    blossom,
+                    heartwood,
+                    canopy,
+                    nu5,
+                    nu6,
+                })
+            }
+        }
+    }
+}
+
+impl consensus::Parameters for Network {
+    fn network_type(&self) -> consensus::NetworkType {
+        match self {
+            Self::Consensus(params) => params.network_type(),
+            Self::RegTest(params) => params.network_type(),
+        }
+    }
+
+    fn activation_height(&self, nu: consensus::NetworkUpgrade) -> Option<BlockHeight> {
+        match self {
+            Self::Consensus(params) => params.activation_height(nu),
+            Self::RegTest(params) => params.activation_height(nu),
+        }
+    }
+}
+
+/// A parameter for regtest mode.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(try_from = "&str")]
+#[serde(into = "String")]
+pub struct RegTestNuParam {
+    consensus_branch_id: consensus::BranchId,
+    activation_height: BlockHeight,
+}
+
+impl TryFrom<&str> for RegTestNuParam {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let (branch_id, height) = value
+            .split_once(':')
+            .ok_or_else(|| "Invalid `regtest_nuparam`")?;
+
+        let consensus_branch_id = u32::from_str_radix(branch_id, 16)
+            .ok()
+            .and_then(|branch_id| consensus::BranchId::try_from(branch_id).ok())
+            .ok_or_else(|| "Invalid `regtest_nuparam`")?;
+
+        let activation_height = height
+            .parse()
+            .map(BlockHeight::from_u32)
+            .map_err(|_| "Invalid `regtest_nuparam`")?;
+
+        Ok(Self {
+            consensus_branch_id,
+            activation_height,
+        })
+    }
+}
+
+impl From<RegTestNuParam> for String {
+    fn from(nuparam: RegTestNuParam) -> Self {
+        format!(
+            "{:08x}:{}",
+            u32::from(nuparam.consensus_branch_id),
+            nuparam.activation_height
+        )
+    }
+}
+
+pub(crate) mod kind {
+    use std::fmt;
+
+    use serde::{de::Visitor, Deserializer, Serializer};
+    use zcash_protocol::consensus::NetworkType;
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<NetworkType, D::Error> {
+        struct NetworkTypeVisitor;
+        impl<'de> Visitor<'de> for NetworkTypeVisitor {
+            type Value = NetworkType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "one of 'main', 'test', or 'regtest'")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match v {
+                    "main" => Ok(NetworkType::Main),
+                    "test" => Ok(NetworkType::Test),
+                    "regtest" => Ok(NetworkType::Regtest),
+                    _ => Err(serde::de::Error::invalid_type(
+                        serde::de::Unexpected::Str(v),
+                        &self,
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(NetworkTypeVisitor)
+    }
+
+    pub(crate) fn serialize<S: Serializer>(
+        network_type: &NetworkType,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(match network_type {
+            NetworkType::Main => "main",
+            NetworkType::Test => "test",
+            NetworkType::Regtest => "regtest",
+        })
+    }
+}

--- a/zallet/src/remote.rs
+++ b/zallet/src/remote.rs
@@ -1,0 +1,170 @@
+use std::borrow::Cow;
+use std::fmt;
+
+use abscissa_core::tracing::info;
+use tonic::transport::{Channel, ClientTlsConfig};
+use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
+use zcash_protocol::consensus::{NetworkType, Parameters};
+
+use crate::{
+    error::{Error, ErrorKind},
+    network::Network,
+};
+
+const ECC_TESTNET: &[Server<'_>] = &[Server::fixed("lightwalletd.testnet.electriccoin.co", 9067)];
+
+const YWALLET_MAINNET: &[Server<'_>] = &[
+    Server::fixed("lwd1.zcash-infra.com", 9067),
+    Server::fixed("lwd2.zcash-infra.com", 9067),
+    Server::fixed("lwd3.zcash-infra.com", 9067),
+    Server::fixed("lwd4.zcash-infra.com", 9067),
+    Server::fixed("lwd5.zcash-infra.com", 9067),
+    Server::fixed("lwd6.zcash-infra.com", 9067),
+    Server::fixed("lwd7.zcash-infra.com", 9067),
+    Server::fixed("lwd8.zcash-infra.com", 9067),
+];
+
+const ZEC_ROCKS_MAINNET: &[Server<'_>] = &[
+    Server::fixed("zec.rocks", 443),
+    Server::fixed("ap.zec.rocks", 443),
+    Server::fixed("eu.zec.rocks", 443),
+    Server::fixed("na.zec.rocks", 443),
+    Server::fixed("sa.zec.rocks", 443),
+];
+const ZEC_ROCKS_TESTNET: &[Server<'_>] = &[Server::fixed("testnet.zec.rocks", 443)];
+
+#[derive(Clone, Debug)]
+pub(crate) enum ServerOperator {
+    Ecc,
+    YWallet,
+    ZecRocks,
+}
+
+impl ServerOperator {
+    fn servers(&self, network: NetworkType) -> &[Server<'_>] {
+        match (self, network) {
+            (ServerOperator::Ecc, NetworkType::Main) => &[],
+            (ServerOperator::Ecc, NetworkType::Test) => ECC_TESTNET,
+            (ServerOperator::YWallet, NetworkType::Main) => YWALLET_MAINNET,
+            (ServerOperator::YWallet, NetworkType::Test) => &[],
+            (ServerOperator::ZecRocks, NetworkType::Main) => ZEC_ROCKS_MAINNET,
+            (ServerOperator::ZecRocks, NetworkType::Test) => ZEC_ROCKS_TESTNET,
+            (_, NetworkType::Regtest) => &[],
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum Servers {
+    Hosted(ServerOperator),
+    Custom(Vec<Server<'static>>),
+}
+
+impl Servers {
+    pub(crate) fn parse(s: &str) -> Result<Self, Error> {
+        match s {
+            "ecc" => Ok(Self::Hosted(ServerOperator::Ecc)),
+            "ywallet" => Ok(Self::Hosted(ServerOperator::YWallet)),
+            "zecrocks" => Ok(Self::Hosted(ServerOperator::ZecRocks)),
+            _ => s
+                .split(',')
+                .map(|sub| {
+                    sub.rsplit_once(':').and_then(|(host, port_str)| {
+                        port_str
+                            .parse()
+                            .ok()
+                            .map(|port| Server::custom(host.into(), port))
+                    })
+                })
+                .collect::<Option<_>>()
+                .map(Self::Custom)
+                .ok_or(ErrorKind::Generic
+                    .context(format!("'{}' must be one of ['ecc', 'ywallet', 'zecrocks'], or a comma-separated list of host:port", s))
+                    .into()),
+        }
+    }
+
+    pub(crate) fn pick(&self, network: Network) -> Result<&Server<'_>, Error> {
+        // For now just use the first server in the list.
+        match self {
+            Servers::Hosted(server_operator) => server_operator
+                .servers(network.network_type())
+                .first()
+                .ok_or(
+                    ErrorKind::Generic
+                        .context(format!("{:?} doesn't serve {:?}", server_operator, network))
+                        .into(),
+                ),
+            Servers::Custom(servers) => Ok(servers.first().expect("not empty")),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Server<'a> {
+    host: Cow<'a, str>,
+    port: u16,
+}
+
+impl fmt::Display for Server<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+impl Server<'static> {
+    const fn fixed(host: &'static str, port: u16) -> Self {
+        Self {
+            host: Cow::Borrowed(host),
+            port,
+        }
+    }
+}
+
+impl<'a> Server<'a> {
+    fn custom(host: String, port: u16) -> Self {
+        Self {
+            host: Cow::Owned(host),
+            port,
+        }
+    }
+
+    fn use_tls(&self) -> bool {
+        // Assume that localhost will never have a cert, and require remotes to have one.
+        !matches!(self.host.as_ref(), "localhost" | "127.0.0.1" | "::1")
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "{}://{}:{}",
+            if self.use_tls() { "https" } else { "http" },
+            self.host,
+            self.port
+        )
+    }
+
+    pub(crate) async fn connect_direct(&self) -> Result<CompactTxStreamerClient<Channel>, Error> {
+        info!("Connecting to {}", self);
+
+        let channel =
+            Channel::from_shared(self.endpoint()).map_err(|e| ErrorKind::Generic.context(e))?;
+
+        let channel = if self.use_tls() {
+            let tls = ClientTlsConfig::new()
+                .domain_name(self.host.to_string())
+                .with_webpki_roots();
+            channel
+                .tls_config(tls)
+                .map_err(|e| ErrorKind::Generic.context(e))?
+        } else {
+            channel
+        };
+
+        Ok(CompactTxStreamerClient::new(
+            channel
+                .connect()
+                .await
+                .map_err(|e| ErrorKind::Generic.context(e))?,
+        ))
+    }
+}


### PR DESCRIPTION
With this PR, Zallet can sync a wallet and respond (mostly with errors) to JSON-RPC requests.

Limitations:
- Currently no support for initialization (use `zcash-devtool` to prepare an appropriate database).
- Uses `lightwalletd` for now (as that's what `zcash_client_backend` currently supports in its `sync` module).
- `z_listaccounts` and `z_getnotescount` have only been connected up in the barest fashion.