### PR TITLE
[WIP] Docker Compose setup for local development

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  init-rage:
+    image: alpine:edge
+    entrypoint: ["sh", "-c"]
+    command: -c "
+      set -e
+      && apk update
+      && apk add --no-cache rage
+      && if [ ! -f /data/identity.txt ]; then
+        echo '[init] generating identity.txt with rage-keygen'
+        && rage-keygen -o /data/identity.txt;
+      else
+        echo '[init] identity.txt already exists, skipping.';
+      fi"
+    volumes:
+      - ./zallet_data:/datad
+
+  zallet:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: zallet
+    restart: unless-stopped
+    depends_on:
+      init-rage:
+        condition: service_completed_successfully
+    volumes:
+      - ./zallet_data:/data
+    entrypoint: ["/usr/local/bin/zallet"]
+    command: ["--config", "/data/zallet.toml"]


### PR DESCRIPTION
This work-in-progress PR adds a `docker-compose.yml` to support local development and testing of the Zallet project.

### What's Included

- **Zallet service built from local Dockerfile**
  - Uses the local `Dockerfile` to build the Zallet binary into a minimal image.
  - Mounts local configuration (`zallet.toml`) and wallet data.

- **Optional `init-rage` service for first-run identity setup**
  - Alpine-based one-shot container that installs `rage` and generates `identity.txt` if it doesn't exist.
  - Shared volume (`./zallet_data`) allows the result to persist across runs.
  - Can be run manually, or automatically if included in the Compose profile.

### Notes

- The `docker-compose.yml` is intended for **local use only** (not production).
- `init-rage` is **optional** and can be triggered manually via:
  ```bash
  docker compose run --rm init-rage
