### PR TITLE
Allow `nuparams` to be added to the config

### DIFF
--- a/zallet/src/commands/migrate_zcash_conf.rs
+++ b/zallet/src/commands/migrate_zcash_conf.rs
@@ -507,7 +507,7 @@ fn build_actions() -> HashMap<&'static str, Action> {
         .chain(Action::map_multi(
             "nuparams",
             |config| &mut config.regtest_nuparams,
-            |value| RegTestNuParam::try_from(value).map_err(|_| ()),
+            |value| RegTestNuParam::try_from(value.to_string()).map_err(|_| ()),
         ))
         .chain(Action::map_related(
             "regtest",

--- a/zallet/src/network.rs
+++ b/zallet/src/network.rs
@@ -90,17 +90,17 @@ impl consensus::Parameters for Network {
 
 /// A parameter for regtest mode.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(try_from = "&str")]
+#[serde(try_from = "String")]
 #[serde(into = "String")]
 pub struct RegTestNuParam {
     consensus_branch_id: consensus::BranchId,
     activation_height: BlockHeight,
 }
 
-impl TryFrom<&str> for RegTestNuParam {
+impl TryFrom<String> for RegTestNuParam {
     type Error = &'static str;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, Self::Error> {
         let (branch_id, height) = value.split_once(':').ok_or("Invalid `regtest_nuparam`")?;
 
         let consensus_branch_id = u32::from_str_radix(branch_id, 16)


### PR DESCRIPTION
I am unsure if TOML support `&str` values directly, so this PR switches to using `String`. With that in place, you can now write, for example:

```
regtest_nuparams = [
  "5ba81b19:1",
  "76b809bb:10",
  "2bb40e60:15",
  "f5b9230b:20",
  "e9ff75a6:25",
  "c2d6d0b4:30",
  "c8e71055:35",
]
```

Closes https://github.com/zcash/wallet/issues/115