### PR TITLE
Fix CI

### DIFF
--- a/zallet/src/components/keystore.rs
+++ b/zallet/src/components/keystore.rs
@@ -505,6 +505,7 @@ impl KeyStore {
         Ok(seed_fp)
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn encrypt_and_store_legacy_seed(
         &self,
         legacy_seed: &SecretVec<u8>,


### PR DESCRIPTION
I think it would be beneficial for external reviewers and contributors if the CI passed, even at the cost of temporarily reducing coverage. Coverage can be restored once the necessary conditions are met again. Right now, it’s difficult to tell whether a PR is introducing new lints, since the failing checks are effectively ignored.

- https://github.com/zcash/wallet/commit/1602d6cae38560e1ab351e27424e971c87365020 - Allowed dead code for a function. This function is actually used in https://github.com/zcash/wallet/pull/152, but that PR has been in draft for a long time and will need updates anyway. I’d prefer to remove the dead code annotation there instead.

- <strike> https://github.com/zcash/wallet/commit/3a6d0cb0bd2d487f2bd876c4241ba774a5caf157 - For the NU7 tests, Zebra currently doesn’t support them (see https://github.com/ZcashFoundation/zebra/blob/main/zebra-chain/src/parameters/network_upgrade.rs#L523). I think it would be better to restore these tests once we pin to the right revision, and remove them for now.</strike> Deferred to Zebra: https://github.com/ZcashFoundation/zebra/issues/9811