### PR TITLE
Explicitly depend on `tracing` with required feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6127,6 +6127,7 @@ dependencies = [
  "toml 0.8.20",
  "tonic 0.13.0",
  "tower 0.4.13",
+ "tracing",
  "trycmd",
  "uuid",
  "xdg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ i18n-embed = { version = "0.15", features = ["fluent-system"] }
 i18n-embed-fl = "0.9"
 rust-embed = "8"
 
+# Logging
+tracing = { version = "0.1", features = ["attributes"] }
+
 # Parsing and serialization
 hex = "0.4"
 serde = { version = "1", features = ["serde_derive"] }

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -113,6 +113,7 @@ tokio = { workspace = true, features = ["fs", "io-util", "rt-multi-thread"] }
 toml.workspace = true
 tonic.workspace = true
 tower = { workspace = true, features = ["timeout"] }
+tracing.workspace = true
 transparent.workspace = true
 uuid.workspace = true
 xdg.workspace = true


### PR DESCRIPTION
The `attributes` feature is ambiently enabled in our pinned MSRV dependencies, but something in a recent change to latest dependencies means that it is no longer ambiently enabled. We should always ensure that non-default feature flags we depend on are explicitly enabled.