### PR TITLE
feat(docker): Optimize build with cache mounts and `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Before the docker CLI sends the context to the docker daemon, it looks for a file
+# named .dockerignore in the root directory of the context. If this file exists, the
+# CLI modifies the context to exclude files and directories that match patterns in it.
+#
+# You may want to specify which files to include in the context, rather than which
+# to exclude. To achieve this, specify * as the first pattern, followed by one or
+# more ! exception patterns.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude everything:
+#
+*
+
+# Now un-exclude required files and folders:
+#
+!.cargo
+!*.toml
+!*.lock
+!zallet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # --- Stage 1: Build with Rust --- (amd64)
 FROM rust:1-slim@sha256:57d415bbd61ce11e2d5f73de068103c7bd9f3188dc132c97cef4a8f62989e944 AS builder
 
@@ -11,14 +12,25 @@ RUN apt-get update && \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-COPY . .
+COPY --link . .
 
-RUN cargo build --release && strip target/release/zallet
+# Build the zallet binary
+# Leverage a cache mount to ${CARGO_HOME} for downloaded dependencies,
+# and a cache mount to ${CARGO_TARGET_DIR} for compiled dependencies.
+RUN --mount=type=bind,source=zallet,target=zallet \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=cache,target=/app/.cargo \
+    --mount=type=cache,target=/app/target/ \
+    cargo build --locked --release --package zallet --bin zallet && \
+    cp /app/target/release/zallet /usr/local/bin/
+
 
 # --- Stage 2: Minimal runtime with distroless ---
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc AS runtime
 
-COPY --from=builder /app/target/release/zallet /usr/local/bin/zallet
+COPY --link --from=builder /usr/local/bin/zallet /usr/local/bin/
 
 USER nonroot
-ENTRYPOINT ["/usr/local/bin/zallet"]
+
+ENTRYPOINT [ "zallet" ]


### PR DESCRIPTION
This commit introduces some optimizations to the Docker build process:

1.  **Build Caching**:
    *   Leverages Docker BuildKit cache mounts for `cargo` dependencies (`/app/.cargo`) and compiled artifacts (`/app/target/`). This speeds up subsequent builds by reusing downloaded and compiled dependencies.
    *   Uses bind mounts for `zallet` source, `Cargo.toml`, and `Cargo.lock` to ensure the build step has access to the necessary files during the cached `RUN` instruction.
    *   The `--link` flag is now used with `COPY` for potentially faster copies when supported.

2.  **Optimized Build Command**:
    *   The `cargo build` command is now more explicit, specifying `--locked --package zallet --bin zallet`.
    *   The `strip` command has been removed to allow runtime debugging information.

3.  **Explicit Naming and Structure**:
    *   The runtime stage is now explicitly named `AS runtime`.
    *   The `ENTRYPOINT` now uses the simple binary name `zallet`, relying on it being in the `PATH`.

4.  **`.dockerignore` File**:
    *   A `.dockerignore` file has been added to control the build context sent to the Docker daemon.
    *   It follows an "exclude all, then include specific" pattern (`*` followed by `!pattern`) to ensure only necessary files (`.cargo`, `*.toml`, `*.lock`, and the `zallet` source directory) are included in the build context. This reduces the context size and can prevent unnecessary cache invalidations.
    

This is a subset of:
- #146