### PR TITLE
Add a `stop` RPC method for regtest mode usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6280,6 +6280,7 @@ dependencies = [
  "incrementalmerkletree",
  "jsonrpsee",
  "known-folders",
+ "nix",
  "once_cell",
  "orchard",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ rpassword = "7"
 http-body-util = "0.1"
 hyper = "1"
 jsonrpsee = "0.24"
+nix = "0.29" # `stop` RPC method
 rust_decimal = { version = "1.37", default-features = false, features = [
     "serde-arbitrary-precision",
     "serde-float",

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -93,6 +93,7 @@ i18n-embed-fl.workspace = true
 incrementalmerkletree.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 known-folders.workspace = true
+nix = { workspace = true, features = ["signal"] }
 orchard.workspace = true
 phf.workspace = true
 rand.workspace = true

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -29,6 +29,7 @@ mod list_unspent;
 mod lock_wallet;
 mod openrpc;
 mod recover_accounts;
+mod stop;
 mod unlock_wallet;
 mod view_transaction;
 mod z_get_total_balance;
@@ -320,6 +321,15 @@ pub(crate) trait Rpc {
         fee: Option<JsonValue>,
         #[argument(rename = "privacyPolicy")] privacy_policy: Option<String>,
     ) -> z_send_many::Response;
+
+    /// Stop the running zallet process.
+    ///
+    /// # Notes
+    ///
+    /// - Works for non windows targets only.
+    /// - Works only if the network of the running zallet process is `Regtest`.
+    #[method(name = "stop")]
+    async fn stop(&self) -> stop::Response;
 }
 
 pub(crate) struct RpcImpl {
@@ -507,5 +517,9 @@ impl RpcServer for RpcImpl {
                 .await?,
             )
             .await)
+    }
+
+    async fn stop(&self) -> stop::Response {
+        stop::call(self.wallet().await?)
     }
 }

--- a/zallet/src/components/json_rpc/methods/stop.rs
+++ b/zallet/src/components/json_rpc/methods/stop.rs
@@ -1,0 +1,31 @@
+use documented::Documented;
+use jsonrpsee::{core::RpcResult, types::ErrorCode as RpcErrorCode};
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_protocol::consensus::{NetworkType, Parameters};
+
+use crate::components::database::DbHandle;
+
+/// Response to a `stop` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// The stop response.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+#[serde(transparent)]
+pub(crate) struct ResultType(());
+
+pub(crate) fn call(wallet: DbHandle) -> Response {
+    #[cfg(not(target_os = "windows"))]
+    match wallet.params().network_type() {
+        NetworkType::Regtest => match nix::sys::signal::raise(nix::sys::signal::SIGINT) {
+            Ok(_) => Ok(ResultType(())),
+            Err(_) => Err(RpcErrorCode::InternalError.into()),
+        },
+        _ => Err(RpcErrorCode::MethodNotFound.into()),
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = wallet;
+        Err(RpcErrorCode::MethodNotFound.into())
+    }
+}


### PR DESCRIPTION
Add a `stop` RPC method, intended for use in regtest mode. The implementation is based on the approach used in Zebra:

https://github.com/ZcashFoundation/zebra/blob/v2.3.0/zebra-rpc/src/methods.rs#L1570-L1595

In Zebra, shutting down cleanly is non-trivial. The signal method was the most consistent solution we found. While there might be a better approach, this solution is simple and effective for regtest scenarios.

Tested manually and confirmed working.

Closes https://github.com/zcash/wallet/issues/153