### PR TITLE
CI: Fix incorrect permissions specification in `build-and-push-docker-hub.yaml`

### DIFF
--- a/.github/workflows/build-and-push-docker-hub.yaml
+++ b/.github/workflows/build-and-push-docker-hub.yaml
@@ -37,10 +37,9 @@ jobs:
   build_push:
     uses: zcash/.github/.github/workflows/build-and-push-docker-hub.yaml@7d26ab8bcae49bed16f4137f8eba5679759888a2 # v1.0.0
     needs: set_env
-
-    # Pass through the same permissions to the called workflow (optional but tidy)
-    permissions: inherit
-
+    permissions:
+      id-token: write
+      contents: read
     with:
       image_name: zallet
       image_tags: ${{ needs.set_env.outputs.tags }}


### PR DESCRIPTION
Fixed a workflow validation error in `.github/workflows/build-and-push-docker-hub.yaml`.
The previous version included `permissions: inherit`, which is **not valid** in the calling workflow context, causing the following error:

> **Invalid workflow file**: Unexpected value `inherit`

###  **Changes Made**

* Removed the invalid `permissions: inherit` declaration.
* Added explicit permissions instead:

```yaml
permissions:
  id-token: write
  contents: read
```

### **Reason for the Change**

* GitHub does not allow `permissions: inherit` in the workflow that *calls* a reusable workflow.
* Explicit permissions must be defined at the job level to ensure proper access for OIDC authentication and secure content handling.

### **Expected Result**

* The workflow now validates and runs successfully.
* Security is maintained by granting only the required permissions.
