### PR TITLE
build: Migrate to "StageX 2.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV TARGET_ARCH=x86_64-unknown-linux-musl
 ENV CFLAGS=-target\ x86_64-unknown-linux-musl
 ENV CXXFLAGS=-stdlib=libc++
 ENV CARGO_HOME=/usr/local/cargo
+ENV CARGO_TARGET_DIR="/usr/src/zallet/target"
 ENV CARGO_INCREMENTAL=0
 ENV RUST_BACKTRACE=1
 ENV RUSTFLAGS="\
@@ -31,56 +32,30 @@ ENV RUSTFLAGS="\
 -C link-arg=-ldl \
 -C link-arg=-lm \
 -C link-arg=-Wl,--build-id=none"
+WORKDIR /usr/src/zallet
+COPY . .
 
-# Make a fake Rust app to keep a cached layer of compiled crates
-WORKDIR /usr/src/app/zallet/tests
-RUN touch cli_tests.rs
-WORKDIR /usr/src/app
-COPY Cargo.toml Cargo.lock ./
-COPY zallet/Cargo.toml ./zallet/
-# Needs at least a main.rs file with a main function
-WORKDIR zallet/src/bin/zallet
-RUN echo "fn main(){}" > main.rs
-
-FROM builder AS deps
+# Fetch dependencies
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo fetch \
         --locked \
         --target ${TARGET_ARCH}
 
-FROM builder AS build-deps
-COPY --from=deps /usr/local/cargo /usr/local/cargo
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build \
-        --release \
-        --locked \
-        --target ${TARGET_ARCH} \
-        --offline
-
-FROM builder AS zallet
-COPY --from=build-deps /usr/src/app/target /usr/src/app/target
-COPY --from=build-deps /usr/local/cargo /usr/local/cargo
-# Copy the rest
-COPY . .
-RUN rm -f zallet/src/main.rs
 # Build the zallet binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/src/app/target \
+    --mount=type=cache,target=/usr/src/zallet/target \
     cargo install \
-        --locked \
+        --frozen \
         --path zallet \
         --bin zallet \
         --target ${TARGET_ARCH} \
-        --features rpc-cli,zcashd-import \
-        --root /usr/local \
-        --offline
+        --features rpc-cli,zcashd-import
 
 # --- Stage 2: layer for local binary extraction ---
 FROM scratch AS export
-COPY --from=zallet /usr/local/bin/zallet /zallet
+COPY --from=builder /usr/local/cargo/bin/zallet /zallet
 
 # --- Stage 3: Minimal runtime with stagex ---
 FROM scratch AS runtime


### PR DESCRIPTION
The StageX tree underwent a major overhaul to switch from being GNU-native to LLVM-native for much better cross compiling support, among many other advantages. It is essentially StageX 2.0, but introducing minor breaking changes. We should have done a better job with release notes but now that we have landed this work (which was ongoing over most of the last year) we are shifting our efforts to: stability, massive compile-time and run-time speed improvements, hardening, timely and largely automated reproductions and updates, better release notes and docs! A lot of people are using stagex fast as it is the only thing that solves the supply chain problem well, but we have some catching up to other distros to do in terms of docs and examples to be sure. 

In addition to documentation, our hope is our upcoming tool "sxctl" will be able to automate migration and updates to stagex based containerfiles.

I've done the following to fix your build:

* Bumped `protobuf` and `abseil-cpp` to latest
* Removed the `user-runtime` which is deprecated now, and switched to `core-filesystem`, then added `USER 1000:1000` as that will likely be removed from `core-filesystem`
* Added rust flags which explicitly instruct usage of `clang` and `lld` during compilation, and removed the  `rocksdb` env var `ROCKSDB_PKG_CONFIG=0` as the flags override that env var

Going forward, it should be sufficient to bump these packages to the latest release.

For now some of us just include scripts like https://git.distrust.co/public/airgap/src/branch/main/src/update.py to simplify discovery of the latest set of built-together hashes.

Thanks for being patient with this and don't hesitate to poke me if you have any issues, I'm happy to help unblock you and make the distro work better for you.

