### PR TITLE
Simulate wallets for stateful testing

### DIFF
--- a/zallet/src/components.rs
+++ b/zallet/src/components.rs
@@ -16,6 +16,10 @@ pub(crate) mod tracing;
 #[cfg(zallet_build = "wallet")]
 pub(crate) mod keystore;
 
+#[cfg(test)]
+#[cfg(zallet_build = "wallet")]
+pub(crate) mod testing;
+
 /// A handle to a background task spawned by a component.
 ///
 /// Background tasks in Zallet are either one-shot (expected to terminate before Zallet),

--- a/zallet/src/components/database/testing.rs
+++ b/zallet/src/components/database/testing.rs
@@ -1,0 +1,85 @@
+//! Test utilities for database operations.
+
+use zcash_client_sqlite::wallet::init::WalletMigrator;
+use zcash_protocol::consensus::Parameters;
+
+use super::{DbHandle, all_external_migrations, connection};
+use crate::{error::Error, network::Network};
+
+/// Creates an in-memory database pool for testing.
+///
+/// Uses pool size 2 to allow concurrent access from both the wallet handle
+/// and the keystore (which needs its own handle for database operations).
+///
+/// Uses a shared in-memory database URI so all connections in the pool
+/// access the same database.
+pub(crate) fn test_pool(params: Network) -> Result<connection::WalletPool, Error> {
+    // Use a shared in-memory database with a unique name per pool
+    // The `cache=shared` mode allows multiple connections to share the same database
+    // The unique name ensures different tests don't interfere with each other
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let db_name = format!(
+        "file:zallet_test_{}?mode=memory&cache=shared",
+        COUNTER.fetch_add(1, Ordering::SeqCst)
+    );
+
+    connection::pool(
+        &db_name,
+        params,
+        Some(connection::PoolConfig { max_size: 2 }),
+    )
+}
+
+/// A test database wrapper that provides access to the pool and handles.
+///
+/// This wraps an in-memory SQLite database with all migrations applied,
+/// suitable for unit and integration tests.
+pub(crate) struct TestDatabase {
+    pool: connection::WalletPool,
+    params: Network,
+}
+
+impl TestDatabase {
+    /// Creates a new in-memory test database with migrations applied.
+    pub(crate) async fn new(params: Network) -> Result<Self, Error> {
+        let pool = test_pool(params)?;
+        let db = Self { pool, params };
+        db.init().await?;
+        Ok(db)
+    }
+
+    /// Initializes the database schema by applying all migrations.
+    async fn init(&self) -> Result<(), Error> {
+        let handle = self.handle().await?;
+        let params = self.params;
+        handle.with_mut(|mut db_data| {
+            WalletMigrator::new()
+                .with_external_migrations(all_external_migrations(params.network_type()))
+                .init_or_migrate(&mut db_data)
+                .map_err(|e| crate::error::ErrorKind::Init.context(e))
+        })?;
+        Ok(())
+    }
+
+    /// Gets a database handle from the pool.
+    pub(crate) async fn handle(&self) -> Result<DbHandle, Error> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| crate::error::ErrorKind::Generic.context(e).into())
+    }
+
+    /// Returns the network parameters.
+    #[allow(dead_code)]
+    pub(crate) fn params(&self) -> Network {
+        self.params
+    }
+
+    /// Returns a reference to the underlying pool.
+    ///
+    /// This is useful for creating a `Database` wrapper for KeyStore.
+    pub(crate) fn pool(&self) -> &connection::WalletPool {
+        &self.pool
+    }
+}

--- a/zallet/src/components/keystore.rs
+++ b/zallet/src/components/keystore.rs
@@ -146,6 +146,9 @@ pub(super) mod db;
 mod error;
 pub(crate) use error::KeystoreError;
 
+#[cfg(test)]
+pub(crate) mod testing;
+
 type RelockTask = (SystemTime, JoinHandle<()>);
 
 #[derive(Clone)]
@@ -170,6 +173,23 @@ impl fmt::Debug for KeyStore {
 }
 
 impl KeyStore {
+    /// Creates a KeyStore for testing with pre-initialized identities.
+    ///
+    /// This bypasses the file-reading logic and allows tests to inject
+    /// identities directly.
+    #[cfg(test)]
+    pub(crate) fn new_for_testing(
+        db: Database,
+        identities: Vec<Box<dyn age::Identity + Send + Sync>>,
+    ) -> Self {
+        Self {
+            db,
+            encrypted_identities: None,
+            identities: Arc::new(RwLock::new(identities)),
+            relock_task: Arc::new(Mutex::new(None)),
+        }
+    }
+
     pub(crate) fn new(config: &ZalletConfig, db: Database) -> Result<Self, Error> {
         // TODO: Maybe support storing the identity in `zallet.toml` instead of as a
         //       separate file on disk?
@@ -871,4 +891,117 @@ fn decrypt_standalone_transparent_privkey(
         .map_err(|e| ErrorKind::Generic.context(e))?;
 
     Ok(secret_key)
+}
+
+#[cfg(test)]
+mod tests {
+    mod integration {
+        use bip0039::{English, Mnemonic};
+        use secrecy::ExposeSecret;
+        use zcash_protocol::consensus;
+
+        use crate::{
+            components::database::{Database, testing::TestDatabase},
+            network::Network,
+        };
+
+        use super::super::testing::test_keystore;
+
+        /// Test mnemonic lifecycle: encrypt, store, list, and decrypt.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn mnemonic_lifecycle() {
+            let network = Network::Consensus(consensus::Network::MainNetwork);
+            let test_db = TestDatabase::new(network).await.unwrap();
+            let database = Database::from_pool(test_db.pool().clone());
+            let keystore = test_keystore(database).await.unwrap();
+
+            // Initially no seeds
+            let seed_fps = keystore.list_seed_fingerprints().await.unwrap();
+            assert!(seed_fps.is_empty(), "Should have no seeds initially");
+
+            // Create a mnemonic and store it
+            let mnemonic: Mnemonic<English> =
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+                    .parse()
+                    .unwrap();
+
+            let stored_fp = keystore
+                .encrypt_and_store_mnemonic(mnemonic.clone())
+                .await
+                .unwrap();
+
+            // Verify seed is now listed
+            let seed_fps = keystore.list_seed_fingerprints().await.unwrap();
+            assert_eq!(seed_fps.len(), 1);
+            assert!(seed_fps.contains(&stored_fp));
+
+            // Decrypt the seed and verify it matches
+            let decrypted_seed = keystore.decrypt_seed(&stored_fp).await.unwrap();
+
+            // The seed should match what we get from the mnemonic
+            let expected_seed = mnemonic.to_seed("");
+            assert_eq!(decrypted_seed.expose_secret(), &expected_seed[..]);
+        }
+
+        /// Test storing multiple mnemonics.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn multiple_mnemonics() {
+            let network = Network::Consensus(consensus::Network::MainNetwork);
+            let test_db = TestDatabase::new(network).await.unwrap();
+            let database = Database::from_pool(test_db.pool().clone());
+            let keystore = test_keystore(database).await.unwrap();
+
+            // Store first mnemonic
+            let mnemonic1: Mnemonic<English> =
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+                    .parse()
+                    .unwrap();
+            let fp1 = keystore
+                .encrypt_and_store_mnemonic(mnemonic1)
+                .await
+                .unwrap();
+
+            // Store second mnemonic (different phrase)
+            let mnemonic2: Mnemonic<English> = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong"
+                .parse()
+                .unwrap();
+            let fp2 = keystore
+                .encrypt_and_store_mnemonic(mnemonic2)
+                .await
+                .unwrap();
+
+            // Fingerprints should be different
+            assert_ne!(
+                fp1, fp2,
+                "Different mnemonics should have different fingerprints"
+            );
+
+            // Both should be listed
+            let seed_fps = keystore.list_seed_fingerprints().await.unwrap();
+            assert_eq!(seed_fps.len(), 2);
+            assert!(seed_fps.contains(&fp1));
+            assert!(seed_fps.contains(&fp2));
+        }
+
+        /// Test that keystore is not locked when using test identities.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn keystore_unlocked_for_testing() {
+            let network = Network::Consensus(consensus::Network::MainNetwork);
+            let test_db = TestDatabase::new(network).await.unwrap();
+            let database = Database::from_pool(test_db.pool().clone());
+            let keystore = test_keystore(database).await.unwrap();
+
+            // Test keystore should not be locked
+            assert!(
+                !keystore.is_locked().await,
+                "Test keystore should not be locked"
+            );
+
+            // Should not use encrypted identities
+            assert!(
+                !keystore.uses_encrypted_identities(),
+                "Test keystore should not use encrypted identities"
+            );
+        }
+    }
 }

--- a/zallet/src/components/keystore/testing.rs
+++ b/zallet/src/components/keystore/testing.rs
@@ -1,0 +1,30 @@
+//! Test utilities for keystore operations.
+
+use super::KeyStore;
+use crate::{components::database::Database, error::Error};
+
+/// Generates a test age identity and its corresponding recipient.
+///
+/// Returns a tuple of (identity, recipient_string) suitable for testing.
+pub(crate) fn generate_test_identity() -> (age::x25519::Identity, String) {
+    let identity = age::x25519::Identity::generate();
+    let recipient = identity.to_public();
+    (identity, recipient.to_string())
+}
+
+/// Creates a test KeyStore with a freshly generated identity.
+///
+/// The keystore will be unlocked (identities loaded) and have recipients
+/// initialized in the database.
+pub(crate) async fn test_keystore(db: Database) -> Result<KeyStore, Error> {
+    let (identity, recipient_string) = generate_test_identity();
+
+    let keystore = KeyStore::new_for_testing(db, vec![Box::new(identity)]);
+
+    // Initialize recipients so encryption operations work
+    keystore
+        .initialize_recipients(vec![recipient_string])
+        .await?;
+
+    Ok(keystore)
+}

--- a/zallet/src/components/testing.rs
+++ b/zallet/src/components/testing.rs
@@ -1,0 +1,170 @@
+//! Unified test fixtures for wallet testing.
+//!
+//! This module provides test utilities for creating in-memory wallets with
+//! accounts, suitable for unit and integration testing of wallet functionality.
+
+use bip0039::{Count, English, Mnemonic};
+use rand::{RngCore, rngs::OsRng};
+use zcash_client_backend::{
+    data_api::{AccountBirthday, WalletWrite, chain::ChainState},
+    keys::UnifiedSpendingKey,
+};
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::consensus::BlockHeight;
+use zip32::fingerprint::SeedFingerprint;
+
+use crate::{
+    components::{
+        database::{Database, DbHandle, testing::TestDatabase},
+        keystore::{KeyStore, testing::test_keystore},
+    },
+    error::Error,
+    network::Network,
+};
+
+/// A complete test wallet environment with database and keystore.
+///
+/// This provides an in-memory wallet suitable for testing RPC methods
+/// and other wallet functionality without requiring disk access.
+pub(crate) struct TestWallet {
+    db: TestDatabase,
+    keystore: KeyStore,
+}
+
+impl TestWallet {
+    /// Creates a new test wallet with in-memory database.
+    pub(crate) async fn new(network: Network) -> Result<Self, Error> {
+        let db = TestDatabase::new(network).await?;
+
+        // Create a Database wrapper for KeyStore using the same pool
+        let database = Database::from_pool(db.pool().clone());
+        let keystore = test_keystore(database).await?;
+
+        Ok(Self { db, keystore })
+    }
+
+    /// Gets a database handle.
+    pub(crate) async fn handle(&self) -> Result<DbHandle, Error> {
+        self.db.handle().await
+    }
+
+    /// Returns a reference to the keystore.
+    pub(crate) fn keystore(&self) -> &KeyStore {
+        &self.keystore
+    }
+
+    /// Returns the network parameters.
+    #[allow(dead_code)]
+    pub(crate) fn params(&self) -> Network {
+        self.db.params()
+    }
+
+    /// Creates a new test account builder.
+    pub(crate) fn account_builder(&self) -> TestAccountBuilder<'_> {
+        TestAccountBuilder::new(self)
+    }
+}
+
+/// Builder for creating test accounts.
+pub(crate) struct TestAccountBuilder<'a> {
+    wallet: &'a TestWallet,
+    mnemonic: Option<Mnemonic<English>>,
+    birthday_height: u32,
+    name: String,
+}
+
+impl<'a> TestAccountBuilder<'a> {
+    fn new(wallet: &'a TestWallet) -> Self {
+        Self {
+            wallet,
+            mnemonic: None,
+            birthday_height: 1,
+            name: "test_account".into(),
+        }
+    }
+
+    /// Sets a specific mnemonic phrase.
+    #[allow(dead_code)]
+    pub(crate) fn with_mnemonic(mut self, mnemonic: Mnemonic<English>) -> Self {
+        self.mnemonic = Some(mnemonic);
+        self
+    }
+
+    /// Sets the account birthday height.
+    #[allow(dead_code)]
+    pub(crate) fn with_birthday(mut self, height: u32) -> Self {
+        self.birthday_height = height;
+        self
+    }
+
+    /// Sets the account name.
+    #[allow(dead_code)]
+    pub(crate) fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Builds the test account.
+    pub(crate) async fn build(self) -> Result<TestAccount, Error> {
+        // Generate or use provided mnemonic
+        let mnemonic = self.mnemonic.unwrap_or_else(|| {
+            // Adapted from `Mnemonic::generate` so we can use `OsRng` directly.
+            const BITS_PER_BYTE: usize = 8;
+            const MAX_ENTROPY_BITS: usize = Count::Words24.entropy_bits();
+            const ENTROPY_BYTES: usize = MAX_ENTROPY_BITS / BITS_PER_BYTE;
+
+            let mut entropy = [0u8; ENTROPY_BYTES];
+            OsRng.fill_bytes(&mut entropy);
+
+            Mnemonic::<English>::from_entropy(entropy)
+                .expect("valid entropy length won't fail to generate the mnemonic")
+        });
+
+        // Store mnemonic in keystore
+        let seed_fp = self
+            .wallet
+            .keystore()
+            .encrypt_and_store_mnemonic(mnemonic.clone())
+            .await?;
+
+        // Decrypt seed for account creation
+        let seed = self.wallet.keystore().decrypt_seed(&seed_fp).await?;
+
+        // Create minimal birthday with empty chain state (no tree data needed for basic tests)
+        let chain_state = ChainState::empty(
+            BlockHeight::from_u32(self.birthday_height.saturating_sub(1)),
+            BlockHash([0; 32]),
+        );
+        let birthday = AccountBirthday::from_parts(chain_state, None);
+
+        // Create account in database
+        let handle = self.wallet.handle().await?;
+        let name = self.name.clone();
+        let (account_id, usk) = handle
+            .with_mut(|mut db| db.create_account(&name, &seed, &birthday, None))
+            .map_err(|e| crate::error::ErrorKind::Generic.context(e))?;
+
+        Ok(TestAccount {
+            account_id,
+            usk,
+            seed_fp,
+            seed,
+            mnemonic,
+        })
+    }
+}
+
+/// A test account with its keys and metadata.
+#[allow(dead_code)]
+pub(crate) struct TestAccount {
+    /// The account identifier in the database.
+    pub account_id: zcash_client_sqlite::AccountUuid,
+    /// The unified spending key for this account.
+    pub usk: UnifiedSpendingKey,
+    /// The seed fingerprint.
+    pub seed_fp: SeedFingerprint,
+    /// The decrypted seed bytes.
+    pub seed: secrecy::SecretVec<u8>,
+    /// The mnemonic phrase.
+    pub mnemonic: Mnemonic<English>,
+}


### PR DESCRIPTION
Zallet developers need to be able to write stateful integration tests to match the level of test coverage that zcashd has. Our most essential RPC methods do not yet have integration test coverage (tests using actual wallet state).

Today our integration testing process is looking very manual, potentially burning a lot of dev hours: https://github.com/zcash/wallet/pull/364#issuecomment-3864359194

This PR is a first attempt at implementing an in-memory SQLite wallet for integration testing purposes.

I think we should create an issue to properly implement integration testing sooner than later.

I'm happy to iterate on this first attempt based on your feedback, or to close this PR. I'm mostly opening it to raise this as a conversation topic.