### PR TITLE
rpc: Adjust JSON-RPC parameter names to match Bitcoin Core

### DIFF
--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -138,6 +138,7 @@ pub(crate) trait Rpc {
     async fn get_raw_transaction(
         &self,
         txid: &str,
+        // TODO: Bitcoin now also allows this to be named `verbosity`.
         verbose: Option<u64>,
         blockhash: Option<String>,
     ) -> get_raw_transaction::Response;
@@ -291,20 +292,20 @@ pub(crate) trait WalletRpc {
 
     /// Returns the total value of funds stored in the node's wallet.
     ///
-    /// TODO: Currently watchonly addresses cannot be omitted; `includeWatchonly` must be
+    /// TODO: Currently watchonly addresses cannot be omitted; `include_watchonly` must be
     /// set to true.
     ///
     /// # Arguments
     ///
     /// - `minconf` (numeric, optional, default=1) Only include private and transparent
     ///   transactions confirmed at least this many times.
-    /// - `includeWatchonly` (bool, optional, default=false) Also include balance in
+    /// - `include_watchonly` (bool, optional, default=false) Also include balance in
     ///   watchonly addresses (see 'importaddress' and 'z_importviewingkey').
     #[method(name = "z_gettotalbalance")]
     async fn z_get_total_balance(
         &self,
         minconf: Option<u32>,
-        #[argument(rename = "includeWatchonly")] include_watch_only: Option<bool>,
+        include_watchonly: Option<bool>,
     ) -> z_get_total_balance::Response;
 
     /// Returns an array of unspent shielded notes with between minconf and maxconf
@@ -384,7 +385,7 @@ pub(crate) trait WalletRpc {
     /// - `minconf` (numeric, optional) Only use funds confirmed at least this many times.
     /// - `fee` (numeric, optional) If set, it must be null. Zallet always uses a fee
     ///   calculated according to ZIP 317.
-    /// - `privacyPolicy` (string, optional, default=`"FullPrivacy"`) Policy for what
+    /// - `privacy_policy` (string, optional, default=`"FullPrivacy"`) Policy for what
     ///   information leakage is acceptable. One of the following strings:
     ///   - `"FullPrivacy"`: Only allow fully-shielded transactions (involving a single
     ///     shielded value pool).
@@ -412,7 +413,7 @@ pub(crate) trait WalletRpc {
         amounts: Vec<z_send_many::AmountParameter>,
         minconf: Option<u32>,
         fee: Option<JsonValue>,
-        #[argument(rename = "privacyPolicy")] privacy_policy: Option<String>,
+        privacy_policy: Option<String>,
     ) -> z_send_many::Response;
 }
 
@@ -622,9 +623,9 @@ impl WalletRpcServer for WalletRpcImpl {
     async fn z_get_total_balance(
         &self,
         minconf: Option<u32>,
-        include_watch_only: Option<bool>,
+        include_watchonly: Option<bool>,
     ) -> z_get_total_balance::Response {
-        z_get_total_balance::call(self.wallet().await?.as_ref(), minconf, include_watch_only)
+        z_get_total_balance::call(self.wallet().await?.as_ref(), minconf, include_watchonly)
     }
 
     async fn list_unspent(

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -107,12 +107,12 @@ pub(super) const PARAM_ADDRESSES_DESC: &str =
 pub(super) const PARAM_AS_OF_HEIGHT_DESC: &str = "Execute the query as if it were run when the blockchain was at the height specified by this argument.";
 
 // FIXME: the following parameters are not yet properly supported
-// * include_watch_only
+// * include_watchonly
 pub(crate) fn call(
     wallet: &DbConnection,
     minconf: Option<u32>,
     maxconf: Option<u32>,
-    _include_watch_only: Option<bool>,
+    _include_watchonly: Option<bool>,
     addresses: Option<Vec<String>>,
     as_of_height: Option<i64>,
 ) -> Response {
@@ -122,7 +122,7 @@ pub(crate) fn call(
         None => ConfirmationsPolicy::new_symmetrical(NonZeroU32::new(1).unwrap(), true),
     };
 
-    //let include_watch_only = include_watch_only.unwrap_or(false);
+    //let include_watchonly = include_watchonly.unwrap_or(false);
     let addresses = addresses
         .unwrap_or_default()
         .iter()

--- a/zallet/src/components/json_rpc/methods/z_get_total_balance.rs
+++ b/zallet/src/components/json_rpc/methods/z_get_total_balance.rs
@@ -31,18 +31,18 @@ pub(crate) struct TotalBalance {
 
 pub(super) const PARAM_MINCONF_DESC: &str =
     "Only include notes in transactions confirmed at least this many times.";
-pub(super) const PARAM_INCLUDE_WATCH_ONLY_DESC: &str =
+pub(super) const PARAM_INCLUDE_WATCHONLY_DESC: &str =
     "Also include balance in watchonly addresses.";
 
 pub(crate) fn call(
     wallet: &DbConnection,
     minconf: Option<u32>,
-    include_watch_only: Option<bool>,
+    include_watchonly: Option<bool>,
 ) -> Response {
-    match include_watch_only {
+    match include_watchonly {
         Some(true) => Ok(()),
         None | Some(false) => Err(LegacyCode::Misc
-            .with_message("include_watch_only argument must be set to true (for now)")),
+            .with_message("include_watchonly argument must be set to true (for now)")),
     }?;
 
     let confirmations_policy = match minconf {


### PR DESCRIPTION
This is helpful to reduce the delta for JSON-RPC 2.0 clients.

Closes zcash/wallet#241.