### PR TITLE
cli: Add hidden regtest-only command for creating account and miner address

### DIFF
--- a/zallet/src/cli.rs
+++ b/zallet/src/cli.rs
@@ -87,6 +87,10 @@ pub(crate) enum ZalletCmd {
     /// Commands for repairing broken wallet states.
     #[command(subcommand)]
     Repair(RepairCmd),
+
+    /// Hidden regtest-only commands.
+    #[command(subcommand, hide = true)]
+    Regtest(RegtestCmd),
 }
 
 /// `start` subcommand
@@ -283,3 +287,16 @@ pub(crate) struct TruncateWalletCmd {
     /// if it is not possible to truncate exactly to the specified height.
     pub(crate) max_height: u32,
 }
+
+#[derive(Debug, Parser)]
+#[cfg_attr(outside_buildscript, derive(Command, Runnable))]
+pub(crate) enum RegtestCmd {
+    /// Generate a default account and return a transparent address for miner outputs.
+    #[cfg(zallet_build = "wallet")]
+    GenerateAccountAndMinerAddress(GenerateAccountAndMinerAddressCmd),
+}
+
+#[cfg(zallet_build = "wallet")]
+#[derive(Debug, Parser)]
+#[cfg_attr(outside_buildscript, derive(Command))]
+pub(crate) struct GenerateAccountAndMinerAddressCmd {}

--- a/zallet/src/commands.rs
+++ b/zallet/src/commands.rs
@@ -22,6 +22,7 @@ use crate::{
 
 mod add_rpc_user;
 mod example_config;
+mod regtest;
 mod repair;
 mod start;
 

--- a/zallet/src/commands/regtest.rs
+++ b/zallet/src/commands/regtest.rs
@@ -1,0 +1,2 @@
+#[cfg(zallet_build = "wallet")]
+mod generate_account_and_miner_address;

--- a/zallet/src/commands/regtest/generate_account_and_miner_address.rs
+++ b/zallet/src/commands/regtest/generate_account_and_miner_address.rs
@@ -1,0 +1,88 @@
+use abscissa_core::Runnable;
+use transparent::keys::IncomingViewingKey;
+use zcash_client_backend::data_api::{AccountBirthday, WalletRead, WalletWrite, chain::ChainState};
+use zcash_keys::encoding::AddressCodec;
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::consensus::BlockHeight;
+
+use crate::{
+    cli::GenerateAccountAndMinerAddressCmd,
+    commands::AsyncRunnable,
+    components::{database::Database, keystore::KeyStore},
+    error::{Error, ErrorKind},
+    network::Network,
+    prelude::*,
+};
+
+impl AsyncRunnable for GenerateAccountAndMinerAddressCmd {
+    async fn run(&self) -> Result<(), Error> {
+        let config = APP.config();
+        let _lock = config.lock_datadir()?;
+
+        let params = config.consensus.network();
+        if !matches!(params, Network::RegTest(_)) {
+            return Err(ErrorKind::Init
+                .context("Command only works on a regtest wallet")
+                .into());
+        }
+
+        let db = Database::open(&config).await?;
+        let keystore = KeyStore::new(&config, db.clone())?;
+        let mut wallet = db.handle().await?;
+
+        match wallet.chain_height() {
+            Ok(None) => Ok(()),
+            Ok(Some(_)) | Err(_) => {
+                Err(ErrorKind::Init.context("Command only works on a fresh wallet"))
+            }
+        }?;
+
+        let seed_fps = keystore.list_seed_fingerprints().await?;
+        let mut seed_fps = seed_fps.into_iter();
+        match (seed_fps.next(), seed_fps.next()) {
+            (None, _) => Err(ErrorKind::Init
+                .context("Need to call generate-mnemonic or import-mnemonic first")
+                .into()),
+            (_, Some(_)) => Err(ErrorKind::Init
+                .context("This regtest API is not supported with multiple seeds")
+                .into()),
+            (Some(seed_fp), None) => {
+                let seed = keystore.decrypt_seed(&seed_fp).await?;
+
+                // We should use the regtest block hash here, but we also know that the
+                // `zcash_client_sqlite` implementation of `WalletWrite::create_account`
+                // does not use the prior chain state's block hash anywhere, so we can
+                // get away with faking it.
+                let birthday = AccountBirthday::from_parts(
+                    ChainState::empty(BlockHeight::from_u32(0), BlockHash([0; 32])),
+                    None,
+                );
+
+                let (_, usk) = wallet
+                    .create_account("Default account", &seed, &birthday, None)
+                    .map_err(|e| {
+                        ErrorKind::Generic.context(format!("Failed to generate miner address: {e}"))
+                    })?;
+
+                let (addr, _) = usk
+                    .transparent()
+                    .to_account_pubkey()
+                    .derive_internal_ivk()
+                    .map_err(|e| {
+                        ErrorKind::Generic.context(format!("Failed to generate miner address: {e}"))
+                    })?
+                    .default_address();
+
+                print!("{}", addr.encode(&params));
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Runnable for GenerateAccountAndMinerAddressCmd {
+    fn run(&self) {
+        self.run_on_runtime();
+    }
+}


### PR DESCRIPTION
This enables the chain-caching logic within the JSON-RPC tests to obtain a miner address that can then be configured within Zebra before the latter is started.