### PR TITLE
[#23] MacOS `cargo test` build fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,6 +3530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
 name = "zallet"
 version = "0.0.0"
 dependencies = [
@@ -3563,6 +3569,7 @@ dependencies = [
  "toml 0.8.19",
  "tonic",
  "tower 0.4.13",
+ "xdg",
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio = "1"
 
 # Filesystem
 home = "0.5"
+xdg = "2.5"
 
 # Localization
 i18n-embed = { version = "0.15", features = ["fluent-system"] }

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -39,6 +39,7 @@ toml.workspace = true
 tonic.workspace = true
 tower = { workspace = true, features = ["timeout"] }
 transparent.workspace = true
+xdg.workspace = true
 zcash_client_backend = { workspace = true, features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",


### PR DESCRIPTION
Adds xdg crate reference to Cargo workspace and toml 
closes #23