### PR TITLE
rpc (z_listunspent): Add transparent UTXOs to `z_listunspent` results.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "blake2b_simd",
  "core2 0.3.3",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6570,7 +6570,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.19.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.17.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "bip32",
  "bitflags 2.9.0",
@@ -6674,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "core2 0.3.3",
  "nonempty",
@@ -6683,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "core2 0.3.3",
  "document-features",
@@ -6836,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cb49e1b897f30adb7a672f37eaf170cab5c300d#7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8be259c579762f1b0f569453a20c0d0dbeae6c07#8be259c579762f1b0f569453a20c0d0dbeae6c07"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,17 +119,17 @@ tonic = "0.13"
 
 [patch.crates-io]
 age = { git = "https://github.com/str4d/rage.git", rev = "84dc1e9f641994388f107ceebdbaa00126e30e16" }
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "8be259c579762f1b0f569453a20c0d0dbeae6c07" }
 
 zaino-fetch = { git = "https://github.com/Electric-Coin-Company/zaino.git", rev = "1004733f3303b1c48b6df6db610c54401554683c" }
 zaino-proto = { git = "https://github.com/Electric-Coin-Company/zaino.git", rev = "1004733f3303b1c48b6df6db610c54401554683c" }

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -102,6 +102,9 @@ Changes to response:
     qualifies as change involves a bunch of annoying subtleties and the
     meaning of this field has varied between Sapling and Orchard.
   - A `walletInternal` field has been added.
+  - Transparent outputs are now included in the response array. The `pool`
+    field for such outputs is set to the string `"transparent"`.
+  - The `memo` field is now omitted for transparent outputs.
 
 ### `z_sendmany`
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -552,7 +552,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.2.2@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.2.2@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
@@ -560,7 +560,7 @@ version = "0.6.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.f4jumble]]
-version = "0.1.1@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.1.1@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.fallible-iterator]]
@@ -1784,43 +1784,43 @@ version = "0.1.2@git:1004733f3303b1c48b6df6db610c54401554683c"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_address]]
-version = "0.9.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.9.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_backend]]
-version = "0.19.1@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.19.1@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_sqlite]]
-version = "0.17.3@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.17.3@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
-version = "0.3.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.3.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_history]]
-version = "0.4.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.4.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_keys]]
-version = "0.10.1@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.10.1@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_primitives]]
-version = "0.24.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.24.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_proofs]]
-version = "0.24.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.24.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_protocol]]
-version = "0.6.1@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.6.1@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_transparent]]
-version = "0.4.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.4.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
@@ -1868,5 +1868,5 @@ version = "0.8.24"
 criteria = "safe-to-deploy"
 
 [[exemptions.zip321]]
-version = "0.5.0@git:7cb49e1b897f30adb7a672f37eaf170cab5c300d"
+version = "0.5.0@git:8be259c579762f1b0f569453a20c0d0dbeae6c07"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This builds atop #193