### PR TITLE
rpc: Fix `z_listunspent` memo output to not truncate null bytes

### DIFF
--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -165,7 +165,7 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
                 })?
                 .map(|memo| {
                     (
-                        hex::encode(memo.encode().as_slice()),
+                        hex::encode(memo.encode().as_array()),
                         match memo {
                             zcash_protocol::memo::Memo::Text(text_memo) => Some(text_memo.into()),
                             _ => None,


### PR DESCRIPTION
Null byte truncation only applies to text memos, per ZIP 302. The `zcashd` output does not truncate null bytes in the hex output.