### PR TITLE
rpc: Add OpenRPC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,6 +4249,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "schemerz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,6 +4398,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6150,6 +6191,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "sapling-crypto",
+ "schemars",
  "schemerz",
  "schemerz-rusqlite",
  "secrecy 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ rpassword = "7"
 http-body-util = "0.1"
 hyper = "1"
 jsonrpsee = "0.24"
+schemars = "0.8"
 tower = "0.4"
 
 # Zcash consensus

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -422,6 +422,10 @@ criteria = "safe-to-deploy"
 version = "1.0.5"
 criteria = "safe-to-run"
 
+[[exemptions.dyn-clone]]
+version = "1.0.19"
+criteria = "safe-to-deploy"
+
 [[exemptions.ed25519]]
 version = "2.2.1"
 criteria = "safe-to-deploy"
@@ -1234,6 +1238,14 @@ criteria = "safe-to-deploy"
 version = "1.0.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.schemars]]
+version = "0.8.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.schemars_derive]]
+version = "0.8.22"
+criteria = "safe-to-deploy"
+
 [[exemptions.schemerz]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
@@ -1276,6 +1288,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde-big-array]]
 version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_derive_internals]]
+version = "0.29.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -100,6 +100,7 @@ rpassword.workspace = true
 rusqlite.workspace = true
 rust-embed.workspace = true
 sapling.workspace = true
+schemars.workspace = true
 schemerz.workspace = true
 schemerz-rusqlite.workspace = true
 secrecy.workspace = true

--- a/zallet/src/components/json_rpc/asyncop.rs
+++ b/zallet/src/components/json_rpc/asyncop.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
+use jsonrpsee::core::RpcResult;
 use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::RwLock;
@@ -139,7 +139,15 @@ impl AsyncOperation {
 
         let (error, result, execution_secs) = match &data.result {
             None => (None, None, None),
-            Some(Err(e)) => (Some(e.clone()), None, None),
+            Some(Err(e)) => (
+                Some(OperationError {
+                    code: e.code(),
+                    message: e.message().to_string(),
+                    data: e.data().map(|data| data.get().to_string()),
+                }),
+                None,
+                None,
+            ),
             Some(Ok(v)) => (
                 None,
                 Some(v.clone()),
@@ -174,7 +182,7 @@ pub(crate) struct OperationStatus {
     creation_time: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<ErrorObjectOwned>,
+    error: Option<OperationError>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<Value>,
@@ -182,4 +190,17 @@ pub(crate) struct OperationStatus {
     /// Execution time for successful operations.
     #[serde(skip_serializing_if = "Option::is_none")]
     execution_secs: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OperationError {
+    /// Code
+    code: i32,
+
+    /// Message
+    message: String,
+
+    /// Optional data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<String>,
 }

--- a/zallet/src/components/json_rpc/asyncop.rs
+++ b/zallet/src/components/json_rpc/asyncop.rs
@@ -3,13 +3,14 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
 /// The possible states that an async operation can be in.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(into = "&'static str")]
 pub(super) enum OperationState {
     Ready,
@@ -172,7 +173,7 @@ impl AsyncOperation {
 }
 
 /// The status of an async operation.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 pub(crate) struct OperationStatus {
     id: String,
 
@@ -192,7 +193,7 @@ pub(crate) struct OperationStatus {
     execution_secs: Option<u64>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 struct OperationError {
     /// Code
     code: i32,

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -37,7 +37,7 @@ pub(crate) trait Rpc {
     /// # Arguments
     /// - `command` (string, optional) The command to get help on.
     #[method(name = "help")]
-    fn help(&self, command: Option<&str>) -> String;
+    fn help(&self, command: Option<&str>) -> help::Response;
 
     /// Returns the list of operation ids currently known to the wallet.
     ///
@@ -269,7 +269,7 @@ impl RpcImpl {
 
 #[async_trait]
 impl RpcServer for RpcImpl {
-    fn help(&self, command: Option<&str>) -> String {
+    fn help(&self, command: Option<&str>) -> help::Response {
         help::call(command)
     }
 

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -27,6 +27,7 @@ mod list_operation_ids;
 mod list_unified_receivers;
 mod list_unspent;
 mod lock_wallet;
+mod openrpc;
 mod recover_accounts;
 mod unlock_wallet;
 
@@ -38,6 +39,10 @@ pub(crate) trait Rpc {
     /// - `command` (string, optional) The command to get help on.
     #[method(name = "help")]
     fn help(&self, command: Option<&str>) -> help::Response;
+
+    /// Returns an OpenRPC schema as a description of this service.
+    #[method(name = "rpc.discover")]
+    fn openrpc(&self) -> openrpc::Response;
 
     /// Returns the list of operation ids currently known to the wallet.
     ///
@@ -73,6 +78,7 @@ pub(crate) trait Rpc {
     #[method(name = "z_getoperationresult")]
     async fn get_operation_result(&self, operationid: Vec<&str>) -> get_operation::Response;
 
+    /// Returns wallet state information.
     #[method(name = "getwalletinfo")]
     async fn get_wallet_info(&self) -> get_wallet_info::Response;
 
@@ -271,6 +277,10 @@ impl RpcImpl {
 impl RpcServer for RpcImpl {
     fn help(&self, command: Option<&str>) -> help::Response {
         help::call(command)
+    }
+
+    fn openrpc(&self) -> openrpc::Response {
+        openrpc::call()
     }
 
     async fn list_operation_ids(&self, status: Option<&str>) -> list_operation_ids::Response {

--- a/zallet/src/components/json_rpc/methods/get_address_for_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_address_for_account.rs
@@ -19,7 +19,8 @@ use crate::components::{
 };
 
 /// Response to a `z_getaddressforaccount` RPC request.
-pub(crate) type Response = RpcResult<Address>;
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = Address;
 
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct Address {

--- a/zallet/src/components/json_rpc/methods/get_address_for_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_address_for_account.rs
@@ -1,7 +1,9 @@
+use documented::Documented;
 use jsonrpsee::{
     core::{JsonValue, RpcResult},
     types::{ErrorCode as RpcErrorCode, ErrorObjectOwned},
 };
+use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_address::unified;
 use zcash_client_backend::{
@@ -22,7 +24,8 @@ use crate::components::{
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = Address;
 
-#[derive(Clone, Debug, Serialize)]
+/// Information about a derived Unified Address.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct Address {
     /// The account's UUID within this Zallet instance.
     account_uuid: String,
@@ -39,6 +42,27 @@ pub(crate) struct Address {
 
     /// The unified address corresponding to the diversifier.
     address: String,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![
+        g.param::<JsonValue>(
+            "account",
+            "Either the UUID or ZIP 32 account index of the account to derive from.",
+            true,
+        ),
+        g.param::<Vec<String>>(
+            "receiver_types",
+            "Receiver types to include in the derived address.",
+            false,
+        ),
+        g.param::<u128>(
+            "diversifier_index",
+            "A specific diversifier index to derive at.",
+            false,
+        ),
+    ]
 }
 
 pub(crate) fn call(

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::{core::RpcResult, types::ErrorCode as RpcErrorCode};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use zaino_state::fetch::FetchServiceSubscriber;
 use zcash_client_backend::{
     data_api::{AccountBirthday, WalletRead, WalletWrite},
@@ -18,7 +18,7 @@ use crate::components::{
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = Account;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct Account {
     /// The new account's UUID within this Zallet instance.
     account_uuid: String,

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -15,7 +15,8 @@ use crate::components::{
 };
 
 /// Response to a `z_getnewaccount` RPC request.
-pub(crate) type Response = RpcResult<Account>;
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = Account;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct Account {

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -1,4 +1,6 @@
+use documented::Documented;
 use jsonrpsee::{core::RpcResult, types::ErrorCode as RpcErrorCode};
+use schemars::JsonSchema;
 use serde::Serialize;
 use zaino_state::fetch::FetchServiceSubscriber;
 use zcash_client_backend::{
@@ -18,7 +20,8 @@ use crate::components::{
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = Account;
 
-#[derive(Clone, Debug, Serialize)]
+/// Information about the new account.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct Account {
     /// The new account's UUID within this Zallet instance.
     account_uuid: String,
@@ -26,6 +29,14 @@ pub(crate) struct Account {
     /// The new account's ZIP 32 account index.
     #[serde(skip_serializing_if = "Option::is_none")]
     account: Option<u64>,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![
+        g.param::<&str>("account_name", "A human-readable name for the account.", true),
+        g.param::<&str>("seedfp", "ZIP 32 seed fingerprint for the BIP 39 mnemonic phrase from which to derive the account.", false),
+    ]
 }
 
 pub(crate) async fn call(

--- a/zallet/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet/src/components/json_rpc/methods/get_notes_count.rs
@@ -1,4 +1,6 @@
+use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_client_backend::data_api::{InputSource, NoteFilter, WalletRead};
 use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
@@ -9,7 +11,8 @@ use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = GetNotesCount;
 
-#[derive(Clone, Debug, Serialize)]
+/// The number of notes in the wallet.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct GetNotesCount {
     /// The number of Sprout notes in the wallet.
     ///
@@ -21,6 +24,14 @@ pub(crate) struct GetNotesCount {
 
     /// The number of Orchard notes in the wallet.
     orchard: u32,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![
+        g.param::<u32>("minconf", "Only include notes in transactions confirmed at least this many times.", false),
+        g.param::<i32>("as_of_height", "Execute the query as if it were run when the blockchain was at the height specified by this argument.", false),
+    ]
 }
 
 pub(crate) fn call(

--- a/zallet/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet/src/components/json_rpc/methods/get_notes_count.rs
@@ -6,7 +6,8 @@ use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 
 /// Response to a `z_getnotescount` RPC request.
-pub(crate) type Response = RpcResult<GetNotesCount>;
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = GetNotesCount;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct GetNotesCount {

--- a/zallet/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet/src/components/json_rpc/methods/get_notes_count.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::core::RpcResult;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use zcash_client_backend::data_api::{InputSource, NoteFilter, WalletRead};
 use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
 
@@ -9,7 +9,7 @@ use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = GetNotesCount;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct GetNotesCount {
     /// The number of Sprout notes in the wallet.
     ///

--- a/zallet/src/components/json_rpc/methods/get_operation.rs
+++ b/zallet/src/components/json_rpc/methods/get_operation.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
+use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::components::json_rpc::asyncop::{AsyncOperation, OperationState, OperationStatus};
@@ -8,9 +10,19 @@ use crate::components::json_rpc::asyncop::{AsyncOperation, OperationState, Opera
 /// Response to a `z_getoperationstatus` or `z_getoperationresult` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// The relevant operations.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<OperationStatus>);
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![g.param::<Vec<&str>>(
+        "operationid",
+        "A list of operation ids we are interested in.",
+        false,
+    )]
+}
 
 pub(crate) async fn status(async_ops: &[AsyncOperation], operationid: Vec<&str>) -> Response {
     let filter = operationid.into_iter().collect::<HashSet<_>>();

--- a/zallet/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_info.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::components::keystore::KeyStore;
 
 /// Response to a `getwalletinfo` RPC request.
-pub(crate) type Response = RpcResult<GetWalletInfo>;
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = GetWalletInfo;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct GetWalletInfo {

--- a/zallet/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_info.rs
@@ -1,7 +1,7 @@
 use std::time::UNIX_EPOCH;
 
 use jsonrpsee::{core::RpcResult, tracing::warn};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::components::keystore::KeyStore;
 
@@ -9,7 +9,7 @@ use crate::components::keystore::KeyStore;
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = GetWalletInfo;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct GetWalletInfo {
     /// The wallet version, in its "Bitcoin client version" form.
     walletversion: u64,

--- a/zallet/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_info.rs
@@ -1,6 +1,8 @@
 use std::time::UNIX_EPOCH;
 
+use documented::Documented;
 use jsonrpsee::{core::RpcResult, tracing::warn};
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::components::keystore::KeyStore;
@@ -9,7 +11,8 @@ use crate::components::keystore::KeyStore;
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = GetWalletInfo;
 
-#[derive(Clone, Debug, Serialize)]
+/// The wallet state information.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct GetWalletInfo {
     /// The wallet version, in its "Bitcoin client version" form.
     walletversion: u64,
@@ -50,6 +53,11 @@ pub(crate) struct GetWalletInfo {
 
     /// The BLAKE2b-256 hash of the HD seed derived from the wallet's emergency recovery phrase.
     mnemonic_seedfp: String,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(_: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![]
 }
 
 pub(crate) async fn call(keystore: &KeyStore) -> Response {

--- a/zallet/src/components/json_rpc/methods/help.rs
+++ b/zallet/src/components/json_rpc/methods/help.rs
@@ -1,8 +1,18 @@
+use jsonrpsee::core::RpcResult;
+use serde::Serialize;
+
 // See `generate_rpc_help()` in `build.rs` for how this is generated.
 include!(concat!(env!("OUT_DIR"), "/rpc_help.rs"));
 
-pub(crate) fn call(command: Option<&str>) -> String {
-    if let Some(command) = command {
+/// Response to a `help` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(String);
+
+pub(crate) fn call(command: Option<&str>) -> Response {
+    Ok(ResultType(if let Some(command) = command {
         match COMMANDS.get(command) {
             None => format!("help: unknown command: {command}\n"),
             Some(help_text) => format!("{command}\n\n{help_text}"),
@@ -17,5 +27,5 @@ pub(crate) fn call(command: Option<&str>) -> String {
             ret.push('\n');
         }
         ret
-    }
+    }))
 }

--- a/zallet/src/components/json_rpc/methods/list_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/list_accounts.rs
@@ -1,4 +1,6 @@
+use documented::Documented;
 use jsonrpsee::{core::RpcResult, types::ErrorCode as RpcErrorCode};
+use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_client_backend::{
     data_api::{Account as _, WalletRead},
@@ -10,11 +12,12 @@ use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 /// Response to a `z_listaccounts` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// A list of accounts.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<Account>);
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 pub(crate) struct Account {
     /// The account's UUID within this Zallet instance.
     account_uuid: String,
@@ -26,13 +29,18 @@ pub(crate) struct Account {
     addresses: Vec<Address>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 struct Address {
     /// A diversifier index used in the account.
     diversifier_index: u128,
 
     /// The unified address corresponding to the diversifier.
     ua: String,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(_: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![]
 }
 
 pub(crate) fn call(wallet: &DbConnection) -> Response {

--- a/zallet/src/components/json_rpc/methods/list_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/list_accounts.rs
@@ -8,7 +8,11 @@ use zcash_client_backend::{
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 
 /// Response to a `z_listaccounts` RPC request.
-pub(crate) type Response = RpcResult<Vec<Account>>;
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(Vec<Account>);
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct Account {
@@ -68,5 +72,5 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
         });
     }
 
-    Ok(accounts)
+    Ok(ResultType(accounts))
 }

--- a/zallet/src/components/json_rpc/methods/list_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/list_accounts.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::{core::RpcResult, types::ErrorCode as RpcErrorCode};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use zcash_client_backend::{
     data_api::{Account as _, WalletRead},
     keys::UnifiedAddressRequest,
@@ -14,7 +14,7 @@ pub(crate) type Response = RpcResult<ResultType>;
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<Account>);
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct Account {
     /// The account's UUID within this Zallet instance.
     account_uuid: String,
@@ -26,7 +26,7 @@ pub(crate) struct Account {
     addresses: Vec<Address>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct Address {
     /// A diversifier index used in the account.
     diversifier_index: u128,

--- a/zallet/src/components/json_rpc/methods/list_addresses.rs
+++ b/zallet/src/components/json_rpc/methods/list_addresses.rs
@@ -17,7 +17,11 @@ use zip32::fingerprint::SeedFingerprint;
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 
 /// Response to a `listaddresses` RPC request.
-pub(crate) type Response = RpcResult<Vec<AddressSource>>;
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(Vec<AddressSource>);
 
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct AddressSource {
@@ -271,11 +275,13 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
         }
     }
 
-    Ok([
-        imported_watchonly.has_data().then_some(imported_watchonly),
-        mnemonic_seed.has_data().then_some(mnemonic_seed),
-    ]
-    .into_iter()
-    .flatten()
-    .collect())
+    Ok(ResultType(
+        [
+            imported_watchonly.has_data().then_some(imported_watchonly),
+            mnemonic_seed.has_data().then_some(mnemonic_seed),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+    ))
 }

--- a/zallet/src/components/json_rpc/methods/list_addresses.rs
+++ b/zallet/src/components/json_rpc/methods/list_addresses.rs
@@ -1,8 +1,10 @@
+use documented::Documented;
 use jsonrpsee::{
     core::RpcResult,
     tracing::{error, warn},
     types::ErrorCode as RpcErrorCode,
 };
+use schemars::JsonSchema;
 use serde::Serialize;
 use transparent::keys::TransparentKeyScope;
 use zcash_address::unified;
@@ -19,11 +21,12 @@ use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 /// Response to a `listaddresses` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// A list of address sources.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<AddressSource>);
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 pub(crate) struct AddressSource {
     source: &'static str,
 
@@ -67,7 +70,7 @@ impl AddressSource {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 struct TransparentAddresses {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     addresses: Vec<String>,
@@ -77,7 +80,7 @@ struct TransparentAddresses {
     change_addresses: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 struct DerivedTransparentAddresses {
     seedfp: String,
 
@@ -96,7 +99,7 @@ struct DerivedTransparentAddresses {
     ephemeral_addresses: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 struct SaplingAddresses {
     #[serde(rename = "zip32KeyPath")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -105,7 +108,7 @@ struct SaplingAddresses {
     addresses: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 struct UnifiedAddresses {
     #[serde(skip_serializing_if = "Option::is_none")]
     seedfp: Option<String>,
@@ -117,7 +120,7 @@ struct UnifiedAddresses {
     addresses: Vec<UnifiedAddress>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 pub(crate) struct UnifiedAddress {
     /// The diversifier index that the UA was derived at.
     diversifier_index: u128,
@@ -127,6 +130,11 @@ pub(crate) struct UnifiedAddress {
 
     /// The unified address corresponding to the diversifier.
     address: String,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(_: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![]
 }
 
 pub(crate) fn call(wallet: &DbConnection) -> Response {

--- a/zallet/src/components/json_rpc/methods/list_operation_ids.rs
+++ b/zallet/src/components/json_rpc/methods/list_operation_ids.rs
@@ -1,9 +1,14 @@
 use jsonrpsee::core::RpcResult;
+use serde::Serialize;
 
 use crate::components::json_rpc::asyncop::{AsyncOperation, OperationState};
 
 /// Response to a `z_listoperationids` RPC request.
-pub(crate) type Response = RpcResult<Vec<String>>;
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(Vec<String>);
 
 pub(crate) async fn call(async_ops: &[AsyncOperation], status: Option<&str>) -> Response {
     // - The outer `Option` indicates whether or not we are filtering.
@@ -25,5 +30,5 @@ pub(crate) async fn call(async_ops: &[AsyncOperation], status: Option<&str>) -> 
         }
     }
 
-    Ok(operation_ids)
+    Ok(ResultType(operation_ids))
 }

--- a/zallet/src/components/json_rpc/methods/list_operation_ids.rs
+++ b/zallet/src/components/json_rpc/methods/list_operation_ids.rs
@@ -1,4 +1,6 @@
+use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::components::json_rpc::asyncop::{AsyncOperation, OperationState};
@@ -6,9 +8,19 @@ use crate::components::json_rpc::asyncop::{AsyncOperation, OperationState};
 /// Response to a `z_listoperationids` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// A list of operation IDs.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<String>);
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![g.param::<&str>(
+        "status",
+        "Filter result by the operation's state e.g. \"success\".",
+        false,
+    )]
+}
 
 pub(crate) async fn call(async_ops: &[AsyncOperation], status: Option<&str>) -> Response {
     // - The outer `Option` indicates whether or not we are filtering.

--- a/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
+++ b/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
@@ -2,7 +2,8 @@ use jsonrpsee::{core::RpcResult, tracing::warn, types::ErrorCode};
 use serde::{Deserialize, Serialize};
 
 /// Response to a `z_listunifiedreceivers` RPC request.
-pub(crate) type Response = RpcResult<ListUnifiedReceivers>;
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = ListUnifiedReceivers;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct ListUnifiedReceivers {

--- a/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
+++ b/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
@@ -1,11 +1,11 @@
 use jsonrpsee::{core::RpcResult, tracing::warn, types::ErrorCode};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Response to a `z_listunifiedreceivers` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = ListUnifiedReceivers;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct ListUnifiedReceivers {
     /// The legacy P2PKH transparent address.
     ///

--- a/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
+++ b/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
@@ -1,11 +1,14 @@
+use documented::Documented;
 use jsonrpsee::{core::RpcResult, tracing::warn, types::ErrorCode};
+use schemars::JsonSchema;
 use serde::Serialize;
 
 /// Response to a `z_listunifiedreceivers` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = ListUnifiedReceivers;
 
-#[derive(Clone, Debug, Serialize)]
+/// The receivers within a unified address.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct ListUnifiedReceivers {
     /// The legacy P2PKH transparent address.
     ///
@@ -26,6 +29,11 @@ pub(crate) struct ListUnifiedReceivers {
     /// A single-receiver Unified Address containing the Orchard receiver.
     #[serde(skip_serializing_if = "Option::is_none")]
     orchard: Option<String>,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![g.param::<&str>("unified_address", "The unified address to inspect.", true)]
 }
 
 pub(crate) fn call(unified_address: &str) -> Response {

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -24,7 +24,11 @@ use crate::components::{
 };
 
 /// Response to a `z_listunspent` RPC request.
-pub(crate) type Response = RpcResult<Vec<UnspentNote>>;
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(Vec<UnspentNote>);
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct UnspentNote {
@@ -84,7 +88,7 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
         )
     })? {
         Some(block) => block.block_height(),
-        None => return Ok(vec![]),
+        None => return Ok(ResultType(vec![])),
     };
 
     let mut unspent_notes = vec![];
@@ -275,5 +279,5 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
         }
     }
 
-    Ok(unspent_notes)
+    Ok(ResultType(unspent_notes))
 }

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -4,7 +4,7 @@ use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode as RpcErrorCode, ErrorObjectOwned as RpcError},
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{Account, AccountPurpose, InputSource, NullifierQuery, WalletRead},
@@ -30,7 +30,7 @@ pub(crate) type Response = RpcResult<ResultType>;
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<UnspentNote>);
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct UnspentNote {
     /// The transaction ID.
     txid: String,

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 
+use documented::Documented;
 use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode as RpcErrorCode, ErrorObjectOwned as RpcError},
 };
+use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_client_backend::{
     address::UnifiedAddress,
@@ -26,11 +28,12 @@ use crate::components::{
 /// Response to a `z_listunspent` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// A list of unspent notes.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(Vec<UnspentNote>);
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 pub(crate) struct UnspentNote {
     /// The transaction ID.
     txid: String,
@@ -75,6 +78,11 @@ pub(crate) struct UnspentNote {
     /// Omitted if the note is not spendable.
     #[serde(skip_serializing_if = "Option::is_none")]
     change: Option<bool>,
+}
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(_: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![]
 }
 
 pub(crate) fn call(wallet: &DbConnection) -> Response {

--- a/zallet/src/components/json_rpc/methods/lock_wallet.rs
+++ b/zallet/src/components/json_rpc/methods/lock_wallet.rs
@@ -1,9 +1,14 @@
 use jsonrpsee::core::RpcResult;
+use serde::Serialize;
 
 use crate::components::{json_rpc::server::LegacyCode, keystore::KeyStore};
 
 /// Response to a `walletlock` RPC request.
-pub(crate) type Response = RpcResult<()>;
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(());
 
 pub(crate) async fn call(keystore: &KeyStore) -> Response {
     if !keystore.uses_encrypted_identities() {
@@ -13,5 +18,5 @@ pub(crate) async fn call(keystore: &KeyStore) -> Response {
 
     keystore.lock().await;
 
-    Ok(())
+    Ok(ResultType(()))
 }

--- a/zallet/src/components/json_rpc/methods/lock_wallet.rs
+++ b/zallet/src/components/json_rpc/methods/lock_wallet.rs
@@ -1,4 +1,6 @@
+use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::components::{json_rpc::server::LegacyCode, keystore::KeyStore};
@@ -6,9 +8,15 @@ use crate::components::{json_rpc::server::LegacyCode, keystore::KeyStore};
 /// Response to a `walletlock` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// Empty result indicating success.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(());
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(_: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![]
+}
 
 pub(crate) async fn call(keystore: &KeyStore) -> Response {
     if !keystore.uses_encrypted_identities() {

--- a/zallet/src/components/json_rpc/methods/openrpc.rs
+++ b/zallet/src/components/json_rpc/methods/openrpc.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeMap;
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::{JsonSchema, SchemaGenerator, r#gen::SchemaSettings, schema::Schema};
+use serde::Serialize;
+
+// See `generate_rpc_help()` in `build.rs` for how this is generated.
+include!(concat!(env!("OUT_DIR"), "/rpc_openrpc.rs"));
+
+/// Response to an `rpc.discover` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = OpenRpc;
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(_: &mut Generator) -> Vec<ContentDescriptor> {
+    vec![]
+}
+
+pub(crate) fn call() -> Response {
+    let mut generator = Generator::new();
+
+    let methods = METHODS
+        .into_iter()
+        .map(|(name, method)| method.generate(&mut generator, name))
+        .collect();
+
+    Ok(OpenRpc {
+        openrpc: "1.3.2",
+        info: Info {
+            title: "Zallet",
+            description: env!("CARGO_PKG_DESCRIPTION"),
+            version: env!("CARGO_PKG_VERSION"),
+        },
+        methods,
+        components: generator.into_components(),
+    })
+}
+
+/// Static information about a Zallet JSON-RPC method.
+pub(super) struct RpcMethod {
+    pub(super) description: &'static str,
+    params: fn(&mut Generator) -> Vec<ContentDescriptor>,
+    result: fn(&mut Generator) -> ContentDescriptor,
+    deprecated: bool,
+}
+
+impl RpcMethod {
+    fn generate(&self, generator: &mut Generator, name: &'static str) -> Method {
+        let description = self.description.trim();
+
+        Method {
+            name,
+            summary: description
+                .split_once('\n')
+                .map(|(summary, _)| summary)
+                .unwrap_or(description),
+            description,
+            params: (self.params)(generator),
+            result: (self.result)(generator),
+            deprecated: self.deprecated,
+        }
+    }
+}
+
+/// An OpenRPC document generator.
+pub(super) struct Generator {
+    inner: SchemaGenerator,
+}
+
+impl Generator {
+    fn new() -> Self {
+        Self {
+            inner: SchemaSettings::draft07()
+                .with(|s| {
+                    s.definitions_path = "#/components/schemas/".into();
+                })
+                .into_generator(),
+        }
+    }
+
+    /// Constructs the descriptor for a JSON-RPC method parameter.
+    pub(super) fn param<T: JsonSchema>(
+        &mut self,
+        name: &'static str,
+        description: &'static str,
+        required: bool,
+    ) -> ContentDescriptor {
+        ContentDescriptor {
+            name,
+            summary: description
+                .split_once('\n')
+                .map(|(summary, _)| summary)
+                .unwrap_or(description),
+            description,
+            required,
+            schema: self.inner.subschema_for::<T>(),
+            deprecated: false,
+        }
+    }
+
+    /// Constructs the descriptor for a JSON-RPC method's result type.
+    pub(super) fn result<T: Documented + JsonSchema>(
+        &mut self,
+        name: &'static str,
+    ) -> ContentDescriptor {
+        ContentDescriptor {
+            name,
+            summary: T::DOCS
+                .split_once('\n')
+                .map(|(summary, _)| summary)
+                .unwrap_or(T::DOCS),
+            description: T::DOCS,
+            required: false,
+            schema: self.inner.subschema_for::<T>(),
+            deprecated: false,
+        }
+    }
+
+    fn into_components(mut self) -> Components {
+        Components {
+            schemas: self.inner.take_definitions(),
+        }
+    }
+}
+
+/// An OpenRPC document.
+#[derive(Clone, Debug, Serialize, Documented)]
+pub(crate) struct OpenRpc {
+    openrpc: &'static str,
+    info: Info,
+    methods: Vec<Method>,
+    components: Components,
+}
+
+impl JsonSchema for OpenRpc {
+    fn schema_name() -> String {
+        "OpenRPC Schema".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        Schema::new_ref(
+            "https://raw.githubusercontent.com/open-rpc/meta-schema/master/schema.json".into(),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Info {
+    title: &'static str,
+    description: &'static str,
+    version: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct Method {
+    name: &'static str,
+    summary: &'static str,
+    description: &'static str,
+    params: Vec<ContentDescriptor>,
+    result: ContentDescriptor,
+    #[serde(skip_serializing_if = "is_false")]
+    deprecated: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ContentDescriptor {
+    name: &'static str,
+    summary: &'static str,
+    description: &'static str,
+    #[serde(skip_serializing_if = "is_false")]
+    required: bool,
+    schema: Schema,
+    #[serde(skip_serializing_if = "is_false")]
+    deprecated: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Components {
+    schemas: BTreeMap<String, Schema>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
+}

--- a/zallet/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/recover_accounts.rs
@@ -20,7 +20,8 @@ use crate::components::{
 };
 
 /// Response to a `z_recoveraccounts` RPC request.
-pub(crate) type Response = RpcResult<Accounts>;
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = Accounts;
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct AccountParameter<'a> {

--- a/zallet/src/components/json_rpc/methods/unlock_wallet.rs
+++ b/zallet/src/components/json_rpc/methods/unlock_wallet.rs
@@ -1,10 +1,15 @@
 use age::secrecy::SecretString;
 use jsonrpsee::core::RpcResult;
+use serde::Serialize;
 
 use crate::components::{json_rpc::server::LegacyCode, keystore::KeyStore};
 
 /// Response to a `walletpassphrase` RPC request.
-pub(crate) type Response = RpcResult<()>;
+pub(crate) type Response = RpcResult<ResultType>;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ResultType(());
 
 pub(crate) async fn call(keystore: &KeyStore, passphrase: SecretString, timeout: u64) -> Response {
     if !keystore.uses_encrypted_identities() {
@@ -18,5 +23,5 @@ pub(crate) async fn call(keystore: &KeyStore, passphrase: SecretString, timeout:
             .with_static("Error: The wallet passphrase entered was incorrect."));
     }
 
-    Ok(())
+    Ok(ResultType(()))
 }

--- a/zallet/src/components/json_rpc/methods/unlock_wallet.rs
+++ b/zallet/src/components/json_rpc/methods/unlock_wallet.rs
@@ -1,5 +1,7 @@
 use age::secrecy::SecretString;
+use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::components::{json_rpc::server::LegacyCode, keystore::KeyStore};
@@ -7,9 +9,26 @@ use crate::components::{json_rpc::server::LegacyCode, keystore::KeyStore};
 /// Response to a `walletpassphrase` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 
-#[derive(Clone, Debug, Serialize)]
+/// Empty result indicating success.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 #[serde(transparent)]
 pub(crate) struct ResultType(());
+
+/// Defines the method parameters for OpenRPC.
+pub(super) fn params(g: &mut super::openrpc::Generator) -> Vec<super::openrpc::ContentDescriptor> {
+    vec![
+        g.param::<String>(
+            "passphrase",
+            "The passphrase for decrypting the wallet's age identity.",
+            true,
+        ),
+        g.param::<u64>(
+            "timeout",
+            "Time in seconds after which the wallet wil relock.",
+            true,
+        ),
+    ]
+}
 
 pub(crate) async fn call(keystore: &KeyStore, passphrase: SecretString, timeout: u64) -> Response {
     if !keystore.uses_encrypted_identities() {


### PR DESCRIPTION
This adds minimal boilerplate to the JSON-RPC method implementations (which were already pretty regular), to enable the OpenRPC document to be generated. The generator itself enforces correct addition of future RPC methods via the type system.

The only duplication of content is in the method parameters. I have ideas for how this could be reduced, but it will do for now.