### PR TITLE
CI: Allow PRs to specify zcash/integration-tests revisions to use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,25 @@ jobs:
           private-key: ${{ secrets.ZALLET_APP_PRIVATE_KEY }}
           owner: zcash
           repositories: integration-tests
+
+      - name: Get requested test branch, if any
+        id: test-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          TEST_SHA=$(gh pr -R zcash/wallet list --search "${HEAD_SHA}" --json body | jq '.[0].body' | sed '/[^ ]ZIT-Revision/!d' | sed -E 's/.*ZIT-Revision: ([^\\]*)\\.*/\1/')
+          echo "test_sha=${TEST_SHA}" >> $GITHUB_OUTPUT
+
       - name: Trigger integration tests
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TEST_SHA: ${{ steps.test-branch.outputs.test_sha }}
         run: >
           gh api repos/zcash/integration-tests/dispatches
           --field event_type="zallet-interop-request"
           --field client_payload[sha]="$GITHUB_SHA"
+          --field client_payload[test_sha]="${TEST_SHA}"
 
   required-checks:
     name: Required status checks have passed


### PR DESCRIPTION
To leverage this, add a line to the PR's top comment (body) of the form:

    ZIT-Revision: <zcash/integration-tests commit ID>