### PR TITLE
Add Docker Image Signing, SBOM & Provenance Attestations

### DIFF
--- a/.github/workflows/build-and-push-docker-hub.yaml
+++ b/.github/workflows/build-and-push-docker-hub.yaml
@@ -35,7 +35,7 @@ jobs:
         fi
 
   build_push:
-    uses: zcash/.github/.github/workflows/build-and-push-docker-hub.yaml@main
+    uses: zcash/.github/.github/workflows/build-and-push-docker-hub.yaml@7d26ab8bcae49bed16f4137f8eba5679759888a2 # v1.0.0
     needs: set_env
 
     # Pass through the same permissions to the called workflow (optional but tidy)


### PR DESCRIPTION
This PR updates the Docker image release workflow to use the new **reusable GitHub Actions template** (`build-and-push-docker-hub.yaml`) that supports **SBOM, provenance, signing, and attestations**.

### Key Improvements

* **OIDC permissions** (`id-token: write`, `contents: read`) added so Cosign can perform **keyless signing**.
* Updated `image_name` to include the **Docker Hub namespace** (`<username>/zallet`) for proper tagging.
* Workflow now automatically:

  1. Builds and pushes the Docker image.
  2. Publishes **SBOM** and **SLSA provenance** as OCI referrers.
  3. Signs the image **by digest** with Cosign (keyless).
  4. Generates and uploads a **signed SPDX SBOM attestation**.

### Benefits

* Images on Docker Hub are now **cryptographically verifiable**:

  ```bash
  cosign verify docker.io/<username>/zallet:<tag>
  ```
* Consumers can fetch and validate SBOMs and provenance metadata.
* Strengthens **supply chain security** and aligns with best practices (Sigstore, SLSA).

### Notes

* Trigger: runs on **tag pushes** (`v*.*.*`) or manually via **workflow_dispatch**.
* Tags produced: `latest`, the semantic version, and the commit SHA.
