### PR TITLE
Switch to ECC fork of Zaino

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "zaino-fetch"
 version = "0.1.2"
-source = "git+https://github.com/zingolabs/zaino.git?rev=fc4a51118328045e7a337a6004698779ec872654#fc4a51118328045e7a337a6004698779ec872654"
+source = "git+https://github.com/Electric-Coin-Company/zaino.git?rev=1004733f3303b1c48b6df6db610c54401554683c#1004733f3303b1c48b6df6db610c54401554683c"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -6427,7 +6427,7 @@ dependencies = [
 [[package]]
 name = "zaino-proto"
 version = "0.1.2"
-source = "git+https://github.com/zingolabs/zaino.git?rev=fc4a51118328045e7a337a6004698779ec872654#fc4a51118328045e7a337a6004698779ec872654"
+source = "git+https://github.com/Electric-Coin-Company/zaino.git?rev=1004733f3303b1c48b6df6db610c54401554683c#1004733f3303b1c48b6df6db610c54401554683c"
 dependencies = [
  "prost",
  "tonic 0.12.3",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "zaino-state"
 version = "0.1.2"
-source = "git+https://github.com/zingolabs/zaino.git?rev=fc4a51118328045e7a337a6004698779ec872654#fc4a51118328045e7a337a6004698779ec872654"
+source = "git+https://github.com/Electric-Coin-Company/zaino.git?rev=1004733f3303b1c48b6df6db610c54401554683c#1004733f3303b1c48b6df6db610c54401554683c"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,8 @@ zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7
 zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "7cb49e1b897f30adb7a672f37eaf170cab5c300d" }
 
-zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "fc4a51118328045e7a337a6004698779ec872654" }
-zaino-proto = { git = "https://github.com/zingolabs/zaino.git", rev = "fc4a51118328045e7a337a6004698779ec872654" }
-zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "fc4a51118328045e7a337a6004698779ec872654" }
+zaino-fetch = { git = "https://github.com/Electric-Coin-Company/zaino.git", rev = "1004733f3303b1c48b6df6db610c54401554683c" }
+zaino-proto = { git = "https://github.com/Electric-Coin-Company/zaino.git", rev = "1004733f3303b1c48b6df6db610c54401554683c" }
+zaino-state = { git = "https://github.com/Electric-Coin-Company/zaino.git", rev = "1004733f3303b1c48b6df6db610c54401554683c" }
 
 zip32 = { git = "https://github.com/zcash/zip32.git", rev = "3fd1ab9e1cb943edde58579cd5c65095494810cb" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1772,15 +1772,15 @@ version = "2.5.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-fetch]]
-version = "0.1.2@git:fc4a51118328045e7a337a6004698779ec872654"
+version = "0.1.2@git:1004733f3303b1c48b6df6db610c54401554683c"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-proto]]
-version = "0.1.2@git:fc4a51118328045e7a337a6004698779ec872654"
+version = "0.1.2@git:1004733f3303b1c48b6df6db610c54401554683c"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-state]]
-version = "0.1.2@git:fc4a51118328045e7a337a6004698779ec872654"
+version = "0.1.2@git:1004733f3303b1c48b6df6db610c54401554683c"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_address]]


### PR DESCRIPTION
Includes a fix to a `zaino-state` bug that has completely blocked Zallet from working for several days (which we can't revert back from because the original update of Zaino was needed to fix a different bug). This allows Zallet to function while we wait on a full fix upstream.