### PR TITLE
Add / reference issues corresponding to TODOs in the code

### DIFF
--- a/zallet/src/commands.rs
+++ b/zallet/src/commands.rs
@@ -77,7 +77,8 @@ pub(crate) fn lock_datadir(datadir: &Path) -> Result<fmutex::Guard<'static>, Err
 /// Resolves the requested path relative to the Zallet data directory.
 pub(crate) fn resolve_datadir_path(datadir: &Path, path: &Path) -> PathBuf {
     // TODO: Do we canonicalize here? Where do we enforce any requirements on the
-    // config's relative paths?
+    //       config's relative paths?
+    //       https://github.com/zcash/wallet/issues/249
     datadir.join(path)
 }
 
@@ -85,7 +86,8 @@ impl EntryPoint {
     /// Returns the data directory to use for this Zallet command.
     fn datadir(&self) -> Result<PathBuf, FrameworkError> {
         // TODO: Decide whether to make either the default datadir, or every datadir,
-        // chain-specific.
+        //       chain-specific.
+        //       https://github.com/zcash/wallet/issues/250
         if let Some(datadir) = &self.datadir {
             Ok(datadir.clone())
         } else {

--- a/zallet/src/commands/init_wallet_encryption.rs
+++ b/zallet/src/commands/init_wallet_encryption.rs
@@ -17,7 +17,8 @@ impl AsyncRunnable for InitWalletEncryptionCmd {
         let keystore = KeyStore::new(&config, db)?;
 
         // TODO: The following logic does not support plugin recipients, which can only be
-        // derived from identities by the plugins themselves.
+        //       derived from identities by the plugins themselves.
+        //       https://github.com/zcash/wallet/issues/252
 
         // If we have encrypted identities, it means the operator configured Zallet with
         // an encrypted identity file; obtain the recipients from it.

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -46,6 +46,7 @@ pub(crate) async fn call(
 ) -> Response {
     ensure_wallet_is_unlocked(keystore).await?;
     // TODO: Ensure wallet is backed up.
+    //       https://github.com/zcash/wallet/issues/201
 
     let seedfp = seedfp.map(parse_seedfp_parameter).transpose()?;
 

--- a/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
@@ -479,6 +479,7 @@ pub(crate) async fn call(
     let verbose = verbose.is_some_and(|v| v != 0);
 
     // TODO: We can't support this via the current Zaino API; wait for `ChainIndex`.
+    //       https://github.com/zcash/wallet/issues/237
     if blockhash.is_some() {
         return Err(
             LegacyCode::InvalidParameter.with_static("blockhash argument must be unset (for now).")
@@ -486,9 +487,10 @@ pub(crate) async fn call(
     }
 
     let tx = match chain.get_raw_transaction(txid_str.into(), Some(1)).await {
-        // TODO: Zaino should have a Rust API for fetching tx details,
-        // instead of requiring us to specify a verbosity and then deal
-        // with an enum variant that should never occur.
+        // TODO: Zaino should have a Rust API for fetching tx details, instead of
+        //       requiring us to specify a verbosity and then deal with an enum variant
+        //       that should never occur.
+        //       https://github.com/zcash/wallet/issues/237
         Ok(zebra_rpc::methods::GetRawTransaction::Raw(_)) => unreachable!(),
         Ok(zebra_rpc::methods::GetRawTransaction::Object(tx)) => Ok(tx),
         // TODO: Zaino is not correctly parsing the error response, so we
@@ -505,13 +507,15 @@ pub(crate) async fn call(
     }?;
 
     // TODO: Once we migrate to `ChainIndex`, fetch these via the snapshot.
+    //       https://github.com/zcash/wallet/issues/237
     // TODO: Zebra implements its Rust `getrawtransaction` type incorrectly and treats
-    // `height` as a `u32`, when `-1` is a valid response (for "not in main chain"). This
-    // might be fine for server usage (if it never returns a `-1`, though that would imply
-    // Zebra stores every block from every chain indefinitely), but is incorrect for
-    // client usage (like in Zaino). For now, cast to `i32` as either Zebra is not
-    // generating `-1`, or it is representing it using two's complement as `u32::MAX`
-    // (which will cast correctly).
+    //       `height` as a `u32`, when `-1` is a valid response (for "not in main chain").
+    //       This might be fine for server usage (if it never returns a `-1`, though that
+    //       would imply Zebra stores every block from every chain indefinitely), but is
+    //       incorrect for client usage (like in Zaino). For now, cast to `i32` as either
+    //       Zebra is not generating `-1`, or it is representing it using two's complement
+    //       as `u32::MAX` (which will cast correctly).
+    //       https://github.com/ZcashFoundation/zebra/issues/9671
     let blockhash = tx.block_hash().map(|hash| hash.to_string());
     let height = tx.height().map(|h| h as i32);
     let confirmations = tx.confirmations();
@@ -659,6 +663,7 @@ impl TransparentInput {
                 vout: Some(tx_in.prevout().n()),
                 script_sig: Some(TransparentScriptSig {
                     // TODO: Implement this
+                    //       https://github.com/zcash/wallet/issues/235
                     asm: "TODO: Implement this".into(),
                     hex: script_hex,
                 }),
@@ -672,10 +677,12 @@ impl TransparentOutput {
     fn encode((tx_out, n): (&TxOut, u16)) -> Self {
         let script_pub_key = TransparentScriptPubKey {
             // TODO: Implement this
+            //       https://github.com/zcash/wallet/issues/235
             asm: "TODO: Implement this".into(),
             hex: hex::encode(&tx_out.script_pubkey().0),
             // TODO: zcashd relied on initialization behaviour for the default value
-            // for null-data or non-standard outputs. Figure out what it is.
+            //       for null-data or non-standard outputs. Figure out what it is.
+            //       https://github.com/zcash/wallet/issues/236
             req_sigs: 0,
             kind: "nonstandard",
             addresses: vec![],
@@ -694,6 +701,7 @@ impl TransparentOutput {
 #[cfg(zallet_unimplemented)]
 impl JoinSplit {
     fn encode(js_desc: &zcash_primitives::transaction::components::sprout::JsDescription) -> Self {
+        // https://github.com/zcash/librustzcash/issues/1943
         todo!("Requires zcash_primitives changes")
     }
 }

--- a/zallet/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_info.rs
@@ -60,6 +60,7 @@ pub(crate) struct GetWalletInfo {
 }
 
 pub(crate) async fn call(keystore: &KeyStore) -> Response {
+    // https://github.com/zcash/wallet/issues/55
     warn!("TODO: Implement getwalletinfo");
 
     let unlocked_until = if keystore.uses_encrypted_identities() {

--- a/zallet/src/components/json_rpc/methods/list_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/list_accounts.rs
@@ -59,6 +59,7 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
 
         // `z_listaccounts` assumes a single HD seed.
         // TODO: Fix this limitation.
+        //       https://github.com/zcash/wallet/issues/82
         let account = account
             .source()
             .key_derivation()
@@ -69,6 +70,7 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
             account,
             addresses: vec![Address {
                 // TODO: Expose the real diversifier index.
+                //       https://github.com/zcash/wallet/issues/82
                 diversifier_index: 0,
                 ua: address.encode(wallet.params()),
             }],

--- a/zallet/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/recover_accounts.rs
@@ -64,6 +64,7 @@ pub(crate) async fn call(
 ) -> Response {
     ensure_wallet_is_unlocked(keystore).await?;
     // TODO: Ensure wallet is backed up.
+    //       https://github.com/zcash/wallet/issues/201
 
     let recover_until = wallet
         .chain_height()

--- a/zallet/src/components/json_rpc/methods/view_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/view_transaction.rs
@@ -278,6 +278,7 @@ pub(crate) async fn call(
 
     // Fetch this early so we can detect if the wallet is not ready yet.
     // TODO: Replace with Zaino `ChainIndex` so we can operate against a chain snapshot.
+    //       https://github.com/zcash/wallet/issues/237
     let chain_height = wallet
         .chain_height()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
@@ -291,7 +292,8 @@ pub(crate) async fn call(
         )?;
 
     // TODO: Should we enforce ZIP 212 when viewing outputs of a transaction that is
-    // already in the wallet?
+    //       already in the wallet?
+    //       https://github.com/zcash/wallet/issues/254
     let zip212_enforcement = sapling::note_encryption::Zip212Enforcement::GracePeriod;
 
     let mut spends = vec![];
@@ -428,6 +430,7 @@ pub(crate) async fn call(
                 let txid_prev = input.prevout().txid().to_string();
 
                 // TODO: Migrate to a hopefully much nicer Rust API once we migrate to the new Zaino ChainIndex trait.
+                //       https://github.com/zcash/wallet/issues/237
                 let (account_uuid, address, value) =
                     match chain.get_raw_transaction(txid_prev.clone(), Some(1)).await {
                         Ok(GetRawTransaction::Object(tx)) => {
@@ -879,7 +882,8 @@ impl WalletTxInfo {
             match mined_height {
                 Some(mined_height) => i64::from(chain_height + 1 - mined_height),
                 None => {
-                    // TODO: Also check if the transaction is in the mempool for this branch.
+                    // TODO: Also check if the transaction is in the mempool.
+                    //       https://github.com/zcash/wallet/issues/237
                     -1
                 }
             }
@@ -900,8 +904,9 @@ impl WalletTxInfo {
             status = "mined";
 
             // TODO: Once Zaino updates its API to support atomic queries, it should not
-            // be possible to fail to fetch the block that a transaction was observed
-            // mined in.
+            //       be possible to fail to fetch the block that a transaction was
+            //       observed mined in.
+            //       https://github.com/zcash/wallet/issues/237
             // TODO: Block data optional until we migrate to `ChainIndex`.
             //       https://github.com/zcash/wallet/issues/237
             if let Some(block_metadata) = wallet.block_metadata(height)? {

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -93,7 +93,8 @@ pub(crate) async fn call(
     Option<ContextInfo>,
     impl Future<Output = RpcResult<SendResult>>,
 )> {
-    // TODO: Check that Sapling is active.
+    // TODO: Check that Sapling is active, by inspecting height of `chain` snapshot.
+    //       https://github.com/zcash/wallet/issues/237
 
     if amounts.is_empty() {
         return Err(
@@ -173,7 +174,7 @@ pub(crate) async fn call(
     }?;
 
     // Sanity check for transaction size
-    // TODO
+    // TODO: https://github.com/zcash/wallet/issues/255
 
     let confirmations_policy = match minconf {
         Some(minconf) => NonZeroU32::new(minconf).map_or(
@@ -191,6 +192,7 @@ pub(crate) async fn call(
     let params = *wallet.params();
 
     // TODO: Fetch the real maximums within the account so we can detect correctly.
+    //       https://github.com/zcash/wallet/issues/257
     let mut max_sapling_available = Zatoshis::const_from_u64(MAX_MONEY);
     let mut max_orchard_available = Zatoshis::const_from_u64(MAX_MONEY);
 
@@ -334,6 +336,7 @@ pub(crate) async fn call(
         .await
         .map_err(|e| match e.kind() {
             // TODO: Improve internal error types.
+            //       https://github.com/zcash/wallet/issues/256
             crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
                 LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
             }

--- a/zallet/src/components/json_rpc/payments.rs
+++ b/zallet/src/components/json_rpc/payments.rs
@@ -429,6 +429,7 @@ pub(super) fn get_account_for_address(
     address: &Address,
 ) -> RpcResult<Account> {
     // TODO: Make this more efficient with a `WalletRead` method.
+    //       https://github.com/zcash/librustzcash/issues/1944
     for account_id in wallet
         .get_account_ids()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?

--- a/zallet/src/components/json_rpc/utils.rs
+++ b/zallet/src/components/json_rpc/utils.rs
@@ -43,6 +43,7 @@ pub(super) async fn ensure_wallet_is_unlocked(keystore: &KeyStore) -> RpcResult<
 }
 
 // TODO: Move this to `zcash_protocol`.
+//       https://github.com/zcash/librustzcash/issues/1934
 pub(crate) fn parse_txid(txid_str: &str) -> RpcResult<TxId> {
     let mut bytes = [0; 32];
     hex::decode_to_slice(txid_str, &mut bytes)

--- a/zallet/src/components/keystore.rs
+++ b/zallet/src/components/keystore.rs
@@ -169,7 +169,8 @@ impl fmt::Debug for KeyStore {
 impl KeyStore {
     pub(crate) fn new(config: &ZalletConfig, db: Database) -> Result<Self, Error> {
         // TODO: Maybe support storing the identity in `zallet.toml` instead of as a
-        // separate file on disk?
+        //       separate file on disk?
+        //       https://github.com/zcash/wallet/issues/253
         let path = config.encryption_identity();
 
         let (encrypted_identities, identities) = {

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -538,8 +538,9 @@ impl KeyStoreSection {
 }
 
 /// Note management configuration section.
-///
-/// TODO: Decide whether this should be part of `[builder]`.
+//
+// TODO: Decide whether this should be part of `[builder]`.
+//       https://github.com/zcash/wallet/issues/251
 #[cfg(zallet_build = "wallet")]
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Documented, DocumentedFields)]
 #[serde(deny_unknown_fields)]

--- a/zallet/tests/cmd/example_config.out/zallet.toml
+++ b/zallet/tests/cmd/example_config.out/zallet.toml
@@ -245,8 +245,6 @@ as_of_version = "0.0.0"
 #
 # Note management configuration section.
 #
-# TODO: Decide whether this should be part of `[builder]`.
-#
 [note_management]
 
 # The minimum value that Zallet should target for each shielded note in the wallet.


### PR DESCRIPTION
During the initial pre-alpha implementation phase, we left TODOs in the code for things we might be altering in the short term. Now that the first alpha is approaching, we should start migrating the remaining TODOs to issues so that we can more easily plan to address them.