### PR TITLE
Fix clippy lints

### DIFF
--- a/zallet/src/components/json_rpc/asyncop.rs
+++ b/zallet/src/components/json_rpc/asyncop.rs
@@ -61,6 +61,7 @@ pub(super) struct AsyncOperation {
 
 impl AsyncOperation {
     /// Launches a new async operation.
+    #[allow(unused)]
     pub(super) async fn new<T: Serialize + Send + 'static>(
         f: impl Future<Output = RpcResult<T>> + Send + 'static,
     ) -> Self {

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -216,6 +216,7 @@ impl RpcImpl {
             .map_err(|_| jsonrpsee::types::ErrorCode::InternalError.into())
     }
 
+    #[allow(unused)]
     async fn start_async<T: Serialize + Send + 'static>(
         &self,
         f: impl Future<Output = RpcResult<T>> + Send + 'static,

--- a/zallet/src/components/keystore.rs
+++ b/zallet/src/components/keystore.rs
@@ -497,6 +497,7 @@ impl KeyStore {
         Ok(seed_fp)
     }
 
+    #[allow(unused)]
     pub(crate) async fn encrypt_and_store_legacy_seed(
         &self,
         legacy_seed: &SecretVec<u8>,
@@ -586,6 +587,7 @@ fn encrypt_string(
     Ok(ciphertext)
 }
 
+#[allow(unused)]
 fn encrypt_legacy_seed_bytes(
     recipients: &[Box<dyn age::Recipient + Send>],
     seed: &SecretVec<u8>,


### PR DESCRIPTION
To prevent introducing more Clippy warnings, we can get the Clippy workflow passing. If that’s not the best approach, I can alternatively remove the unused functions or tackle the warnings in another way, let me know.