### PR TITLE
fix: Correct column name in standalone transparent key query

### DIFF
--- a/zallet/src/components/keystore.rs
+++ b/zallet/src/components/keystore.rs
@@ -741,14 +741,14 @@ impl KeyStore {
                 let addr_str = Address::Transparent(*address).encode(network);
                 let encrypted_key_bytes = conn
                     .query_row(
-                        "SELECT encrypted_key_bytes
+                        "SELECT encrypted_transparent_privkey
                          FROM ext_zallet_keystore_standalone_transparent_keys ztk
                          JOIN addresses a ON ztk.pubkey = a.imported_transparent_receiver_pubkey
                          WHERE a.cached_transparent_receiver_address = :address",
                         named_params! {
                             ":address": addr_str,
                         },
-                        |row| row.get::<_, Vec<u8>>("encrypted_key_bytes"),
+                        |row| row.get::<_, Vec<u8>>("encrypted_transparent_privkey"),
                     )
                     .map_err(|e| ErrorKind::Generic.context(e))?;
                 Ok(encrypted_key_bytes)


### PR DESCRIPTION
I think at some point there was a column rename for `ext_zallet_keystore_standalone_transparent_keys` (or a similar misunderstanding), which is causing an SQL error when running this SQL select statement.

The bug is verified by reading the schema definition and seeing the column is `encrypted_transparent_privkey`, while the SELECT query references `encrypted_key_bytes`. Note that other uses of `encrypted_key_bytes` (like the INSERT statements in other locations in this same file) happens to work because they use positional binding, which is likely why the bug wasn't caught. The writes succeeded, but the reads failed.