### PR TITLE
Implement `z_listunifiedreceivers`

### DIFF
--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -227,8 +227,21 @@ pub(crate) trait Rpc {
         #[argument(rename = "includeWatchonly")] include_watch_only: Option<bool>,
     ) -> z_get_total_balance::Response;
 
+    /// Returns a record of the individual receivers contained within the provided UA,
+    /// keyed by receiver type. The UA may not have receivers for some receiver types,
+    /// in which case those keys will be absent.
+    ///
+    /// Transactions that send funds to any of the receivers returned by this RPC
+    /// method will be detected by the wallet as having been sent to the unified
+    /// address.
+    ///
+    /// # Arguments
+    /// - `unified_address` (string, required) The unified address to inspect.
     #[method(name = "z_listunifiedreceivers")]
-    fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response;
+    async fn list_unified_receivers(
+        &self,
+        unified_address: &str,
+    ) -> list_unified_receivers::Response;
 
     /// Returns detailed shielded information about in-wallet transaction `txid`.
     #[method(name = "z_viewtransaction")]
@@ -474,8 +487,11 @@ impl RpcServer for RpcImpl {
         z_get_total_balance::call(self.wallet().await?.as_ref(), minconf, include_watch_only)
     }
 
-    fn list_unified_receivers(&self, unified_address: &str) -> list_unified_receivers::Response {
-        list_unified_receivers::call(unified_address)
+    async fn list_unified_receivers(
+        &self,
+        unified_address: &str,
+    ) -> list_unified_receivers::Response {
+        list_unified_receivers::call(self.wallet().await?.as_ref(), unified_address)
     }
 
     async fn view_transaction(&self, txid: &str) -> view_transaction::Response {

--- a/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
+++ b/zallet/src/components/json_rpc/methods/list_unified_receivers.rs
@@ -1,7 +1,11 @@
 use documented::Documented;
-use jsonrpsee::{core::RpcResult, tracing::warn, types::ErrorCode};
+use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
+use transparent::address::TransparentAddress;
+use zcash_keys::{address::UnifiedAddress, encoding::AddressCodec};
+
+use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 
 /// Response to a `z_listunifiedreceivers` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -33,8 +37,29 @@ pub(crate) struct ListUnifiedReceivers {
 
 pub(super) const PARAM_UNIFIED_ADDRESS_DESC: &str = "The unified address to inspect.";
 
-pub(crate) fn call(unified_address: &str) -> Response {
-    warn!("TODO: Implement z_listunifiedreceivers({unified_address})");
+pub(crate) fn call(wallet: &DbConnection, unified_address: &str) -> Response {
+    let address = match UnifiedAddress::decode(wallet.params(), unified_address) {
+        Ok(addr) => addr,
+        Err(e) => return Err(LegacyCode::InvalidParameter.with_message(e.to_string())),
+    };
 
-    Err(ErrorCode::MethodNotFound.into())
+    let transparent = address.transparent().map(|taddr| match taddr {
+        TransparentAddress::PublicKeyHash(_) => (Some(taddr.encode(wallet.params())), None),
+        TransparentAddress::ScriptHash(_) => (None, Some(taddr.encode(wallet.params()))),
+    });
+
+    let (p2pkh, p2sh) = transparent.unwrap_or((None, None));
+
+    let sapling = address.sapling().map(|s| s.encode(wallet.params()));
+
+    let orchard = address.orchard().and_then(|orch| {
+        UnifiedAddress::from_receivers(Some(*orch), None, None).map(|ua| ua.encode(wallet.params()))
+    });
+
+    Ok(ListUnifiedReceivers {
+        p2pkh,
+        p2sh,
+        sapling,
+        orchard,
+    })
 }


### PR DESCRIPTION
Closes https://github.com/zcash/wallet/issues/85.

This PR adds support for the `z_listunifiedreceivers` RPC method, which returns a breakdown of the receivers encoded in a unified address.

##  Testing 

Rregtest mode via [Zebra Python QA framework](https://github.com/ZcashFoundation/zebra/blob/main/zebra-rpc/qa/README.md)

Create an account:
```
z_getnewaccount("test_account")
# → {'account_uuid': 'f723149f-e4b4-469c-b457-9d510f2843e4'}
```

Get a unified address for the account:
```
z_getaddressforaccount("f723149f-e4b4-469c-b457-9d510f2843e4")
# → uregtest1xd7f0r4jg4rzc32clcalhhf4fegk97a9g54mrty2nzzqwqncuamprp6t86mp303crdvcfc8e0yuswvvrnv70q85awvhfuw38t3x75a5spcxl4rl5sscvpqpjmqcw9la06ky56rwwpgkjxl8zy4cx9qa62e0llhrqpsct0vpylvvqkhrdjfe27nehqx6wmgjl3e85r0nzccy9w4ktylm
```

Call `z_listunifiedreceivers` on that address:
```
z_listunifiedreceivers("uregtest1xd7f0r4...w4ktylm")
# → {
#     'p2pkh': 'tmPrkro4zYKR65yg5jaPHjRpETGgPEZRhcB',
#     'sapling': 'zregtestsapling1ldevlnezjnafrr34kmucn507pf3yhjax34d8vygs5p0j827r9yfrrgvdky8nzy9ffjl4ufr8wtf',
#     'orchard': 'uregtest1jgmtay0s36sgea2rtq640a3p2w94jr2pn3ylle6y4nra4343c87gkw7z5kuadfxjg4mn4h4328tked64qf93uf80jsaea6gg4g2929cg'
# }
```
