### PR TITLE
use zaino traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "tower 0.4.13",
  "xdg",
  "zaino-fetch",
+ "zaino-proto",
  "zaino-state",
  "zcash_address 0.7.0",
  "zcash_client_backend",
@@ -5744,6 +5745,7 @@ dependencies = [
  "zcash_transparent",
  "zebra-chain",
  "zebra-rpc",
+ "zebra-state",
  "zip32 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,12 @@ zcash_primitives = "0.22"
 # Zcash chain state
 zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "b84847ab381ea897480053486b2f7a04898d9f61" }
 zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "b84847ab381ea897480053486b2f7a04898d9f61" }
+zaino-proto = { git = "https://github.com/zingolabs/zaino.git", rev = "b84847ab381ea897480053486b2f7a04898d9f61" }
 # - We do not use branch dependencies in general because they are brittle, but are forced
 #   to do so here because Zaino does.
 zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "main" }
 zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "main" }
+zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "main" }
 
 # Zcash wallet
 deadpool = "0.12"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -107,6 +107,7 @@ transparent.workspace = true
 xdg.workspace = true
 zaino-fetch.workspace = true
 zaino-state.workspace = true
+zaino-proto.workspace = true
 zcash_address.workspace = true
 zcash_client_backend = { workspace = true, features = [
     "lightwalletd-tonic-tls-webpki-roots",
@@ -123,6 +124,7 @@ zcash_primitives.workspace = true
 zcash_protocol = { workspace = true, features = ["local-consensus"] }
 zebra-chain.workspace = true
 zebra-rpc.workspace = true
+zebra-state.workspace = true
 zip32.workspace = true
 
 [build-dependencies]

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -3,9 +3,10 @@ use std::time::Duration;
 
 use abscissa_core::{component::Injectable, Component, FrameworkError};
 use abscissa_tokio::TokioComponent;
-use jsonrpsee::tracing::{self, debug, info};
+use futures::StreamExt as _;
+use jsonrpsee::tracing::{self, debug, info, warn};
 use tokio::{select, task::JoinHandle, time};
-use zaino_state::fetch::FetchServiceSubscriber;
+use zaino_state::{fetch::FetchServiceSubscriber, indexer::LightWalletIndexer as _};
 use zcash_client_backend::data_api::{
     chain::{scan_cached_blocks, BlockCache},
     scanning::{ScanPriority, ScanRange},
@@ -14,6 +15,7 @@ use zcash_client_backend::data_api::{
 };
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::consensus::{self, BlockHeight};
+use zebra_chain::transaction::SerializedTransaction;
 
 use crate::{application::ZalletApp, config::ZalletConfig, error::Error, network::Network};
 
@@ -91,7 +93,7 @@ impl WalletSync {
             // Spawn the ongoing sync tasks.
             let chain = chain_view.subscribe().await?.inner();
             let mut steady_state_task = tokio::spawn(async move {
-                steady_state(chain, &params, db_data.as_mut(), starting_tip).await?;
+                steady_state(&chain, &params, db_data.as_mut(), starting_tip).await?;
                 Ok(())
             });
 
@@ -189,13 +191,13 @@ async fn initialize(
 /// Keeps the wallet state up-to-date with the chain tip, and handles the mempool.
 #[tracing::instrument(skip_all)]
 async fn steady_state(
-    mut chain: FetchServiceSubscriber,
+    chain: &FetchServiceSubscriber,
     params: &Network,
     db_data: &mut DbConnection,
     mut prev_tip: ChainBlock,
 ) -> Result<(), SyncError> {
     info!("Steady-state sync task started");
-    let mut current_tip = steps::get_chain_tip(&chain).await?;
+    let mut current_tip = steps::get_chain_tip(chain).await?;
 
     // TODO: Remove this once we've made `zcash_client_sqlite` changes to support scanning
     // regular blocks.
@@ -205,7 +207,7 @@ async fn steady_state(
         info!("New chain tip: {} {}", current_tip.height, current_tip.hash);
 
         // Figure out the diff between the previous and current chain tips.
-        let fork_point = steps::find_fork(&chain, prev_tip, current_tip).await?;
+        let fork_point = steps::find_fork(chain, prev_tip, current_tip).await?;
         assert!(fork_point.height <= current_tip.height);
 
         // TODO: Decide whether we need this chunking.
@@ -226,9 +228,9 @@ async fn steady_state(
         {
             let mut current_block = current_tip;
             while current_block != fork_point {
-                block_stack.push(steps::fetch_block(&chain, current_block.hash).await?);
+                block_stack.push(steps::fetch_block(chain, current_block.hash).await?);
                 current_block = ChainBlock::resolve(
-                    &chain,
+                    chain,
                     current_block.prev_hash.expect("present by invariant"),
                 )
                 .await?;
@@ -259,8 +261,7 @@ async fn steady_state(
             let scan_range = ScanRange::from_parts(from_height..end_height, ScanPriority::ChainTip);
             db_cache.insert(block_stack).await?;
 
-            let from_state =
-                steps::fetch_chain_state(&chain, from_height.saturating_sub(1)).await?;
+            let from_state = steps::fetch_chain_state(chain, from_height.saturating_sub(1)).await?;
 
             tokio::task::block_in_place(|| {
                 info!("Scanning {}", scan_range);
@@ -279,7 +280,7 @@ async fn steady_state(
 
         // Now that we're done applying the chain diff, update our chain pointers.
         prev_tip = current_tip;
-        current_tip = steps::get_chain_tip(&chain).await?;
+        current_tip = steps::get_chain_tip(chain).await?;
 
         // If the chain tip no longer matches, we have more to do before consuming mempool
         // updates.
@@ -291,22 +292,27 @@ async fn steady_state(
         info!("Reached chain tip, streaming mempool");
         let mempool_height = current_tip.height + 1;
         let consensus_branch_id = consensus::BranchId::for_height(params, mempool_height);
-        // TODO: https://github.com/zingolabs/zaino/issues/249
-        let (mut mempool, _task) = chain.mempool.get_mempool_stream().await?;
-        while let Some(res) = mempool.recv().await {
-            let (mempool_key, mempool_value) = res?;
-            info!("Scanning mempool tx {}", mempool_key.0);
-            let tx_bytes = match mempool_value.0 {
-                zebra_rpc::methods::GetRawTransaction::Raw(tx_bytes) => tx_bytes,
-                zebra_rpc::methods::GetRawTransaction::Object(tx) => tx.hex,
-            };
-            let tx = Transaction::read(tx_bytes.as_ref(), consensus_branch_id)
-                .expect("Zaino should only provide valid transactions");
-            decrypt_and_store_transaction(params, db_data, &tx, None)?;
+        let mut mempool_stream = chain.get_mempool_stream().await?;
+        while let Some(result) = mempool_stream.next().await {
+            match result {
+                Ok(raw_tx) => {
+                    info!("Processing transaction: {:?}", &raw_tx.data[..16]);
+                    let tx = Transaction::read(
+                        SerializedTransaction::from(raw_tx.data).as_ref(),
+                        consensus_branch_id,
+                    )
+                    .expect("Zaino should only provide valid transactions");
+                    decrypt_and_store_transaction(params, db_data, &tx, None)?;
+                }
+                Err(e) => {
+                    warn!("Error receiving transaction: {}", e);
+                    // return error here?
+                }
+            }
         }
 
         // Mempool stream ended, signalling that the chain tip has changed.
-        current_tip = steps::get_chain_tip(&chain).await?;
+        current_tip = steps::get_chain_tip(chain).await?;
     }
 }
 

--- a/zallet/src/components/sync/error.rs
+++ b/zallet/src/components/sync/error.rs
@@ -1,17 +1,13 @@
 use std::fmt;
 
 use shardtree::error::ShardTreeError;
-use zaino_fetch::jsonrpc::error::JsonRpcConnectorError;
-use zaino_state::error::{BlockCacheError, MempoolError, StatusError};
+use zaino_state::error::FetchServiceError;
 use zcash_client_backend::scanning::ScanError;
 use zcash_client_sqlite::error::SqliteClientError;
 
 #[derive(Debug)]
 pub(crate) enum SyncError {
-    BlockCache(BlockCacheError),
-    Indexer(StatusError),
-    Mempool(MempoolError),
-    Node(JsonRpcConnectorError),
+    Indexer(FetchServiceError),
     Scan(ScanError),
     Tree(ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>),
     Other(SqliteClientError),
@@ -20,10 +16,7 @@ pub(crate) enum SyncError {
 impl fmt::Display for SyncError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SyncError::BlockCache(e) => write!(f, "{e}"),
             SyncError::Indexer(e) => write!(f, "{e}"),
-            SyncError::Mempool(e) => write!(f, "{e}"),
-            SyncError::Node(e) => write!(f, "{e}"),
             SyncError::Scan(e) => write!(f, "{e}"),
             SyncError::Tree(e) => write!(f, "{e}"),
             SyncError::Other(e) => write!(f, "{e}"),
@@ -32,24 +25,6 @@ impl fmt::Display for SyncError {
 }
 
 impl std::error::Error for SyncError {}
-
-impl From<BlockCacheError> for SyncError {
-    fn from(e: BlockCacheError) -> Self {
-        Self::BlockCache(e)
-    }
-}
-
-impl From<JsonRpcConnectorError> for SyncError {
-    fn from(e: JsonRpcConnectorError) -> Self {
-        Self::Node(e)
-    }
-}
-
-impl From<MempoolError> for SyncError {
-    fn from(e: MempoolError) -> Self {
-        Self::Mempool(e)
-    }
-}
 
 impl From<ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>> for SyncError {
     fn from(e: ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>) -> Self {
@@ -63,8 +38,8 @@ impl From<SqliteClientError> for SyncError {
     }
 }
 
-impl From<StatusError> for SyncError {
-    fn from(e: StatusError) -> Self {
+impl From<FetchServiceError> for SyncError {
+    fn from(e: FetchServiceError) -> Self {
         Self::Indexer(e)
     }
 }

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -1,7 +1,11 @@
 use jsonrpsee::tracing::info;
 use orchard::tree::MerkleHashOrchard;
-use zaino_fetch::jsonrpc::{error::JsonRpcConnectorError, response::GetBlockResponse};
-use zaino_state::fetch::FetchServiceSubscriber;
+use zaino_fetch::jsonrpc::error::JsonRpcConnectorError;
+use zaino_state::{
+    error::FetchServiceError,
+    fetch::FetchServiceSubscriber,
+    indexer::{LightWalletIndexer as _, ZcashIndexer as _},
+};
 use zcash_client_backend::{
     data_api::{
         chain::{ChainState, CommitmentTreeRoot},
@@ -15,12 +19,18 @@ use zcash_client_backend::{
 };
 use zcash_primitives::{block::BlockHash, merkle_tree::read_frontier_v0};
 use zcash_protocol::consensus::BlockHeight;
+use zebra_chain::{
+    block::Block, serialization::ZcashDeserialize as _, subtree::NoteCommitmentSubtreeIndex,
+};
+use zebra_rpc::methods::GetBlock;
+use zebra_state::HashOrHeight;
 
 use crate::components::database::DbConnection;
 
 use super::SyncError;
 
 // TODO: This type, or something similar, should be part of Zaino or Zebra.
+// TODO: https://github.com/zingolabs/zaino/issues/249
 #[derive(Clone, Copy, Debug)]
 pub(super) struct ChainBlock {
     pub(super) height: BlockHeight,
@@ -48,29 +58,53 @@ impl ChainBlock {
     }
 
     pub(super) async fn tip(chain: &FetchServiceSubscriber) -> Result<Self, SyncError> {
-        Self::resolve_inner(chain, "-1".into()).await
+        let block_id = chain.get_latest_block().await?;
+
+        let compact_block = chain.get_block(block_id).await?;
+
+        Ok(Self {
+            height: BlockHeight::from_u32(compact_block.height.try_into().map_err(
+                |e: std::num::TryFromIntError| {
+                    SyncError::from(FetchServiceError::SerializationError(e.into()))
+                },
+            )?),
+            hash: BlockHash::try_from_slice(compact_block.hash.as_slice())
+                .expect("block hash missing"),
+            prev_hash: BlockHash::try_from_slice(compact_block.prev_hash.as_slice()),
+        })
     }
 
     async fn resolve_inner(
         chain: &FetchServiceSubscriber,
         hash_or_height: String,
     ) -> Result<Self, SyncError> {
-        // TODO: https://github.com/zingolabs/zaino/issues/249
-        match chain.fetcher.get_block(hash_or_height, None).await? {
-            GetBlockResponse::Raw(_) => unreachable!("We requested verbosity 1"),
-            GetBlockResponse::Object {
-                hash,
-                height,
-                previous_block_hash,
-                ..
-            } => Ok(Self {
-                height: height
-                    .map(|h| BlockHeight::from_u32(h.0))
-                    .unwrap_or_else(|| todo!()),
-                hash: BlockHash(hash.0 .0),
-                prev_hash: previous_block_hash.map(|h| BlockHash(h.0 .0)),
-            }),
-        }
+        let hash_or_height: HashOrHeight = hash_or_height
+            .parse()
+            .map_err(|e| SyncError::from(FetchServiceError::SerializationError(e)))?;
+
+        let block_id = match hash_or_height {
+            HashOrHeight::Hash(hash) => zaino_proto::proto::service::BlockId {
+                height: 0,
+                hash: hash.0.to_vec(),
+            },
+            HashOrHeight::Height(height) => zaino_proto::proto::service::BlockId {
+                height: height.0 as u64,
+                hash: Vec::new(),
+            },
+        };
+
+        let compact_block = chain.get_block(block_id).await?;
+
+        Ok(Self {
+            height: BlockHeight::from_u32(compact_block.height.try_into().map_err(
+                |e: std::num::TryFromIntError| {
+                    SyncError::from(FetchServiceError::SerializationError(e.into()))
+                },
+            )?),
+            hash: BlockHash::try_from_slice(compact_block.hash.as_slice())
+                .expect("block hash missing"),
+            prev_hash: BlockHash::try_from_slice(compact_block.prev_hash.as_slice()),
+        })
     }
 }
 
@@ -79,15 +113,16 @@ pub(super) async fn update_subtree_roots(
     db_data: &mut DbConnection,
 ) -> Result<(), SyncError> {
     let sapling_roots = chain
-        .fetcher
-        .get_subtrees_by_index("sapling".into(), 0, None)
+        .z_get_subtrees_by_index("sapling".into(), NoteCommitmentSubtreeIndex(0), None)
         .await?
         .subtrees
         .into_iter()
         .map(|subtree| {
             let mut root_hash = [0; 32];
             hex::decode_to_slice(&subtree.root, &mut root_hash).map_err(|e| {
-                JsonRpcConnectorError::JsonRpcClientError(format!("Invalid subtree root: {}", e))
+                FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::JsonRpcClientError(
+                    format!("Invalid subtree root: {}", e),
+                ))
             })?;
             Ok(CommitmentTreeRoot::from_parts(
                 BlockHeight::from_u32(subtree.end_height.0),
@@ -100,15 +135,16 @@ pub(super) async fn update_subtree_roots(
     db_data.put_sapling_subtree_roots(0, &sapling_roots)?;
 
     let orchard_roots = chain
-        .fetcher
-        .get_subtrees_by_index("orchard".into(), 0, None)
+        .z_get_subtrees_by_index("orchard".into(), NoteCommitmentSubtreeIndex(0), None)
         .await?
         .subtrees
         .into_iter()
         .map(|subtree| {
             let mut root_hash = [0; 32];
             hex::decode_to_slice(&subtree.root, &mut root_hash).map_err(|e| {
-                JsonRpcConnectorError::JsonRpcClientError(format!("Invalid subtree root: {}", e))
+                FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::JsonRpcClientError(
+                    format!("Invalid subtree root: {}", e),
+                ))
             })?;
             Ok(CommitmentTreeRoot::from_parts(
                 BlockHeight::from_u32(subtree.end_height.0),
@@ -173,7 +209,7 @@ pub(super) async fn fetch_blocks(
     let mut blocks = Vec::with_capacity(scan_range.len());
     for height in u32::from(scan_range.block_range().start)..u32::from(scan_range.block_range().end)
     {
-        blocks.push(fetch_block_inner(chain, height.to_string()).await?);
+        blocks.push(fetch_compact_block_inner(chain, height.to_string()).await?);
     }
 
     Ok(blocks)
@@ -184,15 +220,45 @@ pub(super) async fn fetch_block(
     hash: BlockHash,
 ) -> Result<CompactBlock, SyncError> {
     info!("Fetching block {}", hash);
-    fetch_block_inner(chain, hash.to_string()).await
+    fetch_compact_block_inner(chain, hash.to_string()).await
+}
+
+#[allow(dead_code)]
+async fn fetch_full_block_inner(
+    chain: &FetchServiceSubscriber,
+    hash_or_height: String,
+) -> Result<Block, SyncError> {
+    match chain.z_get_block(hash_or_height, Some(0)).await? {
+        GetBlock::Raw(bytes) => {
+            let block = Block::zcash_deserialize(&bytes.as_ref()[..])
+                .map_err(|e| SyncError::from(FetchServiceError::SerializationError(e)))?;
+            Ok(block)
+        }
+        GetBlock::Object { .. } => unreachable!("We requested verbosity 0"),
+    }
 }
 
 // TODO: Switch to fetching full blocks.
-async fn fetch_block_inner(
+async fn fetch_compact_block_inner(
     chain: &FetchServiceSubscriber,
     hash_or_height: String,
 ) -> Result<CompactBlock, SyncError> {
-    let compact_block = chain.block_cache.get_compact_block(hash_or_height).await?;
+    let hash_or_height: HashOrHeight = hash_or_height
+        .parse()
+        .map_err(|e| SyncError::from(FetchServiceError::SerializationError(e)))?;
+
+    let block_id = match hash_or_height {
+        HashOrHeight::Hash(hash) => zaino_proto::proto::service::BlockId {
+            height: 0,
+            hash: hash.0.to_vec(),
+        },
+        HashOrHeight::Height(height) => zaino_proto::proto::service::BlockId {
+            height: height.0 as u64,
+            hash: Vec::new(),
+        },
+    };
+
+    let compact_block = chain.get_block(block_id).await?;
 
     Ok(CompactBlock {
         proto_version: compact_block.proto_version,
@@ -245,43 +311,66 @@ pub(super) async fn fetch_chain_state(
     chain: &FetchServiceSubscriber,
     height: BlockHeight,
 ) -> Result<ChainState, SyncError> {
-    let tree_state = chain.fetcher.get_treestate(height.to_string()).await?;
+    let (hash, height, _time, sapling, orchard) = chain
+        .z_get_treestate(height.to_string())
+        .await?
+        .into_parts();
 
     Ok(ChainState::new(
         BlockHeight::from_u32(
-            tree_state
-                .height
+            height
+                .0
                 .try_into()
                 .expect("blocks in main chain never have height -1"),
         ),
         {
             let mut block_hash = [0; 32];
-            hex::decode_to_slice(&tree_state.hash, &mut block_hash).map_err(|e| {
-                JsonRpcConnectorError::JsonRpcClientError(format!("Invalid block hash: {}", e))
+            hex::decode_to_slice(&hash.0, &mut block_hash).map_err(|e| {
+                FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::JsonRpcClientError(
+                    format!("Invalid block hash: {}", e),
+                ))
             })?;
             BlockHash(block_hash)
         },
-        read_frontier_v0(
-            hex::decode(tree_state.sapling.inner().inner())
+        {
+            read_frontier_v0(
+                hex::decode(sapling.ok_or_else(|| {
+                    FetchServiceError::JsonRpcConnectorError(
+                        JsonRpcConnectorError::JsonRpcClientError(
+                            "Missing sapling tree state".into(),
+                        ),
+                    )
+                })?)
                 .map_err(|e| {
-                    JsonRpcConnectorError::JsonRpcClientError(format!(
-                        "Invalid Sapling tree state: {}",
-                        e
+                    FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::IoError(
+                        std::io::Error::new(std::io::ErrorKind::Other, e),
                     ))
                 })?
                 .as_slice(),
-        )
-        .map_err(JsonRpcConnectorError::IoError)?,
-        read_frontier_v0(
-            hex::decode(tree_state.orchard.inner().inner())
+            )
+            .map_err(|e| {
+                FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::IoError(e))
+            })?
+        },
+        {
+            read_frontier_v0(
+                hex::decode(orchard.ok_or_else(|| {
+                    FetchServiceError::JsonRpcConnectorError(
+                        JsonRpcConnectorError::JsonRpcClientError(
+                            "Missing orchard tree state".into(),
+                        ),
+                    )
+                })?)
                 .map_err(|e| {
-                    JsonRpcConnectorError::JsonRpcClientError(format!(
-                        "Invalid Orchard tree state: {}",
-                        e
+                    FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::IoError(
+                        std::io::Error::new(std::io::ErrorKind::Other, e),
                     ))
                 })?
                 .as_slice(),
-        )
-        .map_err(JsonRpcConnectorError::IoError)?,
+            )
+            .map_err(|e| {
+                FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::IoError(e))
+            })?
+        },
     ))
 }

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -230,7 +230,7 @@ async fn fetch_full_block_inner(
 ) -> Result<Block, SyncError> {
     match chain.z_get_block(hash_or_height, Some(0)).await? {
         GetBlock::Raw(bytes) => {
-            let block = Block::zcash_deserialize(&bytes.as_ref()[..])
+            let block = Block::zcash_deserialize(bytes.as_ref())
                 .map_err(|e| SyncError::from(FetchServiceError::SerializationError(e)))?;
             Ok(block)
         }
@@ -317,15 +317,10 @@ pub(super) async fn fetch_chain_state(
         .into_parts();
 
     Ok(ChainState::new(
-        BlockHeight::from_u32(
-            height
-                .0
-                .try_into()
-                .expect("blocks in main chain never have height -1"),
-        ),
+        BlockHeight::from_u32(height.0),
         {
             let mut block_hash = [0; 32];
-            hex::decode_to_slice(&hash.0, &mut block_hash).map_err(|e| {
+            hex::decode_to_slice(hash.0, &mut block_hash).map_err(|e| {
                 FetchServiceError::JsonRpcConnectorError(JsonRpcConnectorError::JsonRpcClientError(
                     format!("Invalid block hash: {}", e),
                 ))


### PR DESCRIPTION
Updates code to use the `ZcashIndexer` and `LightwalletIndexer` traits from Zaino-State rather than the internal functionality of the `FetchService`.