### PR TITLE
reduce deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@
 FROM stagex/pallet-rust@sha256:9c38bf1066dd9ad1b6a6b584974dd798c2bf798985bf82e58024fbe0515592ca AS pallet-rust
 FROM stagex/user-protobuf@sha256:5e67b3d3a7e7e9db9aa8ab516ffa13e54acde5f0b3d4e8638f79880ab16da72c AS protobuf 
 FROM stagex/user-abseil-cpp@sha256:3dca99adfda0cb631bd3a948a99c2d5f89fab517bda034ce417f222721115aa2 AS abseil-cpp
-FROM stagex/core-gcc@sha256:964ffd3793c5a38ca581e9faefd19918c259f1611c4cbf5dc8be612e3a8b72f5 AS gcc 
-FROM stagex/core-musl@sha256:d9af23284cca2e1002cd53159ada469dfe6d6791814e72d6163c7de18d4ae701 AS musl
-FROM stagex/core-libunwind@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind 
 FROM stagex/core-user-runtime@sha256:055ae534e1e01259449fb4e0226f035a7474674c7371a136298e8bdac65d90bb AS user-runtime
 
 # --- Stage 1: Build with Rust --- (amd64)
@@ -73,11 +70,7 @@ COPY --from=builder /usr/local/bin/zallet /zallet
 # --- Stage 3: Minimal runtime with stagex ---
 # `stagex/core-user-runtime` sets the user to non-root by default
 FROM user-runtime AS runtime
-COPY --from=gcc  /usr/lib/libgcc_s.so.1 /usr/lib/
-COPY --from=gcc  /usr/lib/libstdc++.so.6 /usr/lib/
-COPY --from=musl /lib/ld-musl-x86_64.so.1 /lib/
-COPY --from=libunwind /lib/libunwind.so.8 /lib/
-COPY --from=builder /usr/local/bin/zallet /usr/local/bin/zallet
+COPY --from=export /zallet /usr/local/bin/zallet
 
 WORKDIR /var/lib/zallet
 


### PR DESCRIPTION
This PR removes unnecessary deps to make the Dockerfile more minimal. 

It was tested for reproducibility and to make sure the binary runs.