### PR TITLE
feat: COR-264 add z_shieldcoinbase to WalletRpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ be considered breaking changes.
   - `verifymessage`
   - `z_converttex`
   - `z_importaddress`
+  - `z_shieldcoinbase`
 
 ### Changed
 - `getrawtransaction` now correctly reports the fields `asm`, `reqSigs`, `kind`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ be considered breaking changes.
   `z_shieldcoinbase` (and any other consumer of
   `TransparentOutputFilter::CoinbaseOnly`) to correctly identify coinbase
   outputs.
-- `z_sendmany` and `z_shieldcoinbase` no longer fail with `Query returned no
-  rows` when a proposal includes inputs at HD-derived transparent addresses.
+- `z_sendmany` no longer fails with `Query returned no rows` when a proposal
+  includes inputs at HD-derived transparent addresses.
   The keystore's standalone-key decryption is now invoked only for addresses
   that were imported standalone; HD-derived addresses are signed for using
   the account's unified spending key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ be considered breaking changes.
   not defined.
 - Zallet now refuses to open wallet databases from incompatible earlier alpha
   releases instead of attempting to migrate them.
-- `z_sendmany` and `z_shieldcoinbase` no longer drop standalone transparent
-  signing keys when the same address backs multiple proposal inputs. Keys
-  are now accumulated per address rather than overwritten.
+- `z_sendmany` no longer drop standalone transparent signing keys when the same
+  address backs multiple proposal inputs. Keys are now accumulated per address
+  rather than overwritten.
 - Transparent UTXO ingestion now records `tx_index` for coinbase transactions
   by routing each observed transaction through `decrypt_and_store_transaction`
   in addition to `put_received_transparent_utxo`. This enables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ be considered breaking changes.
   `z_shieldcoinbase` (and any other consumer of
   `TransparentOutputFilter::CoinbaseOnly`) to correctly identify coinbase
   outputs.
+- `z_sendmany` and `z_shieldcoinbase` no longer fail with `Query returned no
+  rows` when a proposal includes inputs at HD-derived transparent addresses.
+  The keystore's standalone-key decryption is now invoked only for addresses
+  that were imported standalone; HD-derived addresses are signed for using
+  the account's unified spending key.
 
 ## [0.1.0-alpha.3] - 2025-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ be considered breaking changes.
   not defined.
 - Zallet now refuses to open wallet databases from incompatible earlier alpha
   releases instead of attempting to migrate them.
+- `z_sendmany` and `z_shieldcoinbase` no longer drop standalone transparent
+  signing keys when the same address backs multiple proposal inputs. Keys
+  are now accumulated per address rather than overwritten.
 
 ## [0.1.0-alpha.3] - 2025-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ be considered breaking changes.
 - `z_sendmany` and `z_shieldcoinbase` no longer drop standalone transparent
   signing keys when the same address backs multiple proposal inputs. Keys
   are now accumulated per address rather than overwritten.
+- Transparent UTXO ingestion now records `tx_index` for coinbase transactions
+  by routing each observed transaction through `decrypt_and_store_transaction`
+  in addition to `put_received_transparent_utxo`. This enables
+  `z_shieldcoinbase` (and any other consumer of
+  `TransparentOutputFilter::CoinbaseOnly`) to correctly identify coinbase
+  outputs.
 
 ## [0.1.0-alpha.3] - 2025-12-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "blake2b_simd",
  "core2 0.3.3",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7624,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -7637,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7689,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bitflags 2.10.0",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "core2 0.3.3",
  "hex",
@@ -7754,7 +7754,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8044,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "core2 0.3.3",
  "document-features",
@@ -8133,7 +8133,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bs58",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7038ff00277e308e641e3868f8c96cd5ea1b94db#7038ff00277e308e641e3868f8c96cd5ea1b94db"
+source = "git+https://github.com/zcash/librustzcash.git?branch=feat%2Fpropose_shielding-parameters#ebb626a538fa2e4070d5191b6edd108a22330916"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,8 +1768,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1805,8 +1804,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4195,7 +4193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4217,7 +4215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -7346,8 +7344,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -7360,8 +7357,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7413,8 +7409,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b99abb0e534b72705f49cb43d5f1a448844b49b9c48590f87888cb84ce6d29"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "bip32",
  "bitflags 2.10.0",
@@ -7459,8 +7454,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "corez",
  "hex",
@@ -7470,8 +7464,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7481,8 +7474,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7528,8 +7520,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7559,8 +7550,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7582,8 +7572,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "corez",
  "document-features",
@@ -7621,8 +7610,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "bip32",
  "bs58",
@@ -8096,8 +8084,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239#2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,18 +152,18 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "7038ff00277e308e641e3868f8c96cd5ea1b94db" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", branch = "feat/propose_shielding-parameters" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,24 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
+# TEMPORARY: Pin librustzcash crates to upstream main
+# (zcash/librustzcash@2c4e6c769c) so that we can consume the
+# `propose_shielding_coinbase` API (added in PR #2376) used by
+# `z_shieldcoinbase`. Drop this block when librustzcash crates are
+# released to crates.io at a version that includes that API.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2c4e6c769c2e70e71f14c9cf95f2dccfdb7ef239" }
+
 # TEMPORARY: All `core2` versions on crates.io were yanked by upstream on
 # 2026-04-14, breaking fresh dependency resolution because we still pull
 # `core2 ^0.3` (via `equihash 0.2.2`) and `core2 ^0.4` (via `zaino-state`)

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -293,21 +293,18 @@ impl MigrateZcashdWalletCmd {
         );
         let mut main_chain_block_heights = HashMap::new();
         if let Some(chain_subscriber) = chain_subscriber.as_ref() {
-            for (_, wallet_tx) in wallet.transactions().iter() {
+            for wallet_tx in wallet.transactions().values() {
                 let block_hash = BlockHash(*wallet_tx.hash_block().as_ref());
                 // Skip transactions that were unmined when the zcashd wallet was last written.
                 if block_hash.0 != [0; 32] {
                     if let Entry::Vacant(entry) = main_chain_block_heights.entry(block_hash) {
-                        match chain_subscriber
+                        // Ignore any blocks that are not in the main chain.
+                        if let GetBlockHeader::Verbose(header) = chain_subscriber
                             .get_block_header(block_hash.to_string(), true)
                             .await?
                         {
-                            GetBlockHeader::Verbose(header) => {
-                                entry.insert(BlockHeight::from_u32(header.height));
-                            }
-                            // Ignore any blocks that are not in the main chain.
-                            _ => (),
-                        };
+                            entry.insert(BlockHeight::from_u32(header.height));
+                        }
                     }
                 }
             }
@@ -464,7 +461,7 @@ impl MigrateZcashdWalletCmd {
                 wallet.unified_accounts().account_metadata.len()
             );
         }
-        for (_, account) in wallet.unified_accounts().account_metadata.iter() {
+        for account in wallet.unified_accounts().account_metadata.values() {
             // The only way that a unified account could be created in zcashd was
             // to be derived from the mnemonic seed, so we can safely unwrap here.
             let (seed, seed_fp) = mnemonic_seed_data

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -6,7 +6,8 @@ use std::time::SystemTime;
 use rand::rngs::OsRng;
 use secrecy::SecretVec;
 use shardtree::{ShardTree, error::ShardTreeError};
-use transparent::{address::TransparentAddress, bundle::OutPoint, keys::TransparentKeyScope};
+use transparent::{address::TransparentAddress, bundle::OutPoint};
+use zcash_client_backend::data_api::{TransparentKeyOrigin, TransparentOutputFilter};
 use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
@@ -335,7 +336,7 @@ impl WalletRead for DbConnection {
         account: Self::AccountId,
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
-    ) -> Result<HashMap<TransparentAddress, (TransparentKeyScope, Balance)>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, (TransparentKeyOrigin, Balance)>, Self::Error> {
         self.with(|db_data| {
             db_data.get_transparent_balances(account, target_height, confirmations_policy)
         })
@@ -427,15 +428,16 @@ impl InputSource for DbConnection {
     }
 
     fn get_spendable_transparent_outputs(
-        &self,
-        address: &TransparentAddress,
-        target_height: TargetHeight,
-        confirmations_policy: ConfirmationsPolicy,
-    ) -> Result<Vec<WalletUtxo>, Self::Error> {
-        self.with(|db_data| {
-            db_data.get_spendable_transparent_outputs(address, target_height, confirmations_policy)
-        })
-    }
+         &self,
+         address: &TransparentAddress,
+         target_height: TargetHeight,
+         confirmations_policy: ConfirmationsPolicy,
+         output_filter: TransparentOutputFilter,
+     ) -> Result<Vec<WalletUtxo>, Self::Error> {
+          self.with(|db_data| {
+              db_data.get_spendable_transparent_outputs(address, target_height, confirmations_policy, output_filter)
+          })
+      }
 
     fn get_account_metadata(
         &self,

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
@@ -13,9 +13,9 @@ use zcash_client_backend::{
         AccountBirthday, AccountMeta, AddressInfo, Balance, DecryptedTransaction, InputSource,
         NoteFilter, ORCHARD_SHARD_HEIGHT, ReceivedNotes, ReceivedTransactionOutput,
         SAPLING_SHARD_HEIGHT, TargetValue, TransparentKeyOrigin, TransparentOutputFilter,
-        WalletCommitmentTrees, WalletRead, WalletUtxo, WalletWrite, Zip32Derivation,
+        WalletCommitmentTrees, WalletRead, WalletWrite, Zip32Derivation,
         chain::ChainState,
-        error::FindAccountForAddressError,
+        error::{FindAccountForAddressError, RewindError},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
@@ -498,7 +498,7 @@ impl InputSource for DbConnection {
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
-    ) -> Result<Option<WalletUtxo>, Self::Error> {
+    ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| db_data.get_unspent_transparent_output(outpoint, target_height))
     }
 
@@ -508,7 +508,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: TransparentOutputFilter,
-    ) -> Result<Vec<WalletUtxo>, Self::Error> {
+    ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.get_spendable_transparent_outputs(
                 address,
@@ -627,7 +627,7 @@ impl WalletWrite for DbConnection {
 
     fn put_received_transparent_utxo(
         &mut self,
-        output: &WalletTransparentOutput,
+        output: &WalletTransparentOutput<Self::AccountId>,
     ) -> Result<Self::UtxoRef, Self::Error> {
         self.with_mut(|mut db_data| db_data.put_received_transparent_utxo(output))
     }
@@ -662,8 +662,14 @@ impl WalletWrite for DbConnection {
         self.with_mut(|mut db_data| db_data.truncate_to_chain_state(chain_state))
     }
 
-    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
-        self.with_mut(|mut db_data| db_data.rewind_to_height(max_height))
+    fn rewind_to_chain_state(
+        &mut self,
+        chain_state: ChainState,
+        reset_account_birthdays: HashSet<Self::AccountId>,
+    ) -> Result<(), RewindError<Self::AccountId, Self::Error>> {
+        self.with_mut(|mut db_data| {
+            db_data.rewind_to_chain_state(chain_state, reset_account_birthdays)
+        })
     }
 
     fn reserve_next_n_ephemeral_addresses(

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -543,26 +543,37 @@ pub(crate) trait WalletRpc {
     ) -> z_send_many::Response;
 
     /// Shields coinbase UTXOs by sending them from a transparent address (or all
-    /// wallet taddrs) to a shielded address.
+    /// wallet taddrs) to a shielded address within the same account.
     ///
     /// This is an asynchronous operation; it returns an operation ID that can
     /// be used with `z_getoperationstatus` or `z_getoperationresult`.
-    ///                                                                                                                     
-    /// # Arguments                                                                                                         
-    /// - `fromaddress` (string, required): The transparent address to sweep
-    ///   from, or `"*"` to sweep from all wallet taddrs.
-    /// - `toaddress` (string, required): The shielded address to receive the funds.                                        
-    /// - `fee` (numeric, optional): The fee amount in ZEC to attach to this
-    ///   transaction. If not provided, the default ZIP-317 fee is used.                                                                                                            
-    /// - `limit` (numeric, optional): Limit on the maximum number of UTXOs to
-    ///   shield. Set to 0 to use as many as will fit in the transaction.                                                                                                         
-    /// - `memo` (string, optional): Encoded as hex. This will be stored in the
-    ///   memo field of the new note.
+    ///
+    /// **Note:** This method's behavior differs from `zcashd`. The `toaddress`
+    /// must be a wallet-owned shielded address and is used to select the account
+    /// whose transparent UTXOs will be shielded. The resulting transaction sends
+    /// funds to the account's internal shielded address, which may differ from
+    /// `toaddress`. The `fromaddress` must also belong to the same account.
+    ///
+    /// # Arguments
+    /// - `fromaddress` (string, required): A wallet-owned transparent address to
+    ///   sweep from, or `"*"` to sweep from all taddrs belonging to the same
+    ///   account as `toaddress`. Must belong to the same account as `toaddress`.
+    /// - `toaddress` (string, required): A wallet-owned shielded address (Sapling,
+    ///   Orchard, or Unified with shielded receivers) used to identify the account.
+    ///   Funds are shielded into the account's internal shielded address, which may
+    ///   differ from this address.
+    /// - `fee` (optional): If provided, this parameter must be `null`; any
+    ///   non-null value will be rejected. The value of this field is ignored,
+    ///   as Zallet always calculates and applies the ZIP-317 fee internally.
+    /// - `limit` (numeric, optional): Accepted for compatibility but currently
+    ///   ignored; it does not constrain how many UTXOs are shielded.
+    /// - `memo` (string, optional): Accepted for compatibility but currently
+    ///   ignored; it is not stored in the memo field of any new note.
     /// - `privacy_policy` (string, optional): Policy for what information
-    ///   leakage is acceptable.                           
-    ///                                                                                                                     
-    /// # Returns                                                                                                           
-    /// - An operation ID for tracking the async operation.                                                                 
+    ///   leakage is acceptable.
+    ///
+    /// # Returns
+    /// - An operation ID for tracking the async operation.
     #[method(name = "z_shieldcoinbase")]
     async fn z_shieldcoinbase(
         &self,

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -1,3 +1,4 @@
+//! Contains general and wallet-specific RPC trait methods.
 use async_trait::async_trait;
 use jsonrpsee::{
     core::{JsonValue, RpcResult},
@@ -60,6 +61,8 @@ mod view_transaction;
 mod z_get_total_balance;
 #[cfg(zallet_build = "wallet")]
 mod z_send_many;
+#[cfg(zallet_build = "wallet")]
+mod z_shieldcoinbase;
 
 /// The general JSON-RPC interface, containing the methods provided in all Zallet builds.
 #[rpc(server)]
@@ -538,6 +541,38 @@ pub(crate) trait WalletRpc {
         fee: Option<JsonValue>,
         privacy_policy: Option<String>,
     ) -> z_send_many::Response;
+
+    /// Shields coinbase UTXOs by sending them from a transparent address (or all
+    /// wallet taddrs) to a shielded address.
+    ///
+    /// This is an asynchronous operation; it returns an operation ID that can
+    /// be used with `z_getoperationstatus` or `z_getoperationresult`.
+    ///                                                                                                                     
+    /// # Arguments                                                                                                         
+    /// - `fromaddress` (string, required): The transparent address to sweep
+    ///   from, or `"*"` to sweep from all wallet taddrs.
+    /// - `toaddress` (string, required): The shielded address to receive the funds.                                        
+    /// - `fee` (numeric, optional): The fee amount in ZEC to attach to this
+    ///   transaction. If not provided, the default ZIP-317 fee is used.                                                                                                            
+    /// - `limit` (numeric, optional): Limit on the maximum number of UTXOs to
+    ///   shield. Set to 0 to use as many as will fit in the transaction.                                                                                                         
+    /// - `memo` (string, optional): Encoded as hex. This will be stored in the
+    ///   memo field of the new note.
+    /// - `privacy_policy` (string, optional): Policy for what information
+    ///   leakage is acceptable.                           
+    ///                                                                                                                     
+    /// # Returns                                                                                                           
+    /// - An operation ID for tracking the async operation.                                                                 
+    #[method(name = "z_shieldcoinbase")]
+    async fn z_shieldcoinbase(
+        &self,
+        fromaddress: String,
+        toaddress: String,
+        fee: Option<JsonValue>,
+        limit: Option<u32>,
+        memo: Option<String>,
+        privacy_policy: Option<String>,
+    ) -> z_shieldcoinbase::Response;
 }
 
 pub(crate) struct RpcImpl {
@@ -546,7 +581,6 @@ pub(crate) struct RpcImpl {
     keystore: KeyStore,
     chain: Chain,
 }
-
 impl RpcImpl {
     /// Creates a new instance of the general RPC handler.
     pub(crate) fn new(
@@ -852,6 +886,33 @@ impl WalletRpcServer for WalletRpcImpl {
                     amounts,
                     minconf,
                     fee,
+                    privacy_policy,
+                )
+                .await?,
+            )
+            .await)
+    }
+
+    async fn z_shieldcoinbase(
+        &self,
+        fromaddress: String,
+        toaddress: String,
+        fee: Option<JsonValue>,
+        limit: Option<u32>,
+        memo: Option<String>,
+        privacy_policy: Option<String>,
+    ) -> z_shieldcoinbase::Response {
+        Ok(self
+            .start_async(
+                z_shieldcoinbase::call(
+                    self.wallet().await?,
+                    self.keystore.clone(),
+                    self.chain().await?,
+                    fromaddress,
+                    toaddress,
+                    fee,
+                    limit,
+                    memo,
                     privacy_policy,
                 )
                 .await?,

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -62,6 +62,8 @@ mod z_get_total_balance;
 mod z_import_address;
 #[cfg(zallet_build = "wallet")]
 mod z_send_many;
+#[cfg(zallet_build = "wallet")]
+mod z_shieldcoinbase;
 
 /// The general JSON-RPC interface, containing the methods provided in all Zallet builds.
 #[rpc(server)]
@@ -561,6 +563,50 @@ pub(crate) trait WalletRpc {
         fee: Option<JsonValue>,
         privacy_policy: Option<String>,
     ) -> z_send_many::Response;
+
+    /// Shields coinbase UTXOs by sending them from a transparent address (or all
+    /// wallet taddrs) to a shielded address within the same account.
+    ///
+    /// This is an asynchronous operation; it returns an operation ID that can
+    /// be used with `z_getoperationstatus` or `z_getoperationresult`.
+    ///
+    /// **Note:** This method's behavior differs from `zcashd`. The `toaddress`
+    /// must be a wallet-owned shielded address and is used to select the account
+    /// whose transparent UTXOs will be shielded. The resulting transaction sends
+    /// funds to the account's internal shielded address, which may differ from
+    /// `toaddress`. The `fromaddress` must also belong to the same account.
+    ///
+    /// # Arguments
+    /// - `fromaddress` (string, required): A wallet-owned transparent address to
+    ///   sweep from, or `"*"` to sweep from all taddrs belonging to the same
+    ///   account as `toaddress`. Must belong to the same account as `toaddress`.
+    /// - `toaddress` (string, required): A wallet-owned shielded address (Sapling,
+    ///   Orchard, or Unified with shielded receivers) used to identify the account.
+    ///   Funds are shielded into the account's internal shielded address, which may
+    ///   differ from this address.
+    /// - `fee` (optional): This parameter must be omitted or set to `null`;
+    ///   any other value will be rejected. When accepted, the value of this field
+    ///   is ignored, as Zallet always calculates and applies the ZIP-317 fee
+    ///   internally.
+    /// - `limit` (numeric, optional): Accepted for compatibility but currently
+    ///   ignored; it does not constrain how many UTXOs are shielded.
+    /// - `memo` (string, optional): Accepted for compatibility but currently
+    ///   ignored; it is not stored in the memo field of any new note.
+    /// - `privacy_policy` (string, optional): Policy for what information
+    ///   leakage is acceptable.
+    ///
+    /// # Returns
+    /// - An operation ID for tracking the async operation.
+    #[method(name = "z_shieldcoinbase")]
+    async fn z_shieldcoinbase(
+        &self,
+        fromaddress: String,
+        toaddress: String,
+        fee: Option<JsonValue>,
+        limit: Option<u32>,
+        memo: Option<String>,
+        privacy_policy: Option<String>,
+    ) -> z_shieldcoinbase::Response;
 }
 
 pub(crate) struct RpcImpl {
@@ -891,6 +937,33 @@ impl WalletRpcServer for WalletRpcImpl {
                     amounts,
                     minconf,
                     fee,
+                    privacy_policy,
+                )
+                .await?,
+            )
+            .await)
+    }
+
+    async fn z_shieldcoinbase(
+        &self,
+        fromaddress: String,
+        toaddress: String,
+        fee: Option<JsonValue>,
+        limit: Option<u32>,
+        memo: Option<String>,
+        privacy_policy: Option<String>,
+    ) -> z_shieldcoinbase::Response {
+        Ok(self
+            .start_async(
+                z_shieldcoinbase::call(
+                    self.wallet().await?,
+                    self.keystore.clone(),
+                    self.chain().await?,
+                    fromaddress,
+                    toaddress,
+                    fee,
+                    limit,
+                    memo,
                     privacy_policy,
                 )
                 .await?,

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -596,7 +596,16 @@ pub(crate) trait WalletRpc {
     ///   leakage is acceptable.
     ///
     /// # Returns
-    /// - An operation ID for tracking the async operation.
+    /// An object matching `zcashd`'s `z_shieldcoinbase` shape:
+    /// - `remainingUTXOs` (numeric): Number of coinbase UTXOs eligible for
+    ///   shielding that were not selected. Zallet currently ignores `limit`,
+    ///   so in practice this is `0` whenever the proposal succeeded.
+    /// - `remainingValue` (numeric, ZEC): Total value of those UTXOs.
+    /// - `shieldingUTXOs` (numeric): Number of coinbase UTXOs being shielded
+    ///   by this operation.
+    /// - `shieldingValue` (numeric, ZEC): Total value being shielded.
+    /// - `opid` (string): Operation id to pass to `z_getoperationstatus` or
+    ///   `z_getoperationresult` to retrieve the final result.
     #[method(name = "z_shieldcoinbase")]
     async fn z_shieldcoinbase(
         &self,
@@ -953,21 +962,19 @@ impl WalletRpcServer for WalletRpcImpl {
         memo: Option<String>,
         privacy_policy: Option<String>,
     ) -> z_shieldcoinbase::Response {
-        Ok(self
-            .start_async(
-                z_shieldcoinbase::call(
-                    self.wallet().await?,
-                    self.keystore.clone(),
-                    self.chain().await?,
-                    fromaddress,
-                    toaddress,
-                    fee,
-                    limit,
-                    memo,
-                    privacy_policy,
-                )
-                .await?,
-            )
-            .await)
+        let (preflight, context, fut) = z_shieldcoinbase::call(
+            self.wallet().await?,
+            self.keystore.clone(),
+            self.chain().await?,
+            fromaddress,
+            toaddress,
+            fee,
+            limit,
+            memo,
+            privacy_policy,
+        )
+        .await?;
+        let opid = self.start_async((context, fut)).await;
+        Ok(z_shieldcoinbase::ShieldCoinbaseResult::new(preflight, opid))
     }
 }

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -564,54 +564,65 @@ pub(crate) trait WalletRpc {
         privacy_policy: Option<String>,
     ) -> z_send_many::Response;
 
-    /// Shields coinbase UTXOs by sending them from a transparent address (or all
-    /// wallet taddrs) to a shielded address within the same account.
+    /// Shields coinbase UTXOs from a single wallet-owned source into a
+    /// shielded address.
     ///
-    /// This is an asynchronous operation; it returns an operation ID that can
-    /// be used with `z_getoperationstatus` or `z_getoperationresult`.
-    ///
-    /// **Note:** This method's behavior differs from `zcashd`. The `toaddress`
-    /// must be a wallet-owned shielded address and is used to select the account
-    /// whose transparent UTXOs will be shielded. The resulting transaction sends
-    /// funds to the account's internal shielded address, which may differ from
-    /// `toaddress`. The `fromaddress` must also belong to the same account.
+    /// This is an asynchronous operation; it returns an operation id that
+    /// can be used with `z_getoperationstatus` or `z_getoperationresult`.
     ///
     /// # Arguments
-    /// - `fromaddress` (string, required): A wallet-owned transparent address to
-    ///   sweep from, or `"*"` to sweep from all taddrs belonging to the same
-    ///   account as `toaddress`. Must belong to the same account as `toaddress`.
-    /// - `toaddress` (string, required): A wallet-owned shielded address (Sapling,
-    ///   Orchard, or Unified with shielded receivers) used to identify the account.
-    ///   Funds are shielded into the account's internal shielded address, which may
-    ///   differ from this address.
-    /// - `fee` (optional): This parameter must be omitted or set to `null`;
-    ///   any other value will be rejected. When accepted, the value of this field
-    ///   is ignored, as Zallet always calculates and applies the ZIP-317 fee
-    ///   internally.
-    /// - `limit` (numeric, optional): If supplied, caps the number of selected
-    ///   coinbase UTXOs to the highest-value `n` of those eligible. Recommended
-    ///   for wallets with many eligible coinbase UTXOs: without it, a single
-    ///   transaction is built containing all eligible UTXOs, which can exceed
-    ///   transaction-size limits at broadcast time. Zallet logs a warning (but
-    ///   does not enforce a hard cap) when the proposal selects more than ~400
-    ///   inputs.
-    /// - `memo` (string, optional): If supplied, stored in the memo field of
-    ///   the resulting shielded payment. Must be a hex-encoded string (up to
-    ///   1024 hex characters = 512 bytes).
+    /// - `fromaddress`: Either a single transparent address owned by this
+    ///   wallet, or an account UUID (string) to sweep every coinbase UTXO
+    ///   across that account's transparent receivers. Arrays of addresses
+    ///   are not accepted; pass the account UUID instead if you need to
+    ///   sweep across multiple receivers. Unlike `zcashd`, the wildcard
+    ///   `"*"` (sweep all wallet t-addrs) is rejected with an
+    ///   `InvalidParameter` error: cross-account sweeps would correlate
+    ///   otherwise-unrelated accounts on-chain, so callers must scope the
+    ///   sweep to a single account by passing its UUID.
+    /// - `toaddress`: Any Zcash shielded address (Sapling, Orchard, or
+    ///   Unified with a shielded receiver) that will receive the shielded
+    ///   funds. Need not belong to this wallet. Transparent / TEX
+    ///   destinations are rejected by the backend.
+    /// - `fee` (numeric, optional): If set, it must be null. Zallet always
+    ///   uses a fee calculated according to ZIP 317; the parameter is
+    ///   accepted for positional compatibility with `zcashd`'s
+    ///   `z_shieldcoinbase` only.
+    /// - `limit` (numeric, optional): If supplied, caps the number of
+    ///   selected coinbase UTXOs to the highest-value `n` of those
+    ///   eligible. Recommended for wallets with many eligible coinbase
+    ///   UTXOs: without it, a single transaction is built containing all
+    ///   eligible UTXOs, which can exceed transaction-size limits at
+    ///   broadcast time.
+    /// - `memo` (string, optional): If supplied, stored in the memo field
+    ///   of the resulting shielded payment. Hex-encoded, up to 1024 hex
+    ///   characters (= 512 bytes).
     /// - `privacy_policy` (string, optional): Policy for what information
-    ///   leakage is acceptable.
+    ///   leakage is acceptable. Coinbase shielding always reveals the
+    ///   source transparent address(es), so only two policy values are
+    ///   accepted:
+    ///   - `"AllowRevealedSenders"`: Allow revealing the source transparent
+    ///     address. Sufficient when sweeping from a single t-addr.
+    ///   - `"AllowLinkingAccountAddresses"`: Additionally allow linking
+    ///     multiple source t-addrs on-chain. Required when sweeping from
+    ///     an account UUID that expands to >1 transparent receiver with
+    ///     eligible coinbase UTXOs.
+    ///
+    ///   When omitted or `null`, the default is chosen from `fromaddress`:
+    ///   `"AllowRevealedSenders"` for a single t-addr, or
+    ///   `"AllowLinkingAccountAddresses"` for an account UUID. Any other
+    ///   policy name (including stricter values like `"FullPrivacy"` and
+    ///   looser ones like `"NoPrivacy"`) is rejected.
     ///
     /// # Returns
     /// An object matching `zcashd`'s `z_shieldcoinbase` shape:
-    /// - `remainingUTXOs` (numeric): Number of coinbase UTXOs eligible for
-    ///   shielding that were not selected. Non-zero when `limit` is smaller
-    ///   than the count of eligible coinbase UTXOs.
+    /// - `remainingUTXOs` (numeric): Eligible-but-not-selected coinbase UTXO
+    ///   count.
     /// - `remainingValue` (numeric, ZEC): Total value of those UTXOs.
-    /// - `shieldingUTXOs` (numeric): Number of coinbase UTXOs being shielded
-    ///   by this operation.
+    /// - `shieldingUTXOs` (numeric): Number of coinbase UTXOs being
+    ///   shielded by this operation.
     /// - `shieldingValue` (numeric, ZEC): Total value being shielded.
-    /// - `opid` (string): Operation id to pass to `z_getoperationstatus` or
-    ///   `z_getoperationresult` to retrieve the final result.
+    /// - `opid` (string): Operation id.
     #[method(name = "z_shieldcoinbase")]
     async fn z_shieldcoinbase(
         &self,

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -589,7 +589,12 @@ pub(crate) trait WalletRpc {
     ///   is ignored, as Zallet always calculates and applies the ZIP-317 fee
     ///   internally.
     /// - `limit` (numeric, optional): If supplied, caps the number of selected
-    ///   coinbase UTXOs to the highest-value `n` of those eligible.
+    ///   coinbase UTXOs to the highest-value `n` of those eligible. Recommended
+    ///   for wallets with many eligible coinbase UTXOs: without it, a single
+    ///   transaction is built containing all eligible UTXOs, which can exceed
+    ///   transaction-size limits at broadcast time. Zallet logs a warning (but
+    ///   does not enforce a hard cap) when the proposal selects more than ~400
+    ///   inputs.
     /// - `memo` (string, optional): If supplied, stored in the memo field of
     ///   the resulting shielded payment. Must be a hex-encoded string (up to
     ///   1024 hex characters = 512 bytes).

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -588,18 +588,19 @@ pub(crate) trait WalletRpc {
     ///   any other value will be rejected. When accepted, the value of this field
     ///   is ignored, as Zallet always calculates and applies the ZIP-317 fee
     ///   internally.
-    /// - `limit` (numeric, optional): Accepted for compatibility but currently
-    ///   ignored; it does not constrain how many UTXOs are shielded.
-    /// - `memo` (string, optional): Accepted for compatibility but currently
-    ///   ignored; it is not stored in the memo field of any new note.
+    /// - `limit` (numeric, optional): If supplied, caps the number of selected
+    ///   coinbase UTXOs to the highest-value `n` of those eligible.
+    /// - `memo` (string, optional): If supplied, stored in the memo field of
+    ///   the resulting shielded payment. Must be a hex-encoded string (up to
+    ///   1024 hex characters = 512 bytes).
     /// - `privacy_policy` (string, optional): Policy for what information
     ///   leakage is acceptable.
     ///
     /// # Returns
     /// An object matching `zcashd`'s `z_shieldcoinbase` shape:
     /// - `remainingUTXOs` (numeric): Number of coinbase UTXOs eligible for
-    ///   shielding that were not selected. Zallet currently ignores `limit`,
-    ///   so in practice this is `0` whenever the proposal succeeded.
+    ///   shielding that were not selected. Non-zero when `limit` is smaller
+    ///   than the count of eligible coinbase UTXOs.
     /// - `remainingValue` (numeric, ZEC): Total value of those UTXOs.
     /// - `shieldingUTXOs` (numeric): Number of coinbase UTXOs being shielded
     ///   by this operation.

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -12,8 +12,8 @@ use transparent::keys::TransparentKeyScope;
 use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
-        Account, AccountPurpose, InputSource, WalletRead,
         wallet::{ConfirmationsPolicy, TargetHeight},
+        Account, AccountPurpose, InputSource, TransparentOutputFilter, WalletRead,
     },
     encoding::AddressCodec,
     fees::{orchard::InputView as _, sapling::InputView as _},
@@ -27,7 +27,7 @@ use crate::components::{
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
-        utils::{JsonZec, parse_as_of_height, parse_minconf, value_from_zatoshis},
+        utils::{parse_as_of_height, parse_minconf, value_from_zatoshis, JsonZec},
     },
 };
 
@@ -192,7 +192,12 @@ pub(crate) fn call(
             .iter()
             .try_fold(vec![], |mut acc, (addr, _)| {
                 let mut outputs = wallet
-                    .get_spendable_transparent_outputs(addr, target_height, confirmations_policy)
+                    .get_spendable_transparent_outputs(
+                        addr,
+                        target_height,
+                        confirmations_policy,
+                        TransparentOutputFilter::All,
+                    )
                     .map_err(|e| {
                         RpcError::owned(
                             LegacyCode::Database.into(),

--- a/zallet/src/components/json_rpc/methods/view_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/view_transaction.rs
@@ -366,7 +366,7 @@ pub(crate) async fn call(
                     &format!(
                         "SELECT txid, {output_prefix}_index, accounts.uuid, address, value
                         FROM {pool_prefix}_received_notes rn
-                        JOIN transactions ON tx = id_tx
+                        JOIN transactions ON transaction_id = id_tx
                         JOIN accounts ON accounts.id = rn.account_id
                         LEFT OUTER JOIN addresses ON address_id = addresses.id
                         WHERE nf = :nf"
@@ -405,7 +405,7 @@ pub(crate) async fn call(
                 conn.query_row(
                     "SELECT to_address
                             FROM sent_notes
-                            JOIN transactions ON tx = id_tx
+                            JOIN transactions ON transaction_id = id_tx
                             WHERE txid = :txid
                             AND   output_pool = :output_pool
                             AND   output_index = :output_index",

--- a/zallet/src/components/json_rpc/methods/z_import_address.rs
+++ b/zallet/src/components/json_rpc/methods/z_import_address.rs
@@ -67,7 +67,8 @@ pub(crate) async fn call(
     };
 
     if rescan.unwrap_or(true) {
-        crate::components::sync::fetch_transparent_utxos(&chain, wallet)
+        let params = *wallet.params();
+        crate::components::sync::fetch_transparent_utxos(&chain, &params, wallet)
             .await
             .map_err(|e| LegacyCode::Misc.with_message(format!("Rescan failed: {e}")))?;
     }

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -132,11 +132,11 @@ pub(crate) async fn call(
         let memo = amount.memo.as_deref().map(parse_memo).transpose()?;
         let value = zatoshis_from_value(&amount.amount)?;
 
-        let payment =
-            Payment::new(addr, Some(value), memo, None, None, vec![]).ok_or_else(|| {
-                LegacyCode::InvalidParameter
-                    .with_static("Cannot send memo to transparent recipient")
-            })?;
+         let payment =
+             Payment::new(addr, Some(value), memo, None, None, vec![]).map_err(|_| {
+                 LegacyCode::InvalidParameter
+                     .with_static("Cannot send memo to transparent recipient")
+             })?;
 
         payments.push(payment);
         total_out = (total_out + value)

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -12,6 +12,8 @@ use zaino_state::FetchServiceSubscriber;
 use zcash_address::{ZcashAddress, unified};
 use zcash_client_backend::data_api::wallet::SpendingKeys;
 use zcash_client_backend::proposal::Proposal;
+#[cfg(feature = "transparent-key-import")]
+use zcash_client_backend::{data_api::WalletRead, wallet::TransparentAddressSource};
 use zcash_client_backend::{
     data_api::{
         Account,
@@ -365,6 +367,23 @@ pub(crate) async fn call(
 
     #[cfg(feature = "transparent-key-import")]
     let standalone_keys = {
+        // Determine which transparent receivers in this account were imported
+        // standalone (vs. HD-derived). Only those have an associated entry in
+        // the keystore's standalone-key table; HD-derived receivers are signed
+        // for using `usk` and must not be looked up via
+        // `decrypt_standalone_transparent_key` (which would error with
+        // `QueryReturnedNoRows`).
+        let standalone_addrs: HashSet<TransparentAddress> = wallet
+            .get_transparent_receivers(account.id(), true, true)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .into_iter()
+            .filter_map(|(addr, metadata)| match metadata.source() {
+                TransparentAddressSource::StandalonePubkey(_)
+                | TransparentAddressSource::StandaloneScript(_) => Some(addr),
+                TransparentAddressSource::Derived { .. } => None,
+            })
+            .collect();
+
         let mut keys: HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> = HashMap::new();
         for step in proposal.steps() {
             for input in step.transparent_inputs() {
@@ -373,6 +392,9 @@ pub(crate) async fn call(
                     .as_ref()
                     .and_then(TransparentAddress::from_script_from_chain)
                 {
+                    if !standalone_addrs.contains(&address) {
+                        continue;
+                    }
                     let secret_key = keystore
                         .decrypt_standalone_transparent_key(&address)
                         .await

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::num::NonZeroU32;
 
@@ -365,7 +365,7 @@ pub(crate) async fn call(
 
     #[cfg(feature = "transparent-key-import")]
     let standalone_keys = {
-        let mut keys = std::collections::HashMap::new();
+        let mut keys: HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> = HashMap::new();
         for step in proposal.steps() {
             for input in step.transparent_inputs() {
                 if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
@@ -385,7 +385,7 @@ pub(crate) async fn call(
                             }
                             _ => LegacyCode::Database.with_message(e.to_string()),
                         })?;
-                    keys.insert(address, vec![secret_key]);
+                    keys.entry(address).or_default().push(secret_key);
                 }
             }
         }

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::num::NonZeroU32;
 
@@ -12,8 +12,6 @@ use zaino_state::FetchServiceSubscriber;
 use zcash_address::{ZcashAddress, unified};
 use zcash_client_backend::data_api::wallet::SpendingKeys;
 use zcash_client_backend::proposal::Proposal;
-#[cfg(feature = "transparent-key-import")]
-use zcash_client_backend::{data_api::WalletRead, wallet::TransparentAddressSource};
 use zcash_client_backend::{
     data_api::{
         Account,
@@ -52,8 +50,8 @@ use crate::{
     prelude::*,
 };
 
-#[cfg(feature = "transparent-key-import")]
-use {transparent::address::TransparentAddress, zcash_script::script};
+#[cfg(feature = "zcashd-import")]
+use crate::components::json_rpc::utils::collect_standalone_transparent_keys;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub(crate) struct AmountParameter {
@@ -365,54 +363,10 @@ pub(crate) async fn call(
     )
     .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
-    #[cfg(feature = "transparent-key-import")]
-    let standalone_keys = {
-        // Determine which transparent receivers in this account were imported
-        // standalone (vs. HD-derived). Only those have an associated entry in
-        // the keystore's standalone-key table; HD-derived receivers are signed
-        // for using `usk` and must not be looked up via
-        // `decrypt_standalone_transparent_key` (which would error with
-        // `QueryReturnedNoRows`).
-        let standalone_addrs: HashSet<TransparentAddress> = wallet
-            .get_transparent_receivers(account.id(), true, true)
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-            .into_iter()
-            .filter_map(|(addr, metadata)| match metadata.source() {
-                TransparentAddressSource::StandalonePubkey(_)
-                | TransparentAddressSource::StandaloneScript(_) => Some(addr),
-                TransparentAddressSource::Derived { .. } => None,
-            })
-            .collect();
-
-        let mut keys: HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> = HashMap::new();
-        for step in proposal.steps() {
-            for input in step.transparent_inputs() {
-                if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
-                    .ok()
-                    .as_ref()
-                    .and_then(TransparentAddress::from_script_from_chain)
-                {
-                    if !standalone_addrs.contains(&address) {
-                        continue;
-                    }
-                    let secret_key = keystore
-                        .decrypt_standalone_transparent_key(&address)
-                        .await
-                        .map_err(|e| match e.kind() {
-                            // TODO: Improve internal error types.
-                            crate::error::ErrorKind::Generic
-                                if e.to_string() == "Wallet is locked" =>
-                            {
-                                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-                            }
-                            _ => LegacyCode::Database.with_message(e.to_string()),
-                        })?;
-                    keys.entry(address).or_default().push(secret_key);
-                }
-            }
-        }
-        keys
-    };
+    #[cfg(feature = "zcashd-import")]
+    let standalone_keys =
+        collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account.id(), &proposal)
+            .await?;
 
     // TODO: verify that the proposal satisfies the requested privacy policy
 
@@ -429,11 +383,10 @@ pub(crate) async fn call(
             wallet,
             chain,
             proposal,
-            SpendingKeys::new(
-                usk,
-                #[cfg(feature = "zcashd-import")]
-                standalone_keys,
-            ),
+            #[cfg(feature = "zcashd-import")]
+            SpendingKeys::new(usk, standalone_keys),
+            #[cfg(not(feature = "zcashd-import"))]
+            SpendingKeys::from_unified_spending_key(usk),
         ),
     ))
 }

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -11,7 +11,7 @@ use zaino_state::FetchServiceSubscriber;
 use zcash_address::unified;
 use zcash_client_backend::{
     data_api::{
-        Account, WalletRead,
+        Account, TransparentOutputFilter, WalletRead,
         wallet::{
             SpendingKeys, create_proposed_transactions, input_selection::GreedyInputSelector,
             propose_shielding,
@@ -206,18 +206,20 @@ pub(crate) async fn call(
 
     let input_selector = GreedyInputSelector::new();
 
-    // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding threshold
-    // to shield all available coinbase UTXOs.
-    let proposal = propose_shielding::<_, _, _, _, Infallible>(
-        wallet.as_mut(),
-        &params,
-        &input_selector,
-        &change_strategy,
-        Zatoshis::ZERO,
-        &from_addrs,
-        account.id(),
-        confirmations_policy,
-    )
+     // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding threshold
+     // to shield all available coinbase UTXOs. Passes TransparentOutputFilter::CoinbaseOnly
+     // to ensure only coinbase UTXOs are selected for shielding.
+     let proposal = propose_shielding::<_, _, _, _, Infallible>(
+         wallet.as_mut(),
+         &params,
+         &input_selector,
+         &change_strategy,
+         Zatoshis::ZERO,
+         &from_addrs,
+         account.id(),
+         confirmations_policy,
+         TransparentOutputFilter::CoinbaseOnly,
+     )
     // TODO: Map errors to `zcashd` shape.
     .map_err(|e| {
         LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -42,19 +42,22 @@ use crate::{
     prelude::*,
 };
 
-#[cfg(feature = "transparent-key-import")]
+#[cfg(feature = "zcashd-import")]
 use zcash_script::script;
 
 pub(crate) type ResultType = OperationId;
 pub(crate) type Response = RpcResult<ResultType>;
 
-pub(super) const PARAM_FROMADDRESS_DESC: &str =
-    "The transparent address to sweep from, or \"*\" to sweep from all wallet taddrs.";
-pub(super) const PARAM_TOADDRESS_DESC: &str = "The shielded address to receive the funds.";
-pub(super) const PARAM_FEE_DESC: &str = "If set, it must be null.";
-pub(super) const PARAM_LIMIT_DESC: &str = "Limit on the maximum number of UTXOs to shield. Set to 0 to use as many as will fit in the transaction.";
-pub(super) const PARAM_MEMO_DESC: &str =
-    "Encoded as hex. This will be stored in the memo field of the new note.";
+pub(super) const PARAM_FROMADDRESS_DESC: &str = "A wallet-owned transparent address to sweep from, or \"*\" to sweep from all taddrs \
+     belonging to the same account as toaddress. Must belong to the same account as toaddress.";
+pub(super) const PARAM_TOADDRESS_DESC: &str = "A wallet-owned shielded address used to identify the account. Funds are shielded into \
+     the account's internal shielded address, which may differ from this address.";
+pub(super) const PARAM_FEE_DESC: &str =
+    "If provided, must be null. Zallet always calculates and applies the ZIP-317 fee internally.";
+pub(super) const PARAM_LIMIT_DESC: &str = "Accepted for compatibility but currently ignored; does not constrain how many UTXOs are \
+     shielded.";
+pub(super) const PARAM_MEMO_DESC: &str = "Accepted for compatibility but currently ignored; not stored in the memo field of any new \
+     note.";
 pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
     "Policy for what information leakage is acceptable.";
 
@@ -129,7 +132,10 @@ pub(crate) async fn call(
     }
 
     // Look up the account that owns the destination address.
-    let account = get_account_for_address(wallet.as_ref(), &to_address)?;
+    let account = get_account_for_address(wallet.as_ref(), &to_address).map_err(|_| {
+        LegacyCode::InvalidAddressOrKey
+            .with_static("Invalid parameter: toaddress does not belong to this wallet.")
+    })?;
 
     // Resolve the transparent source addresses.
     // TODO(schell): When fromaddress is "*", we currently only sweep transparent
@@ -288,7 +294,7 @@ pub(crate) async fn call(
     )
     .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
-    #[cfg(feature = "transparent-key-import")]
+    #[cfg(feature = "zcashd-import")]
     let standalone_keys = {
         let mut keys = std::collections::HashMap::new();
         for step in proposal.steps() {
@@ -298,22 +304,20 @@ pub(crate) async fn call(
                     .as_ref()
                     .and_then(TransparentAddress::from_script_from_chain)
                 {
-                    // Try to look up a standalone imported key for this address.
-                    // If the address is HD-derived (not standalone imported), this
-                    // will fail because there's no entry in the standalone keys table.
-                    // In that case, skip it — the USK handles HD-derived keys.
-                    match keystore.decrypt_standalone_transparent_key(&address).await {
-                        Ok(secret_key) => {
-                            keys.insert(address, secret_key);
-                        }
-                        Err(e) if e.to_string() == "Wallet is locked" => {
-                            return Err(LegacyCode::WalletUnlockNeeded.with_message(e.to_string()));
-                        }
-                        Err(_) => {
-                            // Not a standalone imported key; HD-derived key will be
-                            // provided via the USK.
-                        }
-                    }
+                    let secret_key = keystore
+                        .decrypt_standalone_transparent_key(&address)
+                        .await
+                        .map_err(|e| match e.kind() {
+                            // TODO: Improve internal error types.
+                            //       https://github.com/zcash/wallet/issues/256
+                            crate::error::ErrorKind::Generic
+                                if e.to_string() == "Wallet is locked" =>
+                            {
+                                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+                            }
+                            _ => LegacyCode::Database.with_message(e.to_string()),
+                        })?;
+                    keys.insert(address, secret_key);
                 }
             }
         }

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -3,7 +3,6 @@
 use std::convert::Infallible;
 use std::future::Future;
 
-use abscissa_core::Application;
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
 use schemars::JsonSchema;

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -1,0 +1,379 @@
+//! Implementation of the `z_shieldcoinbase` RPC method.
+
+use std::convert::Infallible;
+use std::future::Future;
+
+use abscissa_core::Application;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use secrecy::ExposeSecret;
+use transparent::address::TransparentAddress;
+use zaino_state::FetchServiceSubscriber;
+use zcash_address::unified;
+use zcash_client_backend::{
+    data_api::{
+        Account, WalletRead,
+        wallet::{
+            SpendingKeys, create_proposed_transactions, input_selection::GreedyInputSelector,
+            propose_shielding,
+        },
+    },
+    fees::{DustOutputPolicy, StandardFeeRule, standard::MultiOutputChangeStrategy},
+    proposal::Proposal,
+    wallet::OvkPolicy,
+};
+use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
+use zcash_proofs::prover::LocalTxProver;
+use zcash_protocol::{PoolType, ShieldedProtocol, value::Zatoshis};
+
+use crate::{
+    components::{
+        database::DbHandle,
+        json_rpc::{
+            asyncop::{ContextInfo, OperationId},
+            payments::{
+                PrivacyPolicy, SendResult, broadcast_transactions, enforce_privacy_policy,
+                get_account_for_address,
+            },
+            server::LegacyCode,
+        },
+        keystore::KeyStore,
+    },
+    fl,
+    prelude::*,
+};
+
+#[cfg(feature = "transparent-key-import")]
+use zcash_script::script;
+
+pub(crate) type ResultType = OperationId;
+pub(crate) type Response = RpcResult<ResultType>;
+
+pub(super) const PARAM_FROMADDRESS_DESC: &str =
+    "The transparent address to sweep from, or \"*\" to sweep from all wallet taddrs.";
+pub(super) const PARAM_TOADDRESS_DESC: &str = "The shielded address to receive the funds.";
+pub(super) const PARAM_FEE_DESC: &str = "If set, it must be null.";
+pub(super) const PARAM_LIMIT_DESC: &str = "Limit on the maximum number of UTXOs to shield. Set to 0 to use as many as will fit in the transaction.";
+pub(super) const PARAM_MEMO_DESC: &str =
+    "Encoded as hex. This will be stored in the memo field of the new note.";
+pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
+    "Policy for what information leakage is acceptable.";
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn call(
+    mut wallet: DbHandle,
+    keystore: KeyStore,
+    chain: FetchServiceSubscriber,
+    fromaddress: String,
+    toaddress: String,
+    fee: Option<JsonValue>,
+    limit: Option<u32>,
+    memo: Option<String>,
+    privacy_policy: Option<String>,
+) -> RpcResult<(
+    Option<ContextInfo>,
+    impl Future<Output = RpcResult<SendResult>>,
+)> {
+    // Validate fee: Zallet always uses ZIP-317 fees internally.
+    if fee.is_some() {
+        return Err(LegacyCode::InvalidParameter
+            .with_static("Zallet always calculates fees internally; the fee field must be null."));
+    }
+
+    // Parse the privacy policy.
+    // Default to AllowRevealedSenders since shielding always reveals the transparent sender.
+    let privacy_policy = match privacy_policy.as_deref() {
+        Some("LegacyCompat") => Err(LegacyCode::InvalidParameter
+            .with_static("LegacyCompat privacy policy is unsupported in Zallet")),
+        Some(s) => PrivacyPolicy::from_str(s).ok_or_else(|| {
+            LegacyCode::InvalidParameter.with_message(format!("Unknown privacy policy {s}"))
+        }),
+        None => Ok(PrivacyPolicy::AllowRevealedSenders),
+    }?;
+
+    // TODO(schell): `propose_shielding` does not accept a memo parameter. The memo is
+    // accepted here for API compatibility but is currently ignored. Once the backend
+    // supports attaching a memo to shielding transactions, wire it through.
+    let _memo = memo;
+
+    // TODO(schell): `propose_shielding` does not support a UTXO limit parameter. The
+    // limit is accepted here for API compatibility but is currently ignored. Consider
+    // pre-filtering UTXOs or extending the backend API to support this.
+    let _limit = limit;
+
+    // Validate the destination address: must have at least one shielded receiver.
+    let to_address = Address::decode(wallet.params(), &toaddress).ok_or_else(|| {
+        LegacyCode::InvalidParameter.with_message(format!(
+            "Invalid parameter, unknown address format: {toaddress}"
+        ))
+    })?;
+
+    match &to_address {
+        Address::Transparent(_) | Address::Tex(_) => {
+            return Err(LegacyCode::InvalidParameter.with_static(
+                "Invalid parameter, toaddress must be a shielded address (Sapling, Orchard, or Unified with shielded receivers).",
+            ));
+        }
+        Address::Unified(ua) => {
+            let has_shielded = ua
+                .receiver_types()
+                .iter()
+                .any(|t| matches!(t, unified::Typecode::Sapling | unified::Typecode::Orchard));
+            if !has_shielded {
+                return Err(LegacyCode::InvalidParameter.with_static(
+                    "Invalid parameter, the provided Unified Address has no shielded receivers.",
+                ));
+            }
+        }
+        // Sapling addresses are always valid shielded destinations.
+        Address::Sapling(_) => {}
+    }
+
+    // Look up the account that owns the destination address.
+    let account = get_account_for_address(wallet.as_ref(), &to_address)?;
+
+    // Resolve the transparent source addresses.
+    // TODO(schell): When fromaddress is "*", we currently only sweep transparent
+    // addresses belonging to the same account as toaddress. Check with teammates
+    // whether "*" should sweep across all wallet accounts instead (matching zcashd's
+    // single-keypool model more closely).
+    let from_addrs: Vec<TransparentAddress> = if fromaddress == "*" {
+        wallet
+            .get_transparent_receivers(account.id(), true, true)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .into_keys()
+            .collect()
+    } else {
+        // Parse as a transparent address. z_shieldcoinbase only accepts transparent
+        // source addresses (or "*").
+        let from_address = Address::decode(wallet.params(), &fromaddress).ok_or_else(|| {
+            LegacyCode::InvalidAddressOrKey
+                .with_static("Invalid from address: should be a taddr or the string \"*\".")
+        })?;
+
+        let transparent_addr = match from_address {
+            Address::Transparent(addr) => addr,
+            _ => {
+                return Err(LegacyCode::InvalidAddressOrKey.with_static(
+                    "Invalid from address: z_shieldcoinbase only supports transparent source addresses.",
+                ));
+            }
+        };
+
+        // Verify the transparent address belongs to the same account as toaddress.
+        // TODO(schell): Check with teammates whether cross-account shielding should
+        // be supported. Currently propose_shielding takes a single to_account and
+        // the from_addrs must belong to that account for key derivation to work.
+        let from_account =
+            get_account_for_address(wallet.as_ref(), &Address::Transparent(transparent_addr))?;
+        if from_account.id() != account.id() {
+            return Err(LegacyCode::InvalidParameter.with_static(
+                "Invalid parameter: fromaddress and toaddress must belong to the same account.",
+            ));
+        }
+
+        vec![transparent_addr]
+    };
+
+    if from_addrs.is_empty() {
+        return Err(
+            LegacyCode::InvalidParameter.with_static("No transparent addresses found to shield.")
+        );
+    }
+
+    // Set up confirmations policy from the wallet configuration.
+    let confirmations_policy = APP.config().builder.confirmations_policy().map_err(|_| {
+        LegacyCode::Wallet.with_message(
+            "Configuration error: minimum confirmations for spending trusted TXOs \
+             cannot exceed that for untrusted TXOs.",
+        )
+    })?;
+
+    let params = *wallet.params();
+
+    let change_strategy = MultiOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedProtocol::Orchard,
+        DustOutputPolicy::default(),
+        APP.config().note_management.split_policy(),
+    );
+
+    let input_selector = GreedyInputSelector::new();
+
+    // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding threshold
+    // to shield all available coinbase UTXOs.
+    let proposal = propose_shielding::<_, _, _, _, Infallible>(
+        wallet.as_mut(),
+        &params,
+        &input_selector,
+        &change_strategy,
+        Zatoshis::ZERO,
+        &from_addrs,
+        account.id(),
+        confirmations_policy,
+    )
+    // TODO: Map errors to `zcashd` shape.
+    .map_err(|e| {
+        LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
+    })?;
+
+    enforce_privacy_policy(&proposal, privacy_policy)?;
+
+    // Check Orchard action limits.
+    let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
+    for step in proposal.steps() {
+        let orchard_spends = step
+            .shielded_inputs()
+            .iter()
+            .flat_map(|inputs| inputs.notes())
+            .filter(|note| note.note().protocol() == ShieldedProtocol::Orchard)
+            .count();
+
+        let orchard_outputs = step
+            .payment_pools()
+            .values()
+            .filter(|pool| pool == &&PoolType::ORCHARD)
+            .count()
+            + step
+                .balance()
+                .proposed_change()
+                .iter()
+                .filter(|change| change.output_pool() == PoolType::ORCHARD)
+                .count();
+
+        let orchard_actions = orchard_spends.max(orchard_outputs);
+
+        if orchard_actions > orchard_actions_limit {
+            let (count, kind) = if orchard_outputs <= orchard_actions_limit {
+                (orchard_spends, "inputs")
+            } else if orchard_spends <= orchard_actions_limit {
+                (orchard_outputs, "outputs")
+            } else {
+                (orchard_actions, "actions")
+            };
+
+            return Err(LegacyCode::Misc.with_message(fl!(
+                "err-excess-orchard-actions",
+                count = count,
+                kind = kind,
+                limit = orchard_actions_limit,
+                config = "-orchardactionlimit=N",
+                bound = format!("N >= %u"),
+            )));
+        }
+    }
+
+    // Derive the spending key for the account.
+    let derivation = account.source().key_derivation().ok_or_else(|| {
+        LegacyCode::InvalidAddressOrKey
+            .with_static("Invalid address, no payment source found for account.")
+    })?;
+
+    // Fetch spending key last, to avoid a keystore decryption if unnecessary.
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            // TODO: Improve internal error types.
+            //       https://github.com/zcash/wallet/issues/256
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+    let usk = UnifiedSpendingKey::from_seed(
+        wallet.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+
+    #[cfg(feature = "transparent-key-import")]
+    let standalone_keys = {
+        let mut keys = std::collections::HashMap::new();
+        for step in proposal.steps() {
+            for input in step.transparent_inputs() {
+                if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
+                    .ok()
+                    .as_ref()
+                    .and_then(TransparentAddress::from_script_from_chain)
+                {
+                    // Try to look up a standalone imported key for this address.
+                    // If the address is HD-derived (not standalone imported), this
+                    // will fail because there's no entry in the standalone keys table.
+                    // In that case, skip it — the USK handles HD-derived keys.
+                    match keystore.decrypt_standalone_transparent_key(&address).await {
+                        Ok(secret_key) => {
+                            keys.insert(address, secret_key);
+                        }
+                        Err(e) if e.to_string() == "Wallet is locked" => {
+                            return Err(LegacyCode::WalletUnlockNeeded.with_message(e.to_string()));
+                        }
+                        Err(_) => {
+                            // Not a standalone imported key; HD-derived key will be
+                            // provided via the USK.
+                        }
+                    }
+                }
+            }
+        }
+        keys
+    };
+
+    Ok((
+        Some(ContextInfo::new(
+            "z_shieldcoinbase",
+            serde_json::json!({
+                "fromaddress": fromaddress,
+                "toaddress": toaddress,
+                "limit": _limit,
+            }),
+        )),
+        run(
+            wallet,
+            chain,
+            proposal,
+            SpendingKeys::new(
+                usk,
+                #[cfg(feature = "zcashd-import")]
+                standalone_keys,
+            ),
+        ),
+    ))
+}
+
+/// Construct and broadcast the shielding transaction.
+///
+/// Notes:
+/// 1. Spendable notes/UTXOs are not locked, so an operation running in parallel
+///    could also try to use them.
+async fn run(
+    mut wallet: DbHandle,
+    chain: FetchServiceSubscriber,
+    proposal: Proposal<StandardFeeRule, Infallible>,
+    spending_keys: SpendingKeys,
+) -> RpcResult<SendResult> {
+    let prover = LocalTxProver::bundled();
+    let (wallet, txids) = crate::spawn_blocking!("z_shieldcoinbase runner", move || {
+        let params = *wallet.params();
+        create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+            wallet.as_mut(),
+            &params,
+            &prover,
+            &prover,
+            &spending_keys,
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .map(|txids| (wallet, txids))
+    })
+    .await
+    .map_err(|e| {
+        LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
+    })?
+    .map_err(|e| {
+        LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
+    })?;
+
+    broadcast_transactions(&wallet, chain, txids.into()).await
+}

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -9,33 +9,33 @@ use schemars::JsonSchema;
 use secrecy::ExposeSecret;
 use serde::Serialize;
 use transparent::address::TransparentAddress;
+use uuid::Uuid;
 use zaino_state::FetchServiceSubscriber;
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
-        Account, InputSource, TransparentOutputFilter, WalletRead,
+        Account as _, InputSource, TransparentOutputFilter, WalletRead,
         wallet::{
-            SpendingKeys, create_proposed_transactions, input_selection::GreedyInputSelector,
-            propose_shielding_coinbase,
+            ConfirmationsPolicy, SpendingKeys, TargetHeight, create_proposed_transactions,
+            input_selection::GreedyInputSelector, propose_shielding_coinbase,
         },
     },
     fees::StandardFeeRule,
     proposal::Proposal,
     wallet::OvkPolicy,
 };
+use zcash_client_sqlite::AccountUuid;
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::Zatoshis;
 
+use crate::components::json_rpc::payments::enforce_privacy_policy;
 use crate::{
     components::{
-        database::DbHandle,
+        database::{DbConnection, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
-            payments::{
-                PrivacyPolicy, SendResult, broadcast_transactions, enforce_privacy_policy,
-                get_account_for_address, parse_memo,
-            },
+            payments::{PrivacyPolicy, SendResult, broadcast_transactions, parse_memo},
             server::LegacyCode,
             utils::{JsonZec, value_from_zatoshis},
         },
@@ -44,8 +44,8 @@ use crate::{
     prelude::*,
 };
 
-#[cfg(feature = "transparent-key-import")]
-use zcash_script::script;
+#[cfg(feature = "zcashd-import")]
+use crate::components::json_rpc::utils::collect_standalone_transparent_keys;
 
 /// The result of a `z_shieldcoinbase` pre-flight call.
 ///
@@ -93,6 +93,9 @@ impl ShieldCoinbaseResult {
     }
 }
 
+pub(crate) type ResultType = ShieldCoinbaseResult;
+pub(crate) type Response = RpcResult<ResultType>;
+
 /// Pre-flight numeric fields, computed before the async portion runs.
 ///
 /// Held as a separate type so that the [`OperationId`] (only available after
@@ -105,24 +108,28 @@ pub(crate) struct Preflight {
     pub(super) shielding_value: JsonZec,
 }
 
-pub(crate) type ResultType = ShieldCoinbaseResult;
-pub(crate) type Response = RpcResult<ResultType>;
-
-pub(super) const PARAM_FROMADDRESS_DESC: &str = "A wallet-owned transparent address to sweep from, or \"*\" to sweep from all taddrs \
-     belonging to the same account as toaddress. Must belong to the same account as toaddress.";
-pub(super) const PARAM_TOADDRESS_DESC: &str = "A wallet-owned shielded address used to identify the account. Funds are shielded into \
-     the account's internal shielded address, which may differ from this address.";
+pub(super) const PARAM_FROMADDRESS_DESC: &str = "Source of coinbase UTXOs to shield. Either a single transparent address owned by this \
+     wallet, or an account UUID to sweep every coinbase UTXO across that account's transparent \
+     receivers. Unlike `zcashd`, the wildcard `\"*\"` (sweep all wallet t-addrs) is rejected: \
+     scope the sweep to a single account by passing its UUID.";
+pub(super) const PARAM_TOADDRESS_DESC: &str = "Any Zcash shielded address (Sapling, Orchard, or Unified with a shielded receiver) that \
+     will receive the shielded funds. Need not belong to this wallet. Transparent or TEX \
+     destinations are rejected.";
 pub(super) const PARAM_FEE_DESC: &str =
     "If provided, must be null. Zallet always calculates and applies the ZIP-317 fee internally.";
 pub(super) const PARAM_LIMIT_DESC: &str = "If supplied, caps the number of selected coinbase UTXOs to the highest-value `n` of those \
      eligible. Recommended for wallets with many eligible coinbase UTXOs: without it, a single \
      transaction is built containing all eligible UTXOs, which can exceed transaction-size \
-     limits at broadcast time. Zallet logs a warning (but does not enforce a hard cap) when \
-     the proposal selects more than ~400 inputs.";
+     limits at broadcast time.";
 pub(super) const PARAM_MEMO_DESC: &str = "If supplied, stored in the memo field of the resulting shielded payment. Must be a \
      hex-encoded string (up to 1024 hex characters = 512 bytes).";
-pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
-    "Policy for what information leakage is acceptable.";
+pub(super) const PARAM_PRIVACY_POLICY_DESC: &str = "Policy for what information leakage is acceptable. May be omitted or set to null to use a \
+     default chosen from `fromaddress`: `AllowRevealedSenders` when `fromaddress` is a single \
+     transparent address, `AllowLinkingAccountAddresses` when it is an account UUID. \
+     If provided explicitly, must be one of `AllowRevealedSenders` or \
+     `AllowLinkingAccountAddresses`; any other value is rejected. Coinbase shielding always \
+     reveals the source transparent address(es), so policies stricter than `AllowRevealedSenders` \
+     cannot be satisfied.";
 
 /// Soft threshold above which [`call`] emits a `warn!` log about potential
 /// transaction-size issues at broadcast time.
@@ -158,105 +165,40 @@ pub(crate) async fn call(
             .with_static("Zallet always calculates fees internally; the fee field must be null."));
     }
 
-    // Parse the privacy policy.
-    // Default to AllowRevealedSenders since shielding always reveals the transparent sender.
-    let privacy_policy = match privacy_policy.as_deref() {
-        Some("LegacyCompat") => Err(LegacyCode::InvalidParameter
-            .with_static("LegacyCompat privacy policy is unsupported in Zallet")),
-        Some(s) => PrivacyPolicy::from_str(s).ok_or_else(|| {
-            LegacyCode::InvalidParameter.with_message(format!("Unknown privacy policy {s}"))
-        }),
-        None => Ok(PrivacyPolicy::AllowRevealedSenders),
-    }?;
-
-    // Parse the memo parameter (hex-encoded). The backend will attach it to the
-    // resulting shielded payment. The backend rejects memos longer than 512 bytes
-    // by way of `MemoBytes::from_bytes`.
-    let memo = memo.as_deref().map(parse_memo).transpose()?;
-
-    // The `limit` parameter caps the number of selected coinbase UTXOs to the
-    // highest-value `n` of those eligible.
-    let limit_usize = limit.map(|n| n as usize);
-
-    // Parse and validate the destination address. We need both:
-    // - a `ZcashAddress` to pass to `propose_shielding_coinbase` (the backend's
-    //   shielded-receiver enforcement runs against this value).
-    // - a `zcash_keys::address::Address` to call `get_account_for_address` and
-    //   anchor the zallet-level same-account constraint: zallet's
-    //   `z_shieldcoinbase` requires `toaddress` to belong to a wallet account
-    //   (matching `zcashd`'s behavior), on top of the backend's requirement
-    //   that it be shielded.
-    let to_address = Address::decode(wallet.params(), &toaddress).ok_or_else(|| {
-        LegacyCode::InvalidParameter.with_message(format!(
-            "Invalid parameter, unknown address format: {toaddress}"
-        ))
-    })?;
+    // Parse the destination address.
     let to_zcash_address: ZcashAddress = toaddress.parse().map_err(|_| {
         LegacyCode::InvalidParameter.with_message(format!(
             "Invalid parameter, unknown address format: {toaddress}"
         ))
     })?;
 
-    // Look up the account that owns the destination address. This enforces the
-    // zallet-level "same account" requirement; the backend additionally
-    // enforces "must be a shielded address" via
-    // `ProposalError::ShieldingRequiresShieldedRecipient`.
-    let account = get_account_for_address(wallet.as_ref(), &to_address)?;
+    // Parse the memo parameter (hex-encoded).
+    let memo = memo.as_deref().map(parse_memo).transpose()?;
+    let limit_usize = limit.map(|n| n as usize);
 
-    // Resolve the transparent source addresses.
-    let from_addrs: Vec<TransparentAddress> = if fromaddress == "*" {
-        wallet
-            .get_transparent_receivers(account.id(), true, true)
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-            .into_keys()
-            .collect()
-    } else {
-        // Parse as a transparent address. z_shieldcoinbase only accepts transparent
-        // source addresses (or "*").
-        let from_address = Address::decode(wallet.params(), &fromaddress).ok_or_else(|| {
-            LegacyCode::InvalidAddressOrKey
-                .with_static("Invalid from address: should be a taddr or the string \"*\".")
-        })?;
+    // Classify `fromaddress` before touching the DB, so we can use its shape
+    // (single t-addr vs account UUID) to pick the default privacy policy.
+    let from_input = parse_fromaddress(wallet.as_ref().params(), &fromaddress)?;
+    let privacy_policy = parse_privacy_policy(privacy_policy.as_deref(), &from_input)?;
 
-        let transparent_addr: TransparentAddress = match from_address {
-            Address::Transparent(addr) => addr,
-            // Don't allow tex addresses, just as zcashd doesn't allow tex addresses.
-            // It would mostly likely be a mistake if the user specifies a tex address here, so we'll err.
-            _ => {
-                return Err(LegacyCode::InvalidAddressOrKey.with_static(
-                    "Invalid from address: z_shieldcoinbase only supports transparent source addresses.",
-                ));
-            }
-        };
-
-        // Verify the transparent address belongs to the same account as toaddress.
-        let from_account =
-            get_account_for_address(wallet.as_ref(), &Address::Transparent(transparent_addr))?;
-        if from_account.id() != account.id() {
-            return Err(LegacyCode::InvalidParameter.with_static(
-                "Invalid parameter: fromaddress and toaddress must belong to the same account.",
-            ));
-        }
-
-        vec![transparent_addr]
-    };
+    // Resolve `fromaddress` to the source account + its source transparent
+    // addresses (one address for a t-addr input, all account receivers for a
+    // UUID input).
+    let (account_id, from_addrs) = resolve_fromaddress_input(wallet.as_ref(), &from_input)?;
 
     if from_addrs.is_empty() {
-        return Err(
-            LegacyCode::InvalidParameter.with_static("No transparent addresses found to shield.")
-        );
+        return Err(LegacyCode::InvalidParameter
+            .with_static("No source transparent addresses resolved from `fromaddress`."));
     }
 
-    // Set up confirmations policy from the wallet configuration.
-    let confirmations_policy = APP.config().builder.confirmations_policy().map_err(|_| {
-        LegacyCode::Wallet.with_message(
-            "Configuration error: minimum confirmations for spending trusted TXOs \
-             cannot exceed that for untrusted TXOs.",
-        )
-    })?;
+    let account = wallet
+        .get_account(account_id)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| {
+            LegacyCode::Database.with_message(format!("Account vanished mid-call: {account_id:?}"))
+        })?;
 
     let params = *wallet.params();
-
     let input_selector = GreedyInputSelector::new();
 
     // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding
@@ -281,59 +223,26 @@ pub(crate) async fn call(
         LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
     })?;
 
+    // Coinbase shielding always reveals the transparent sender(s); when the proposal selects
+    // from multiple source addresses (an account UUID expanded to >1 receivers that all hold
+    // eligible coinbase UTXOs) it also links those addresses on-chain. The privacy policy
+    // parsed above bounds which of these leakages the caller is willing to accept;
+    // `enforce_privacy_policy` rejects the proposal if it requires more than the caller permitted.
     enforce_privacy_policy(&proposal, privacy_policy)?;
 
-    // Compute the `zcashd`-shape pre-flight numbers.
+    // Pre-flight numerics. We compute `remaining_*` by enumerating all eligible coinbase UTXOs
+    // (`total_*`) and subtracting the ones the proposal selected (`shielding_*`). The
+    // enumeration is fragile (chain races; see the `checked_sub` errors below) and only exists
+    // because the wallet backend does not yet expose "give me only the unlocked outputs".
     //
-    // `shielding_*` is what the proposal will spend; we sum directly over the
-    // proposal's selected transparent inputs.
-    //
-    // `remaining_*` is what was eligible-but-not-selected. We re-enumerate the
-    // spendable coinbase UTXOs for `from_addrs` at the same target height the
-    // proposal used and subtract.
-    //
-    // RACE NOTE: Between `propose_shielding` (above) and the enumeration
-    // below, a new block could land and either advance maturity (adding new
-    // eligible UTXOs) or invalidate previously-eligible ones via reorg. In
-    // the first case `total_value` only inflates, leaving
-    // `shielding_value <= total_value`; the subtraction is safe and
-    // `remaining_*` will harmlessly over-count by the freshly-mature outputs.
-    // In the (rare) reorg case, `shielding_value > total_value` is possible.
-    // We treat that as an internal error and abort before registering the
-    // opid, so no half-state is exposed to the caller.
-    let mut shielding_utxos: u64 = 0;
-    let mut shielding_value_zats = Zatoshis::ZERO;
-    for step in proposal.steps() {
-        for utxo in step.transparent_inputs() {
-            shielding_utxos = shielding_utxos.saturating_add(1);
-            shielding_value_zats = (shielding_value_zats + utxo.value()).ok_or_else(|| {
-                LegacyCode::Wallet
-                    .with_static("Internal error: shielding value sum overflowed Zatoshis bounds.")
-            })?;
-        }
-    }
-
+    // TODO: once note/utxo locking lands upstream (blocked on
+    // https://github.com/zcash/librustzcash/issues/2161), drop the enumeration + subtraction
+    // and read `remaining_utxos`/`remaining_value` directly by querying the wallet for the
+    // outputs that the proposal left unlocked.
+    let (shielding_utxos, shielding_value_zats) = sum_selected_inputs(&proposal)?;
     let target_height = proposal.min_target_height();
-    let mut total_utxos: u64 = 0;
-    let mut total_value_zats = Zatoshis::ZERO;
-    for addr in &from_addrs {
-        let utxos = wallet
-            .get_spendable_transparent_outputs(
-                addr,
-                target_height,
-                confirmations_policy,
-                TransparentOutputFilter::CoinbaseOnly,
-            )
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
-        total_utxos = total_utxos.saturating_add(utxos.len() as u64);
-        for utxo in utxos {
-            total_value_zats = (total_value_zats + utxo.value()).ok_or_else(|| {
-                LegacyCode::Wallet.with_static(
-                    "Internal error: total transparent value overflowed Zatoshis bounds.",
-                )
-            })?;
-        }
-    }
+    let (total_utxos, total_value_zats) =
+        enumerate_eligible(wallet.as_mut(), &from_addrs, target_height)?;
 
     let remaining_utxos = total_utxos.checked_sub(shielding_utxos).ok_or_else(|| {
         LegacyCode::Wallet.with_static(
@@ -343,17 +252,10 @@ pub(crate) async fn call(
     })?;
     let remaining_value_zats = (total_value_zats - shielding_value_zats).ok_or_else(|| {
         LegacyCode::Wallet.with_static(
-            "Internal accounting error: proposal value exceeds enumerated \
-                 total (likely a chain race during shielding setup).",
+            "Internal accounting error: proposal value exceeds enumerated total \
+             (likely a chain race during shielding setup).",
         )
     })?;
-
-    let preflight = Preflight {
-        remaining_utxos,
-        remaining_value: value_from_zatoshis(remaining_value_zats),
-        shielding_utxos,
-        shielding_value: value_from_zatoshis(shielding_value_zats),
-    };
 
     // Only warn when the caller did not constrain the batch themselves; if
     // `limit` was supplied, the caller has already opted into a specific batch
@@ -368,19 +270,24 @@ pub(crate) async fn call(
         );
     }
 
-    // Derive the spending key for the account.
-    let derivation = account.source().key_derivation().ok_or_else(|| {
-        LegacyCode::InvalidAddressOrKey
-            .with_static("Invalid address, no payment source found for account.")
-    })?;
+    let preflight = Preflight {
+        remaining_utxos,
+        remaining_value: value_from_zatoshis(remaining_value_zats),
+        shielding_utxos,
+        shielding_value: value_from_zatoshis(shielding_value_zats),
+    };
 
-    // Fetch spending key last, to avoid a keystore decryption if unnecessary.
+    // Derive the spending key for the source account.
+    let derivation = account.source().key_derivation().ok_or_else(|| {
+        LegacyCode::InvalidAddressOrKey.with_message(format!(
+            "No payment source found for account {}.",
+            account_id.expose_uuid(),
+        ))
+    })?;
     let seed = keystore
         .decrypt_seed(derivation.seed_fingerprint())
         .await
         .map_err(|e| match e.kind() {
-            // TODO: Improve internal error types.
-            //       https://github.com/zcash/wallet/issues/256
             crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
                 LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
             }
@@ -393,57 +300,10 @@ pub(crate) async fn call(
     )
     .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
-    #[cfg(feature = "transparent-key-import")]
-    let standalone_keys = {
-        // Determine which transparent receivers in this account were imported
-        // standalone (vs. HD-derived). Only those have an associated entry in
-        // the keystore's standalone-key table; HD-derived receivers are signed
-        // for using `usk` and must not be looked up via
-        // `decrypt_standalone_transparent_key` (which would error with
-        // `QueryReturnedNoRows`).
-        use zcash_client_backend::wallet::TransparentAddressSource;
-        let standalone_addrs: std::collections::HashSet<TransparentAddress> = wallet
-            .get_transparent_receivers(account.id(), true, true)
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-            .into_iter()
-            .filter_map(|(addr, metadata)| match metadata.source() {
-                TransparentAddressSource::StandalonePubkey(_)
-                | TransparentAddressSource::StandaloneScript(_) => Some(addr),
-                TransparentAddressSource::Derived { .. } => None,
-            })
-            .collect();
-
-        let mut keys: std::collections::HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> =
-            std::collections::HashMap::new();
-        for step in proposal.steps() {
-            for input in step.transparent_inputs() {
-                if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
-                    .ok()
-                    .as_ref()
-                    .and_then(TransparentAddress::from_script_from_chain)
-                {
-                    if !standalone_addrs.contains(&address) {
-                        continue;
-                    }
-                    let secret_key = keystore
-                        .decrypt_standalone_transparent_key(&address)
-                        .await
-                        .map_err(|e| match e.kind() {
-                            // TODO: Improve internal error types.
-                            //       https://github.com/zcash/wallet/issues/256
-                            crate::error::ErrorKind::Generic
-                                if e.to_string() == "Wallet is locked" =>
-                            {
-                                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-                            }
-                            _ => LegacyCode::Database.with_message(e.to_string()),
-                        })?;
-                    keys.entry(address).or_default().push(secret_key);
-                }
-            }
-        }
-        keys
-    };
+    #[cfg(feature = "zcashd-import")]
+    let standalone_keys =
+        collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account_id, &proposal)
+            .await?;
 
     Ok((
         preflight,
@@ -459,20 +319,186 @@ pub(crate) async fn call(
             wallet,
             chain,
             proposal,
-            SpendingKeys::new(
-                usk,
-                #[cfg(feature = "zcashd-import")]
-                standalone_keys,
-            ),
+            #[cfg(feature = "zcashd-import")]
+            SpendingKeys::new(usk, standalone_keys),
+            #[cfg(not(feature = "zcashd-import"))]
+            SpendingKeys::from_unified_spending_key(usk),
         ),
     ))
 }
 
-/// Construct and broadcast the shielding transaction.
+/// Classified form of the `fromaddress` parameter. Pure-function output of
+/// [`parse_fromaddress`], split out from the DB-touching
+/// [`resolve_fromaddress_input`] so the parsing rules can be unit-tested.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum FromAddressInput {
+    /// An account UUID: sweep every transparent receiver in this account.
+    AccountUuid(Uuid),
+    /// A wallet-owned transparent address: shield coinbase UTXOs at exactly
+    /// this address.
+    TransparentAddress(TransparentAddress),
+}
+
+/// Classify the string form of `fromaddress` as either an account UUID or a
+/// transparent address, without touching the wallet database.
 ///
-/// Notes:
-/// 1. Spendable notes/UTXOs are not locked, so an operation running in parallel
-///    could also try to use them.
+/// UUIDs and Zcash transparent addresses use disjoint string forms (UUIDs are
+/// hex with dashes at fixed positions; transparent addresses are base58check
+/// with a leading `t1` / `t2` / `t3` / `tm`), so the parse order is safe.
+pub(super) fn parse_fromaddress(
+    params: &crate::network::Network,
+    fromaddress: &str,
+) -> RpcResult<FromAddressInput> {
+    // `zcashd`'s `z_shieldcoinbase` accepts `"*"` as a wildcard meaning "sweep
+    // coinbase UTXOs from every transparent address in the wallet". Zallet
+    // does not support that shape: sweeping across accounts would correlate
+    // them on-chain (see PR #402 review). Callers must scope the sweep to a
+    // single account UUID or a single transparent address.
+    if fromaddress == "*" {
+        return Err(LegacyCode::InvalidParameter.with_static(
+            "Invalid `fromaddress`: the `\"*\"` wildcard (sweep all wallet t-addrs) is not \
+             supported by Zallet. Pass either a wallet-owned transparent address or an \
+             account UUID to scope the sweep.",
+        ));
+    }
+    if let Ok(uuid) = Uuid::parse_str(fromaddress) {
+        return Ok(FromAddressInput::AccountUuid(uuid));
+    }
+    match Address::decode(params, fromaddress) {
+        Some(Address::Transparent(addr)) => Ok(FromAddressInput::TransparentAddress(addr)),
+        Some(_) => Err(LegacyCode::InvalidAddressOrKey.with_message(format!(
+            "Invalid `fromaddress`: only transparent addresses are accepted (got a \
+             non-transparent Zcash address): {fromaddress}",
+        ))),
+        None => Err(LegacyCode::InvalidParameter.with_message(format!(
+            "Invalid `fromaddress`: expected a wallet-owned transparent address or an \
+             account UUID, got {fromaddress:?}",
+        ))),
+    }
+}
+
+/// Resolve a classified `fromaddress` to a source account and the transparent
+/// addresses to draw coinbase UTXOs from.
+fn resolve_fromaddress_input(
+    wallet: &DbConnection,
+    from_input: &FromAddressInput,
+) -> RpcResult<(AccountUuid, Vec<TransparentAddress>)> {
+    match from_input {
+        FromAddressInput::AccountUuid(uuid) => {
+            let account_id = AccountUuid::from_uuid(*uuid);
+            if wallet
+                .get_account(account_id)
+                .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+                .is_none()
+            {
+                return Err(LegacyCode::InvalidParameter
+                    .with_message(format!("Unknown account UUID: {uuid}")));
+            }
+            let from_addrs = wallet
+                .get_transparent_receivers(account_id, true, true)
+                .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+                .into_keys()
+                .collect();
+            Ok((account_id, from_addrs))
+        }
+        FromAddressInput::TransparentAddress(addr) => {
+            let owner = wallet
+                .find_account_for_address(wallet.params(), &Address::Transparent(*addr))
+                .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+                .ok_or_else(|| {
+                    LegacyCode::InvalidAddressOrKey.with_message(format!(
+                        "Transparent address is not owned by any account in this wallet: {addr:?}",
+                    ))
+                })?;
+            Ok((owner, vec![*addr]))
+        }
+    }
+}
+
+/// Parse the `privacy_policy` argument, choosing a default from the
+/// `fromaddress` shape when omitted.
+///
+/// Coinbase shielding always reveals the transparent sender(s), so the set of
+/// policies that can ever be satisfied is small. We restrict the user-supplied
+/// values accordingly:
+///
+/// * `AllowRevealedSenders` — strictest policy that allows revealing source
+///   transparent addresses. Suffices when sweeping from a single t-addr.
+/// * `AllowLinkingAccountAddresses` — additionally allows linking multiple
+///   source t-addrs on-chain. Required when sweeping from an account UUID that
+///   expands to >1 transparent receiver with eligible coinbase UTXOs.
+///
+/// Any other policy name (including stricter ones like `FullPrivacy` and
+/// looser ones like `NoPrivacy`) is rejected to avoid misleading the caller
+/// about what coinbase shielding can offer.
+///
+/// When omitted, the default is chosen by the *shape* of `fromaddress`:
+/// single t-addr → `AllowRevealedSenders`, account UUID → `AllowLinkingAccountAddresses`.
+pub(super) fn parse_privacy_policy(
+    privacy_policy: Option<&str>,
+    from_input: &FromAddressInput,
+) -> RpcResult<PrivacyPolicy> {
+    match privacy_policy {
+        None => Ok(match from_input {
+            FromAddressInput::TransparentAddress(_) => PrivacyPolicy::AllowRevealedSenders,
+            FromAddressInput::AccountUuid(_) => PrivacyPolicy::AllowLinkingAccountAddresses,
+        }),
+        Some("AllowRevealedSenders") => Ok(PrivacyPolicy::AllowRevealedSenders),
+        Some("AllowLinkingAccountAddresses") => Ok(PrivacyPolicy::AllowLinkingAccountAddresses),
+        Some(other) => Err(LegacyCode::InvalidParameter.with_message(format!(
+            "Invalid privacy_policy {other:?} for z_shieldcoinbase: only \
+             \"AllowRevealedSenders\" and \"AllowLinkingAccountAddresses\" are accepted, \
+             because coinbase shielding always reveals the source transparent address(es).",
+        ))),
+    }
+}
+
+fn sum_selected_inputs(
+    proposal: &Proposal<StandardFeeRule, Infallible>,
+) -> RpcResult<(u64, Zatoshis)> {
+    let mut count: u64 = 0;
+    let mut sum = Zatoshis::ZERO;
+    for step in proposal.steps() {
+        for utxo in step.transparent_inputs() {
+            count = count.saturating_add(1);
+            sum = (sum + utxo.value()).ok_or_else(|| {
+                LegacyCode::Wallet
+                    .with_static("Internal error: shielding value sum overflowed Zatoshis bounds.")
+            })?;
+        }
+    }
+    Ok((count, sum))
+}
+
+fn enumerate_eligible(
+    wallet: &mut DbConnection,
+    from_addrs: &[TransparentAddress],
+    target_height: TargetHeight,
+) -> RpcResult<(u64, Zatoshis)> {
+    let mut total_utxos: u64 = 0;
+    let mut total_value_zats = Zatoshis::ZERO;
+    for addr in from_addrs {
+        let utxos = wallet
+            .get_spendable_transparent_outputs(
+                addr,
+                target_height,
+                ConfirmationsPolicy::MIN,
+                TransparentOutputFilter::CoinbaseOnly,
+            )
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+        total_utxos = total_utxos.saturating_add(utxos.len() as u64);
+        for utxo in utxos {
+            total_value_zats = (total_value_zats + utxo.value()).ok_or_else(|| {
+                LegacyCode::Wallet.with_static(
+                    "Internal error: total transparent value overflowed Zatoshis bounds.",
+                )
+            })?;
+        }
+    }
+    Ok((total_utxos, total_value_zats))
+}
+
+/// Construct and broadcast the shielding transaction.
 async fn run(
     mut wallet: DbHandle,
     chain: FetchServiceSubscriber,
@@ -502,4 +528,163 @@ async fn run(
     })?;
 
     broadcast_transactions(&wallet, chain, txids.into()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::json_rpc::server::LegacyCode;
+    use crate::network::Network;
+    use zcash_protocol::consensus;
+
+    fn mainnet() -> Network {
+        Network::Consensus(consensus::Network::MainNetwork)
+    }
+
+    fn testnet() -> Network {
+        Network::Consensus(consensus::Network::TestNetwork)
+    }
+
+    // Reused from validate_address.rs tests.
+    const MAINNET_P2PKH: &str = "t1VydNnkjBzfL1iAMyUbwGKJAF7PgvuCfMY";
+    const MAINNET_P2SH: &str = "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd";
+    const TESTNET_P2PKH: &str = "tmGqwWtL7RsbxikDSN26gsbicxVr2xJNe86";
+    // Reused from validate_address.rs:160.
+    const MAINNET_SAPLING: &str =
+        "zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9slya";
+
+    const VALID_UUID: &str = "123e4567-e89b-12d3-a456-426614174000";
+
+    #[test]
+    fn uuid_classified_as_account_uuid() {
+        let parsed = parse_fromaddress(&mainnet(), VALID_UUID).unwrap();
+        let expected_uuid = Uuid::parse_str(VALID_UUID).unwrap();
+        assert_eq!(parsed, FromAddressInput::AccountUuid(expected_uuid));
+    }
+
+    #[test]
+    fn p2pkh_taddr_classified_as_transparent_address() {
+        let parsed = parse_fromaddress(&mainnet(), MAINNET_P2PKH).unwrap();
+        match parsed {
+            FromAddressInput::TransparentAddress(TransparentAddress::PublicKeyHash(_)) => {}
+            other => panic!("Expected P2PKH TransparentAddress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn p2sh_taddr_classified_as_transparent_address() {
+        let parsed = parse_fromaddress(&mainnet(), MAINNET_P2SH).unwrap();
+        match parsed {
+            FromAddressInput::TransparentAddress(TransparentAddress::ScriptHash(_)) => {}
+            other => panic!("Expected P2SH TransparentAddress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn testnet_taddr_classified_on_testnet() {
+        let parsed = parse_fromaddress(&testnet(), TESTNET_P2PKH).unwrap();
+        match parsed {
+            FromAddressInput::TransparentAddress(TransparentAddress::PublicKeyHash(_)) => {}
+            other => panic!("Expected testnet P2PKH TransparentAddress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mainnet_taddr_on_testnet_rejected() {
+        // Wrong network: mainnet t1 address parsed under testnet params is
+        // not a valid transparent address, so it should fail the parser with
+        // an InvalidParameter rather than an InvalidAddressOrKey.
+        let err = parse_fromaddress(&testnet(), MAINNET_P2PKH).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+    }
+
+    #[test]
+    fn sapling_shielded_address_rejected_as_non_transparent() {
+        let err = parse_fromaddress(&mainnet(), MAINNET_SAPLING).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidAddressOrKey as i32);
+    }
+
+    #[test]
+    fn garbage_string_rejected() {
+        let err = parse_fromaddress(&mainnet(), "not-a-thing").unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+    }
+
+    #[test]
+    fn empty_string_rejected() {
+        let err = parse_fromaddress(&mainnet(), "").unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+    }
+
+    #[test]
+    fn star_wildcard_rejected_with_informative_error() {
+        let err = parse_fromaddress(&mainnet(), "*").unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+        let msg = err.message();
+        assert!(
+            msg.contains("\"*\"") && msg.contains("wildcard"),
+            "error message should mention the `*` wildcard explicitly, got: {msg}",
+        );
+        assert!(
+            msg.contains("account UUID"),
+            "error message should direct the caller to use an account UUID, got: {msg}",
+        );
+    }
+
+    fn taddr_input() -> FromAddressInput {
+        match parse_fromaddress(&mainnet(), MAINNET_P2PKH).unwrap() {
+            input @ FromAddressInput::TransparentAddress(_) => input,
+            other => panic!("Expected TransparentAddress input, got {other:?}"),
+        }
+    }
+
+    fn uuid_input() -> FromAddressInput {
+        FromAddressInput::AccountUuid(Uuid::parse_str(VALID_UUID).unwrap())
+    }
+
+    #[test]
+    fn privacy_policy_default_for_taddr_input_is_revealed_senders() {
+        let p = parse_privacy_policy(None, &taddr_input()).unwrap();
+        assert_eq!(p, PrivacyPolicy::AllowRevealedSenders);
+    }
+
+    #[test]
+    fn privacy_policy_default_for_uuid_input_is_linking_account_addresses() {
+        let p = parse_privacy_policy(None, &uuid_input()).unwrap();
+        assert_eq!(p, PrivacyPolicy::AllowLinkingAccountAddresses);
+    }
+
+    #[test]
+    fn privacy_policy_accepts_revealed_senders_for_either_input() {
+        for input in [taddr_input(), uuid_input()] {
+            let p = parse_privacy_policy(Some("AllowRevealedSenders"), &input).unwrap();
+            assert_eq!(p, PrivacyPolicy::AllowRevealedSenders);
+        }
+    }
+
+    #[test]
+    fn privacy_policy_accepts_linking_account_addresses_for_either_input() {
+        for input in [taddr_input(), uuid_input()] {
+            let p = parse_privacy_policy(Some("AllowLinkingAccountAddresses"), &input).unwrap();
+            assert_eq!(p, PrivacyPolicy::AllowLinkingAccountAddresses);
+        }
+    }
+
+    #[test]
+    fn privacy_policy_rejects_full_privacy() {
+        let err = parse_privacy_policy(Some("FullPrivacy"), &taddr_input()).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+    }
+
+    #[test]
+    fn privacy_policy_rejects_no_privacy() {
+        let err = parse_privacy_policy(Some("NoPrivacy"), &taddr_input()).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+    }
+
+    #[test]
+    fn privacy_policy_rejects_unknown_string() {
+        let err = parse_privacy_policy(Some("not-a-policy"), &taddr_input()).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+    }
 }

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -4,14 +4,17 @@ use std::convert::Infallible;
 use std::future::Future;
 
 use abscissa_core::Application;
+use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
+use schemars::JsonSchema;
 use secrecy::ExposeSecret;
+use serde::Serialize;
 use transparent::address::TransparentAddress;
 use zaino_state::FetchServiceSubscriber;
 use zcash_address::unified;
 use zcash_client_backend::{
     data_api::{
-        Account, TransparentOutputFilter, WalletRead,
+        Account, InputSource, TransparentOutputFilter, WalletRead,
         wallet::{
             SpendingKeys, create_proposed_transactions, input_selection::GreedyInputSelector,
             propose_shielding,
@@ -35,6 +38,7 @@ use crate::{
                 get_account_for_address,
             },
             server::LegacyCode,
+            utils::{JsonZec, value_from_zatoshis},
         },
         keystore::KeyStore,
     },
@@ -45,7 +49,68 @@ use crate::{
 #[cfg(feature = "transparent-key-import")]
 use zcash_script::script;
 
-pub(crate) type ResultType = OperationId;
+/// The result of a `z_shieldcoinbase` pre-flight call.
+///
+/// Mirrors the JSON object returned by `zcashd`'s `z_shieldcoinbase`:
+/// `{ remainingUTXOs, remainingValue, shieldingUTXOs, shieldingValue, opid }`.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct ShieldCoinbaseResult {
+    /// Number of coinbase UTXOs that were eligible for shielding but were not
+    /// selected by this operation.
+    ///
+    /// Note: Zallet currently ignores the `limit` parameter, so in practice
+    /// this is `0` whenever the proposal succeeded. The field is preserved
+    /// for compatibility with `zcashd`-shape clients.
+    #[serde(rename = "remainingUTXOs")]
+    remaining_utxos: u64,
+
+    /// Total value (in ZEC) of coinbase UTXOs that were eligible for
+    /// shielding but were not selected by this operation. See `remainingUTXOs`.
+    #[serde(rename = "remainingValue")]
+    remaining_value: JsonZec,
+
+    /// Number of coinbase UTXOs being shielded by this operation.
+    #[serde(rename = "shieldingUTXOs")]
+    shielding_utxos: u64,
+
+    /// Total value (in ZEC) of coinbase UTXOs being shielded by this
+    /// operation.
+    #[serde(rename = "shieldingValue")]
+    shielding_value: JsonZec,
+
+    /// Operation id to pass to `z_getoperationstatus` /
+    /// `z_getoperationresult` to retrieve the final result.
+    opid: OperationId,
+}
+
+impl ShieldCoinbaseResult {
+    /// Combines the synchronously-computed [`Preflight`] numerics with the
+    /// [`OperationId`] returned by [`crate::components::json_rpc::asyncop`]
+    /// once the async portion is registered.
+    pub(super) fn new(preflight: Preflight, opid: OperationId) -> Self {
+        Self {
+            remaining_utxos: preflight.remaining_utxos,
+            remaining_value: preflight.remaining_value,
+            shielding_utxos: preflight.shielding_utxos,
+            shielding_value: preflight.shielding_value,
+            opid,
+        }
+    }
+}
+
+/// Pre-flight numeric fields, computed before the async portion runs.
+///
+/// Held as a separate type so that the [`OperationId`] (only available after
+/// the async operation is registered) can be joined with these values to
+/// produce the final [`ShieldCoinbaseResult`].
+pub(crate) struct Preflight {
+    pub(super) remaining_utxos: u64,
+    pub(super) remaining_value: JsonZec,
+    pub(super) shielding_utxos: u64,
+    pub(super) shielding_value: JsonZec,
+}
+
+pub(crate) type ResultType = ShieldCoinbaseResult;
 pub(crate) type Response = RpcResult<ResultType>;
 
 pub(super) const PARAM_FROMADDRESS_DESC: &str = "A wallet-owned transparent address to sweep from, or \"*\" to sweep from all taddrs \
@@ -73,6 +138,7 @@ pub(crate) async fn call(
     memo: Option<String>,
     privacy_policy: Option<String>,
 ) -> RpcResult<(
+    Preflight,
     Option<ContextInfo>,
     impl Future<Output = RpcResult<SendResult>>,
 )> {
@@ -226,6 +292,78 @@ pub(crate) async fn call(
 
     enforce_privacy_policy(&proposal, privacy_policy)?;
 
+    // Compute the `zcashd`-shape pre-flight numbers.
+    //
+    // `shielding_*` is what the proposal will spend; we sum directly over the
+    // proposal's selected transparent inputs.
+    //
+    // `remaining_*` is what was eligible-but-not-selected. We re-enumerate the
+    // spendable coinbase UTXOs for `from_addrs` at the same target height the
+    // proposal used and subtract.
+    //
+    // RACE NOTE: Between `propose_shielding` (above) and the enumeration
+    // below, a new block could land and either advance maturity (adding new
+    // eligible UTXOs) or invalidate previously-eligible ones via reorg. In
+    // the first case `total_value` only inflates, leaving
+    // `shielding_value <= total_value`; the subtraction is safe and
+    // `remaining_*` will harmlessly over-count by the freshly-mature outputs.
+    // In the (rare) reorg case, `shielding_value > total_value` is possible.
+    // We treat that as an internal error and abort before registering the
+    // opid, so no half-state is exposed to the caller.
+    let mut shielding_utxos: u64 = 0;
+    let mut shielding_value_zats = Zatoshis::ZERO;
+    for step in proposal.steps() {
+        for utxo in step.transparent_inputs() {
+            shielding_utxos = shielding_utxos.saturating_add(1);
+            shielding_value_zats = (shielding_value_zats + utxo.value()).ok_or_else(|| {
+                LegacyCode::Wallet
+                    .with_static("Internal error: shielding value sum overflowed Zatoshis bounds.")
+            })?;
+        }
+    }
+
+    let target_height = proposal.min_target_height();
+    let mut total_utxos: u64 = 0;
+    let mut total_value_zats = Zatoshis::ZERO;
+    for addr in &from_addrs {
+        let utxos = wallet
+            .get_spendable_transparent_outputs(
+                addr,
+                target_height,
+                confirmations_policy,
+                TransparentOutputFilter::CoinbaseOnly,
+            )
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+        total_utxos = total_utxos.saturating_add(utxos.len() as u64);
+        for utxo in utxos {
+            total_value_zats = (total_value_zats + utxo.value()).ok_or_else(|| {
+                LegacyCode::Wallet.with_static(
+                    "Internal error: total transparent value overflowed Zatoshis bounds.",
+                )
+            })?;
+        }
+    }
+
+    let remaining_utxos = total_utxos.checked_sub(shielding_utxos).ok_or_else(|| {
+        LegacyCode::Wallet.with_static(
+            "Internal accounting error: proposal selected more UTXOs than \
+             enumeration found (likely a chain race during shielding setup).",
+        )
+    })?;
+    let remaining_value_zats = (total_value_zats - shielding_value_zats).ok_or_else(|| {
+        LegacyCode::Wallet.with_static(
+            "Internal accounting error: proposal value exceeds enumerated \
+                 total (likely a chain race during shielding setup).",
+        )
+    })?;
+
+    let preflight = Preflight {
+        remaining_utxos,
+        remaining_value: value_from_zatoshis(remaining_value_zats),
+        shielding_utxos,
+        shielding_value: value_from_zatoshis(shielding_value_zats),
+    };
+
     // Check Orchard action limits.
     let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
     for step in proposal.steps() {
@@ -327,6 +465,7 @@ pub(crate) async fn call(
     };
 
     Ok((
+        preflight,
         Some(ContextInfo::new(
             "z_shieldcoinbase",
             serde_json::json!({

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -434,6 +434,24 @@ pub(crate) async fn call(
 
     #[cfg(feature = "transparent-key-import")]
     let standalone_keys = {
+        // Determine which transparent receivers in this account were imported
+        // standalone (vs. HD-derived). Only those have an associated entry in
+        // the keystore's standalone-key table; HD-derived receivers are signed
+        // for using `usk` and must not be looked up via
+        // `decrypt_standalone_transparent_key` (which would error with
+        // `QueryReturnedNoRows`).
+        use zcash_client_backend::wallet::TransparentAddressSource;
+        let standalone_addrs: std::collections::HashSet<TransparentAddress> = wallet
+            .get_transparent_receivers(account.id(), true, true)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .into_iter()
+            .filter_map(|(addr, metadata)| match metadata.source() {
+                TransparentAddressSource::StandalonePubkey(_)
+                | TransparentAddressSource::StandaloneScript(_) => Some(addr),
+                TransparentAddressSource::Derived { .. } => None,
+            })
+            .collect();
+
         let mut keys: std::collections::HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> =
             std::collections::HashMap::new();
         for step in proposal.steps() {
@@ -443,6 +461,9 @@ pub(crate) async fn call(
                     .as_ref()
                     .and_then(TransparentAddress::from_script_from_chain)
                 {
+                    if !standalone_addrs.contains(&address) {
+                        continue;
+                    }
                     let secret_key = keystore
                         .decrypt_standalone_transparent_key(&address)
                         .await

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -10,16 +10,16 @@ use secrecy::ExposeSecret;
 use serde::Serialize;
 use transparent::address::TransparentAddress;
 use zaino_state::FetchServiceSubscriber;
-use zcash_address::unified;
+use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
         Account, InputSource, TransparentOutputFilter, WalletRead,
         wallet::{
             SpendingKeys, create_proposed_transactions, input_selection::GreedyInputSelector,
-            propose_shielding,
+            propose_shielding_coinbase,
         },
     },
-    fees::{DustOutputPolicy, StandardFeeRule, standard::MultiOutputChangeStrategy},
+    fees::StandardFeeRule,
     proposal::Proposal,
     wallet::OvkPolicy,
 };
@@ -34,7 +34,7 @@ use crate::{
             asyncop::{ContextInfo, OperationId},
             payments::{
                 PrivacyPolicy, SendResult, broadcast_transactions, enforce_privacy_policy,
-                get_account_for_address,
+                get_account_for_address, parse_memo,
             },
             server::LegacyCode,
             utils::{JsonZec, value_from_zatoshis},
@@ -55,11 +55,8 @@ use zcash_script::script;
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct ShieldCoinbaseResult {
     /// Number of coinbase UTXOs that were eligible for shielding but were not
-    /// selected by this operation.
-    ///
-    /// Note: Zallet currently ignores the `limit` parameter, so in practice
-    /// this is `0` whenever the proposal succeeded. The field is preserved
-    /// for compatibility with `zcashd`-shape clients.
+    /// selected by this operation. Non-zero when the caller supplied a `limit`
+    /// that was smaller than the count of eligible coinbase UTXOs.
     #[serde(rename = "remainingUTXOs")]
     remaining_utxos: u64,
 
@@ -118,10 +115,10 @@ pub(super) const PARAM_TOADDRESS_DESC: &str = "A wallet-owned shielded address u
      the account's internal shielded address, which may differ from this address.";
 pub(super) const PARAM_FEE_DESC: &str =
     "If provided, must be null. Zallet always calculates and applies the ZIP-317 fee internally.";
-pub(super) const PARAM_LIMIT_DESC: &str = "Accepted for compatibility but currently ignored; does not constrain how many UTXOs are \
-     shielded.";
-pub(super) const PARAM_MEMO_DESC: &str = "Accepted for compatibility but currently ignored; not stored in the memo field of any new \
-     note.";
+pub(super) const PARAM_LIMIT_DESC: &str = "If supplied, caps the number of selected coinbase UTXOs to the highest-value `n` of those \
+     eligible.";
+pub(super) const PARAM_MEMO_DESC: &str = "If supplied, stored in the memo field of the resulting shielded payment. Must be a \
+     hex-encoded string (up to 1024 hex characters = 512 bytes).";
 pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
     "Policy for what information leakage is acceptable.";
 
@@ -161,52 +158,41 @@ pub(crate) async fn call(
         None => Ok(PrivacyPolicy::AllowRevealedSenders),
     }?;
 
-    // TODO(schell): `propose_shielding` does not accept a memo parameter. The memo is
-    // accepted here for API compatibility but is currently ignored. Once the backend
-    // supports attaching a memo to shielding transactions, wire it through.
-    let _memo = memo;
+    // Parse the memo parameter (hex-encoded). The backend will attach it to the
+    // resulting shielded payment. The backend rejects memos longer than 512 bytes
+    // by way of `MemoBytes::from_bytes`.
+    let memo = memo.as_deref().map(parse_memo).transpose()?;
 
-    // TODO(schell): `propose_shielding` does not support a UTXO limit parameter. The
-    // limit is accepted here for API compatibility but is currently ignored. Consider
-    // pre-filtering UTXOs or extending the backend API to support this.
-    let _limit = limit;
+    // The `limit` parameter caps the number of selected coinbase UTXOs to the
+    // highest-value `n` of those eligible.
+    let limit_usize = limit.map(|n| n as usize);
 
-    // Validate the destination address: must have at least one shielded receiver.
+    // Parse and validate the destination address. We need both:
+    // - a `ZcashAddress` to pass to `propose_shielding_coinbase` (the backend's
+    //   shielded-receiver enforcement runs against this value).
+    // - a `zcash_keys::address::Address` to call `get_account_for_address` and
+    //   anchor the zallet-level same-account constraint: zallet's
+    //   `z_shieldcoinbase` requires `toaddress` to belong to a wallet account
+    //   (matching `zcashd`'s behavior), on top of the backend's requirement
+    //   that it be shielded.
     let to_address = Address::decode(wallet.params(), &toaddress).ok_or_else(|| {
         LegacyCode::InvalidParameter.with_message(format!(
             "Invalid parameter, unknown address format: {toaddress}"
         ))
     })?;
+    let to_zcash_address: ZcashAddress = toaddress.parse().map_err(|_| {
+        LegacyCode::InvalidParameter.with_message(format!(
+            "Invalid parameter, unknown address format: {toaddress}"
+        ))
+    })?;
 
-    match &to_address {
-        Address::Transparent(_) | Address::Tex(_) => {
-            return Err(LegacyCode::InvalidParameter.with_static(
-                "Invalid parameter, toaddress must be a shielded address (Sapling, Orchard, or Unified with shielded receivers).",
-            ));
-        }
-        Address::Unified(ua) => {
-            let has_shielded = ua
-                .receiver_types()
-                .iter()
-                .any(|t| matches!(t, unified::Typecode::Sapling | unified::Typecode::Orchard));
-            if !has_shielded {
-                return Err(LegacyCode::InvalidParameter.with_static(
-                    "Invalid parameter, the provided Unified Address has no shielded receivers.",
-                ));
-            }
-        }
-        // Sapling addresses are always valid shielded destinations.
-        Address::Sapling(_) => {}
-    }
-
-    // Look up the account that owns the destination address.
+    // Look up the account that owns the destination address. This enforces the
+    // zallet-level "same account" requirement; the backend additionally
+    // enforces "must be a shielded address" via
+    // `ProposalError::ShieldingRequiresShieldedRecipient`.
     let account = get_account_for_address(wallet.as_ref(), &to_address)?;
 
     // Resolve the transparent source addresses.
-    // TODO(schell): When fromaddress is "*", we currently only sweep transparent
-    // addresses belonging to the same account as toaddress. Check with teammates
-    // whether "*" should sweep across all wallet accounts instead (matching zcashd's
-    // single-keypool model more closely).
     let from_addrs: Vec<TransparentAddress> = if fromaddress == "*" {
         wallet
             .get_transparent_receivers(account.id(), true, true)
@@ -260,31 +246,26 @@ pub(crate) async fn call(
 
     let params = *wallet.params();
 
-    let change_strategy = MultiOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedProtocol::Orchard,
-        DustOutputPolicy::default(),
-        APP.config().note_management.split_policy(),
-    );
-
     let input_selector = GreedyInputSelector::new();
 
-    // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding threshold
-    // to shield all available coinbase UTXOs. Passes TransparentOutputFilter::CoinbaseOnly
-    // to ensure only coinbase UTXOs are selected for shielding.
-    let proposal = propose_shielding::<_, _, _, _, Infallible>(
+    // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding
+    // threshold to shield all available coinbase UTXOs (or all up to `limit`
+    // when supplied). `propose_shielding_coinbase` hard-codes
+    // `TransparentOutputFilter::CoinbaseOnly`, attaches the supplied memo to
+    // the resulting shielded payment, and produces no transparent or shielded
+    // change (preserving the privacy invariant that a shielded change output
+    // would let `toaddress` learn the sender's total selected-coinbase value).
+    let proposal = propose_shielding_coinbase::<_, _, _, _, Infallible>(
         wallet.as_mut(),
         &params,
         &input_selector,
-        &change_strategy,
+        &StandardFeeRule::Zip317,
         Zatoshis::ZERO,
         &from_addrs,
-        account.id(),
-        confirmations_policy,
-        TransparentOutputFilter::CoinbaseOnly,
+        to_zcash_address,
+        memo,
+        limit_usize,
     )
-    // TODO: Map errors to `zcashd` shape.
     .map_err(|e| {
         LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
     })?;
@@ -491,7 +472,7 @@ pub(crate) async fn call(
             serde_json::json!({
                 "fromaddress": fromaddress,
                 "toaddress": toaddress,
-                "limit": _limit,
+                "limit": limit,
             }),
         )),
         run(

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -1,0 +1,384 @@
+//! Implementation of the `z_shieldcoinbase` RPC method.
+
+use std::convert::Infallible;
+use std::future::Future;
+
+use abscissa_core::Application;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use secrecy::ExposeSecret;
+use transparent::address::TransparentAddress;
+use zaino_state::FetchServiceSubscriber;
+use zcash_address::unified;
+use zcash_client_backend::{
+    data_api::{
+        Account, TransparentOutputFilter, WalletRead,
+        wallet::{
+            SpendingKeys, create_proposed_transactions, input_selection::GreedyInputSelector,
+            propose_shielding,
+        },
+    },
+    fees::{DustOutputPolicy, StandardFeeRule, standard::MultiOutputChangeStrategy},
+    proposal::Proposal,
+    wallet::OvkPolicy,
+};
+use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
+use zcash_proofs::prover::LocalTxProver;
+use zcash_protocol::{PoolType, ShieldedProtocol, value::Zatoshis};
+
+use crate::{
+    components::{
+        database::DbHandle,
+        json_rpc::{
+            asyncop::{ContextInfo, OperationId},
+            payments::{
+                PrivacyPolicy, SendResult, broadcast_transactions, enforce_privacy_policy,
+                get_account_for_address,
+            },
+            server::LegacyCode,
+        },
+        keystore::KeyStore,
+    },
+    fl,
+    prelude::*,
+};
+
+#[cfg(feature = "transparent-key-import")]
+use zcash_script::script;
+
+pub(crate) type ResultType = OperationId;
+pub(crate) type Response = RpcResult<ResultType>;
+
+pub(super) const PARAM_FROMADDRESS_DESC: &str = "A wallet-owned transparent address to sweep from, or \"*\" to sweep from all taddrs \
+     belonging to the same account as toaddress. Must belong to the same account as toaddress.";
+pub(super) const PARAM_TOADDRESS_DESC: &str = "A wallet-owned shielded address used to identify the account. Funds are shielded into \
+     the account's internal shielded address, which may differ from this address.";
+pub(super) const PARAM_FEE_DESC: &str =
+    "If provided, must be null. Zallet always calculates and applies the ZIP-317 fee internally.";
+pub(super) const PARAM_LIMIT_DESC: &str = "Accepted for compatibility but currently ignored; does not constrain how many UTXOs are \
+     shielded.";
+pub(super) const PARAM_MEMO_DESC: &str = "Accepted for compatibility but currently ignored; not stored in the memo field of any new \
+     note.";
+pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
+    "Policy for what information leakage is acceptable.";
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn call(
+    mut wallet: DbHandle,
+    keystore: KeyStore,
+    chain: FetchServiceSubscriber,
+    fromaddress: String,
+    toaddress: String,
+    fee: Option<JsonValue>,
+    limit: Option<u32>,
+    memo: Option<String>,
+    privacy_policy: Option<String>,
+) -> RpcResult<(
+    Option<ContextInfo>,
+    impl Future<Output = RpcResult<SendResult>>,
+)> {
+    // `fee` exists for positional compatibility with `zcashd`'s
+    // `z_shieldcoinbase` only — Zallet always computes the fee internally.
+    // Accept both omission and explicit JSON null; reject any other value
+    // so callers can't silently believe they're configuring it.
+    if fee.as_ref().is_some_and(|v| !v.is_null()) {
+        return Err(LegacyCode::InvalidParameter
+            .with_static("Zallet always calculates fees internally; the fee field must be null."));
+    }
+
+    // Parse the privacy policy.
+    // Default to AllowRevealedSenders since shielding always reveals the transparent sender.
+    let privacy_policy = match privacy_policy.as_deref() {
+        Some("LegacyCompat") => Err(LegacyCode::InvalidParameter
+            .with_static("LegacyCompat privacy policy is unsupported in Zallet")),
+        Some(s) => PrivacyPolicy::from_str(s).ok_or_else(|| {
+            LegacyCode::InvalidParameter.with_message(format!("Unknown privacy policy {s}"))
+        }),
+        None => Ok(PrivacyPolicy::AllowRevealedSenders),
+    }?;
+
+    // TODO(schell): `propose_shielding` does not accept a memo parameter. The memo is
+    // accepted here for API compatibility but is currently ignored. Once the backend
+    // supports attaching a memo to shielding transactions, wire it through.
+    let _memo = memo;
+
+    // TODO(schell): `propose_shielding` does not support a UTXO limit parameter. The
+    // limit is accepted here for API compatibility but is currently ignored. Consider
+    // pre-filtering UTXOs or extending the backend API to support this.
+    let _limit = limit;
+
+    // Validate the destination address: must have at least one shielded receiver.
+    let to_address = Address::decode(wallet.params(), &toaddress).ok_or_else(|| {
+        LegacyCode::InvalidParameter.with_message(format!(
+            "Invalid parameter, unknown address format: {toaddress}"
+        ))
+    })?;
+
+    match &to_address {
+        Address::Transparent(_) | Address::Tex(_) => {
+            return Err(LegacyCode::InvalidParameter.with_static(
+                "Invalid parameter, toaddress must be a shielded address (Sapling, Orchard, or Unified with shielded receivers).",
+            ));
+        }
+        Address::Unified(ua) => {
+            let has_shielded = ua
+                .receiver_types()
+                .iter()
+                .any(|t| matches!(t, unified::Typecode::Sapling | unified::Typecode::Orchard));
+            if !has_shielded {
+                return Err(LegacyCode::InvalidParameter.with_static(
+                    "Invalid parameter, the provided Unified Address has no shielded receivers.",
+                ));
+            }
+        }
+        // Sapling addresses are always valid shielded destinations.
+        Address::Sapling(_) => {}
+    }
+
+    // Look up the account that owns the destination address.
+    let account = get_account_for_address(wallet.as_ref(), &to_address)?;
+
+    // Resolve the transparent source addresses.
+    // TODO(schell): When fromaddress is "*", we currently only sweep transparent
+    // addresses belonging to the same account as toaddress. Check with teammates
+    // whether "*" should sweep across all wallet accounts instead (matching zcashd's
+    // single-keypool model more closely).
+    let from_addrs: Vec<TransparentAddress> = if fromaddress == "*" {
+        wallet
+            .get_transparent_receivers(account.id(), true, true)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .into_keys()
+            .collect()
+    } else {
+        // Parse as a transparent address. z_shieldcoinbase only accepts transparent
+        // source addresses (or "*").
+        let from_address = Address::decode(wallet.params(), &fromaddress).ok_or_else(|| {
+            LegacyCode::InvalidAddressOrKey
+                .with_static("Invalid from address: should be a taddr or the string \"*\".")
+        })?;
+
+        let transparent_addr: TransparentAddress = match from_address {
+            Address::Transparent(addr) => addr,
+            // Don't allow tex addresses, just as zcashd doesn't allow tex addresses.
+            // It would mostly likely be a mistake if the user specifies a tex address here, so we'll err.
+            _ => {
+                return Err(LegacyCode::InvalidAddressOrKey.with_static(
+                    "Invalid from address: z_shieldcoinbase only supports transparent source addresses.",
+                ));
+            }
+        };
+
+        // Verify the transparent address belongs to the same account as toaddress.
+        let from_account =
+            get_account_for_address(wallet.as_ref(), &Address::Transparent(transparent_addr))?;
+        if from_account.id() != account.id() {
+            return Err(LegacyCode::InvalidParameter.with_static(
+                "Invalid parameter: fromaddress and toaddress must belong to the same account.",
+            ));
+        }
+
+        vec![transparent_addr]
+    };
+
+    if from_addrs.is_empty() {
+        return Err(
+            LegacyCode::InvalidParameter.with_static("No transparent addresses found to shield.")
+        );
+    }
+
+    // Set up confirmations policy from the wallet configuration.
+    let confirmations_policy = APP.config().builder.confirmations_policy().map_err(|_| {
+        LegacyCode::Wallet.with_message(
+            "Configuration error: minimum confirmations for spending trusted TXOs \
+             cannot exceed that for untrusted TXOs.",
+        )
+    })?;
+
+    let params = *wallet.params();
+
+    let change_strategy = MultiOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedProtocol::Orchard,
+        DustOutputPolicy::default(),
+        APP.config().note_management.split_policy(),
+    );
+
+    let input_selector = GreedyInputSelector::new();
+
+    // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding threshold
+    // to shield all available coinbase UTXOs. Passes TransparentOutputFilter::CoinbaseOnly
+    // to ensure only coinbase UTXOs are selected for shielding.
+    let proposal = propose_shielding::<_, _, _, _, Infallible>(
+        wallet.as_mut(),
+        &params,
+        &input_selector,
+        &change_strategy,
+        Zatoshis::ZERO,
+        &from_addrs,
+        account.id(),
+        confirmations_policy,
+        TransparentOutputFilter::CoinbaseOnly,
+    )
+    // TODO: Map errors to `zcashd` shape.
+    .map_err(|e| {
+        LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
+    })?;
+
+    enforce_privacy_policy(&proposal, privacy_policy)?;
+
+    // Check Orchard action limits.
+    let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
+    for step in proposal.steps() {
+        let orchard_spends = step
+            .shielded_inputs()
+            .iter()
+            .flat_map(|inputs| inputs.notes())
+            .filter(|note| note.note().protocol() == ShieldedProtocol::Orchard)
+            .count();
+
+        let orchard_outputs = step
+            .payment_pools()
+            .values()
+            .filter(|pool| pool == &&PoolType::ORCHARD)
+            .count()
+            + step
+                .balance()
+                .proposed_change()
+                .iter()
+                .filter(|change| change.output_pool() == PoolType::ORCHARD)
+                .count();
+
+        let orchard_actions = orchard_spends.max(orchard_outputs);
+
+        if orchard_actions > orchard_actions_limit {
+            let (count, kind) = if orchard_outputs <= orchard_actions_limit {
+                (orchard_spends, "inputs")
+            } else if orchard_spends <= orchard_actions_limit {
+                (orchard_outputs, "outputs")
+            } else {
+                (orchard_actions, "actions")
+            };
+
+            return Err(LegacyCode::Misc.with_message(fl!(
+                "err-excess-orchard-actions",
+                count = count,
+                kind = kind,
+                limit = orchard_actions_limit,
+                config = "-orchardactionlimit=N",
+                bound = format!("N >= %u"),
+            )));
+        }
+    }
+
+    // Derive the spending key for the account.
+    let derivation = account.source().key_derivation().ok_or_else(|| {
+        LegacyCode::InvalidAddressOrKey
+            .with_static("Invalid address, no payment source found for account.")
+    })?;
+
+    // Fetch spending key last, to avoid a keystore decryption if unnecessary.
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            // TODO: Improve internal error types.
+            //       https://github.com/zcash/wallet/issues/256
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+    let usk = UnifiedSpendingKey::from_seed(
+        wallet.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+
+    #[cfg(feature = "transparent-key-import")]
+    let standalone_keys = {
+        let mut keys = std::collections::HashMap::new();
+        for step in proposal.steps() {
+            for input in step.transparent_inputs() {
+                if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
+                    .ok()
+                    .as_ref()
+                    .and_then(TransparentAddress::from_script_from_chain)
+                {
+                    let secret_key = keystore
+                        .decrypt_standalone_transparent_key(&address)
+                        .await
+                        .map_err(|e| match e.kind() {
+                            // TODO: Improve internal error types.
+                            //       https://github.com/zcash/wallet/issues/256
+                            crate::error::ErrorKind::Generic
+                                if e.to_string() == "Wallet is locked" =>
+                            {
+                                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+                            }
+                            _ => LegacyCode::Database.with_message(e.to_string()),
+                        })?;
+                    keys.insert(address, vec![secret_key]);
+                }
+            }
+        }
+        keys
+    };
+
+    Ok((
+        Some(ContextInfo::new(
+            "z_shieldcoinbase",
+            serde_json::json!({
+                "fromaddress": fromaddress,
+                "toaddress": toaddress,
+                "limit": _limit,
+            }),
+        )),
+        run(
+            wallet,
+            chain,
+            proposal,
+            SpendingKeys::new(
+                usk,
+                #[cfg(feature = "zcashd-import")]
+                standalone_keys,
+            ),
+        ),
+    ))
+}
+
+/// Construct and broadcast the shielding transaction.
+///
+/// Notes:
+/// 1. Spendable notes/UTXOs are not locked, so an operation running in parallel
+///    could also try to use them.
+async fn run(
+    mut wallet: DbHandle,
+    chain: FetchServiceSubscriber,
+    proposal: Proposal<StandardFeeRule, Infallible>,
+    spending_keys: SpendingKeys,
+) -> RpcResult<SendResult> {
+    let prover = LocalTxProver::bundled();
+    let (wallet, txids) = crate::spawn_blocking!("z_shieldcoinbase runner", move || {
+        let params = *wallet.params();
+        create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+            wallet.as_mut(),
+            &params,
+            &prover,
+            &prover,
+            &spending_keys,
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .map(|txids| (wallet, txids))
+    })
+    .await
+    .map_err(|e| {
+        LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
+    })?
+    .map_err(|e| {
+        LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
+    })?;
+
+    broadcast_transactions(&wallet, chain, txids.into()).await
+}

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -297,7 +297,8 @@ pub(crate) async fn call(
 
     #[cfg(feature = "transparent-key-import")]
     let standalone_keys = {
-        let mut keys = std::collections::HashMap::new();
+        let mut keys: std::collections::HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> =
+            std::collections::HashMap::new();
         for step in proposal.steps() {
             for input in step.transparent_inputs() {
                 if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
@@ -318,7 +319,7 @@ pub(crate) async fn call(
                             }
                             _ => LegacyCode::Database.with_message(e.to_string()),
                         })?;
-                    keys.insert(address, vec![secret_key]);
+                    keys.entry(address).or_default().push(secret_key);
                 }
             }
         }

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -25,7 +25,7 @@ use zcash_client_backend::{
 };
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_proofs::prover::LocalTxProver;
-use zcash_protocol::{PoolType, ShieldedProtocol, value::Zatoshis};
+use zcash_protocol::value::Zatoshis;
 
 use crate::{
     components::{
@@ -41,7 +41,6 @@ use crate::{
         },
         keystore::KeyStore,
     },
-    fl,
     prelude::*,
 };
 
@@ -116,11 +115,23 @@ pub(super) const PARAM_TOADDRESS_DESC: &str = "A wallet-owned shielded address u
 pub(super) const PARAM_FEE_DESC: &str =
     "If provided, must be null. Zallet always calculates and applies the ZIP-317 fee internally.";
 pub(super) const PARAM_LIMIT_DESC: &str = "If supplied, caps the number of selected coinbase UTXOs to the highest-value `n` of those \
-     eligible.";
+     eligible. Recommended for wallets with many eligible coinbase UTXOs: without it, a single \
+     transaction is built containing all eligible UTXOs, which can exceed transaction-size \
+     limits at broadcast time. Zallet logs a warning (but does not enforce a hard cap) when \
+     the proposal selects more than ~400 inputs.";
 pub(super) const PARAM_MEMO_DESC: &str = "If supplied, stored in the memo field of the resulting shielded payment. Must be a \
      hex-encoded string (up to 1024 hex characters = 512 bytes).";
 pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
     "Policy for what information leakage is acceptable.";
+
+/// Soft threshold above which [`call`] emits a `warn!` log about potential
+/// transaction-size issues at broadcast time.
+///
+/// Not enforced as a hard limit: callers may legitimately want to drain a long
+/// tail of small coinbase UTXOs in a single call. The escape hatch for callers
+/// who hit broadcast-size issues is the `limit` RPC parameter, which shields
+/// the highest-value `n` UTXOs and leaves the rest for a subsequent call.
+pub(super) const COINBASE_INPUTS_WARN_THRESHOLD: u64 = 400;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn call(
@@ -344,48 +355,17 @@ pub(crate) async fn call(
         shielding_value: value_from_zatoshis(shielding_value_zats),
     };
 
-    // Check Orchard action limits.
-    let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
-    for step in proposal.steps() {
-        let orchard_spends = step
-            .shielded_inputs()
-            .iter()
-            .flat_map(|inputs| inputs.notes())
-            .filter(|note| note.note().protocol() == ShieldedProtocol::Orchard)
-            .count();
-
-        let orchard_outputs = step
-            .payment_pools()
-            .values()
-            .filter(|pool| pool == &&PoolType::ORCHARD)
-            .count()
-            + step
-                .balance()
-                .proposed_change()
-                .iter()
-                .filter(|change| change.output_pool() == PoolType::ORCHARD)
-                .count();
-
-        let orchard_actions = orchard_spends.max(orchard_outputs);
-
-        if orchard_actions > orchard_actions_limit {
-            let (count, kind) = if orchard_outputs <= orchard_actions_limit {
-                (orchard_spends, "inputs")
-            } else if orchard_spends <= orchard_actions_limit {
-                (orchard_outputs, "outputs")
-            } else {
-                (orchard_actions, "actions")
-            };
-
-            return Err(LegacyCode::Misc.with_message(fl!(
-                "err-excess-orchard-actions",
-                count = count,
-                kind = kind,
-                limit = orchard_actions_limit,
-                config = "-orchardactionlimit=N",
-                bound = format!("N >= %u"),
-            )));
-        }
+    // Only warn when the caller did not constrain the batch themselves; if
+    // `limit` was supplied, the caller has already opted into a specific batch
+    // size and the warning is noise.
+    if limit.is_none() && shielding_utxos > COINBASE_INPUTS_WARN_THRESHOLD {
+        warn!(
+            "z_shieldcoinbase: proposal selected {} coinbase UTXOs, which exceeds the \
+             soft warning threshold of {}. The resulting transaction may exceed \
+             network/mempool size limits at broadcast time. If broadcast fails, retry \
+             with a `limit` parameter to shield in smaller batches.",
+            shielding_utxos, COINBASE_INPUTS_WARN_THRESHOLD,
+        );
     }
 
     // Derive the spending key for the account.

--- a/zallet/src/components/json_rpc/utils.rs
+++ b/zallet/src/components/json_rpc/utils.rs
@@ -27,6 +27,17 @@ use {
     zip32::fingerprint::SeedFingerprint,
 };
 
+#[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+use {
+    crate::error::ErrorKind,
+    std::collections::HashMap,
+    transparent::address::TransparentAddress,
+    zcash_client_backend::{
+        fees::StandardFeeRule, proposal::Proposal, wallet::TransparentAddressSource,
+    },
+    zcash_script::script,
+};
+
 /// The account identifier used for HD derivation of transparent and Sapling addresses via
 /// the legacy `getnewaddress` and `z_getnewaddress` code paths.
 #[cfg(zallet_build = "wallet")]
@@ -42,6 +53,66 @@ pub(super) async fn ensure_wallet_is_unlocked(keystore: &KeyStore) -> RpcResult<
     } else {
         Ok(())
     }
+}
+
+/// Collects the standalone (non-HD) transparent spending keys required to sign the
+/// transparent inputs of `proposal`.
+///
+/// Determines which transparent receivers in this account were imported standalone
+/// (vs. HD-derived). Only those have an associated entry in the keystore's
+/// standalone-key table; HD-derived receivers are signed for using `usk` and must not
+/// be looked up via `decrypt_standalone_transparent_key` (which would error with
+/// `QueryReturnedNoRows`).
+///
+/// Gated on `zcashd-import` because the keystore's standalone-key table (and the
+/// `decrypt_standalone_transparent_key` accessor) only exists under that feature.
+/// Also gated on the `wallet` build because its only callers (`z_send_many` and
+/// `z_shieldcoinbase`) are wallet-only, and the `DbConnection`/`KeyStore` types it
+/// uses are only imported in that build.
+#[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account_id: AccountUuid,
+    proposal: &Proposal<StandardFeeRule, NoteRef>,
+) -> RpcResult<HashMap<TransparentAddress, Vec<secp256k1::SecretKey>>> {
+    let standalone_addrs: HashSet<TransparentAddress> = wallet
+        .get_transparent_receivers(account_id, true, true)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .into_iter()
+        .filter_map(|(addr, metadata)| match metadata.source() {
+            TransparentAddressSource::StandalonePubkey(_)
+            | TransparentAddressSource::StandaloneScript(_) => Some(addr),
+            TransparentAddressSource::Derived { .. } => None,
+        })
+        .collect();
+
+    let mut keys: HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> = HashMap::new();
+    for step in proposal.steps() {
+        for input in step.transparent_inputs() {
+            if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
+                .ok()
+                .as_ref()
+                .and_then(TransparentAddress::from_script_from_chain)
+            {
+                if !standalone_addrs.contains(&address) {
+                    continue;
+                }
+                let secret_key = keystore
+                    .decrypt_standalone_transparent_key(&address)
+                    .await
+                    .map_err(|e| match e.kind() {
+                        // TODO: Improve internal error types.
+                        ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                            LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+                        }
+                        _ => LegacyCode::Database.with_message(e.to_string()),
+                    })?;
+                keys.entry(address).or_default().push(secret_key);
+            }
+        }
+    }
+    Ok(keys)
 }
 
 pub(crate) fn parse_txid(txid_str: &str) -> RpcResult<TxId> {

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -550,6 +550,9 @@ pub(crate) async fn fetch_transparent_utxos(
                 Script(script::Code(script.as_raw_bytes().to_vec())),
             ),
             Some(mined_height),
+            None,
+            None,
+            None,
         )
         .expect("the UTXO was detected via a supported address kind");
 

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -33,7 +33,7 @@
 
 #![allow(deprecated)] // For zaino
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{
     Arc,
     atomic::{AtomicU32, Ordering},
@@ -42,6 +42,7 @@ use std::time::Duration;
 
 use futures::StreamExt as _;
 use jsonrpsee::tracing::{self, debug, info, warn};
+use rusqlite::OptionalExtension;
 use tokio::{sync::Notify, time};
 use transparent::{
     address::Script,
@@ -154,6 +155,7 @@ impl WalletSync {
         let poll_transparent_task = crate::spawn!("Poll transparent", async move {
             poll_transparent(
                 chain_subscriber,
+                params,
                 db_data.as_mut(),
                 poll_tip_change_signal_receiver,
             )
@@ -506,10 +508,9 @@ async fn recover_history(
 /// stores them in the wallet database.
 pub(crate) async fn fetch_transparent_utxos(
     chain: &FetchServiceSubscriber,
+    params: &Network,
     db_data: &mut DbConnection,
 ) -> Result<(), SyncError> {
-    let params = db_data.params();
-
     // Collect all of the wallet's non-ephemeral transparent addresses.
     //
     // TODO: This is likely to be append-only unless we add support for removing an
@@ -532,22 +533,87 @@ pub(crate) async fn fetch_transparent_utxos(
         .z_get_address_utxos(AddressStrings::new(addresses))
         .await?;
 
-    // Notify the wallet about all mined UTXOs.
+    // Notify the wallet about all mined UTXOs, and collect unique (txid,
+    // mined_height) pairs for the second pass below — needed to populate
+    // `transactions.tx_index = 0` for coinbase (see zcash/wallet#436).
+    let mut tx_heights: HashMap<TxId, BlockHeight> = HashMap::new();
+
     for utxo in utxos {
         let (address, txid, index, script, value_zat, mined_height) = utxo.into_parts();
         debug!("{address} has UTXO in tx {txid} at index {}", index.index());
 
+        let mined_height = BlockHeight::from_u32(mined_height.0);
         let output = WalletTransparentOutput::from_parts(
             OutPoint::new(txid.0, index.index()),
             TxOut::new(
                 Zatoshis::const_from_u64(value_zat),
                 Script(script::Code(script.as_raw_bytes().to_vec())),
             ),
-            Some(BlockHeight::from_u32(mined_height.0)),
+            Some(mined_height),
         )
         .expect("the UTXO was detected via a supported address kind");
 
         db_data.put_received_transparent_utxo(&output)?;
+
+        tx_heights.insert(TxId::from_bytes(txid.0), mined_height);
+    }
+
+    // Second pass: enhance each newly-observed tx via `decrypt_and_store_transaction`
+    // so that `transactions.tx_index = 0` is recorded for coinbase (required by
+    // `TransparentOutputFilter::CoinbaseOnly`).
+    //
+    // Skip when either `tx_index` or `raw` is already set: the row has been
+    // enhanced (or had `tx_index` populated by the block scanner) and a re-fetch
+    // would be redundant. This bounds the per-poll cost so that an attacker
+    // flooding the wallet with non-coinbase transparent UTXOs cannot drive
+    // unbounded RPC fetches. Fetch failures are logged-and-skipped to keep a
+    // flaky indexer from wedging sync.
+    for (txid, mined_height) in tx_heights {
+        let already_enhanced = db_data
+            .with_raw(|conn, _params| {
+                conn.query_row(
+                    "SELECT tx_index IS NOT NULL OR raw IS NOT NULL \
+                     FROM transactions WHERE txid = :txid",
+                    rusqlite::named_params![":txid": &txid.as_ref()[..]],
+                    |row| row.get::<_, bool>(0),
+                )
+                .optional()
+            })
+            .map_err(zcash_client_sqlite::error::SqliteClientError::from)?;
+        if already_enhanced.unwrap_or(false) {
+            continue;
+        }
+
+        let tx_obj = match chain.get_raw_transaction(txid.to_string(), Some(1)).await {
+            Ok(zebra_rpc::methods::GetRawTransaction::Object(tx_obj)) => tx_obj,
+            Ok(zebra_rpc::methods::GetRawTransaction::Raw(_)) => {
+                warn!("Unexpected raw response for {txid}; skipping tx_index update");
+                continue;
+            }
+            Err(e) => {
+                warn!("Failed to fetch tx {txid} for tx_index update: {e}");
+                continue;
+            }
+        };
+
+        let parse_height = tx_obj
+            .height()
+            .and_then(|h| u32::try_from(h).ok().map(BlockHeight::from_u32))
+            .unwrap_or(mined_height);
+        let tx = match Transaction::read(
+            tx_obj.hex().as_ref(),
+            consensus::BranchId::for_height(params, parse_height),
+        ) {
+            Ok(tx) => tx,
+            Err(e) => {
+                warn!("Failed to parse tx {txid} for tx_index update: {e}");
+                continue;
+            }
+        };
+
+        if let Err(e) = decrypt_and_store_transaction(params, db_data, &tx, Some(mined_height)) {
+            warn!("Failed to enhance tx {txid} for tx_index update: {e}");
+        }
     }
 
     Ok(())
@@ -559,6 +625,7 @@ pub(crate) async fn fetch_transparent_utxos(
 #[tracing::instrument(skip_all)]
 async fn poll_transparent(
     chain: FetchServiceSubscriber,
+    params: Network,
     db_data: &mut DbConnection,
     tip_change_signal: Arc<Notify>,
 ) -> Result<(), SyncError> {
@@ -568,7 +635,7 @@ async fn poll_transparent(
         // Wait for the chain tip to advance
         tip_change_signal.notified().await;
 
-        fetch_transparent_utxos(&chain, db_data).await?;
+        fetch_transparent_utxos(&chain, &params, db_data).await?;
         // TODO: Once Zaino has an index over the mempool, monitor it for changes to the
         // unmined UTXO set (which we can't get directly from the stream without building
         // an index because existing mempool txs can be spent within the mempool).


### PR DESCRIPTION
COR-264

## Summary

Adds the `z_shieldcoinbase` JSON-RPC method, integrated with the upstream `propose_shielding_coinbase` API ([librustzcash#2353](https://github.com/zcash/librustzcash/pull/2353), merged). Matches `zcashd`'s pre-flight return shape (`{ remainingUTXOs, remainingValue, shieldingUTXOs, shieldingValue, opid }`). End-to-end verified against [`zcash/integration-tests#80`](https://github.com/zcash/integration-tests/pull/80) (all 10 tests pass).

The `memo` and `limit` parameters are honored: `memo` is attached to the resulting shielded payment, and `limit` caps the number of selected coinbase UTXOs to the highest-value `n` of those eligible. The proposal produces no transparent or shielded change, preserving the privacy invariant that a shielded change output would otherwise let `toaddress` learn the sender's total selected-coinbase value.

## Commits

1. `feat(rpc): add z_shieldcoinbase` — the RPC method itself, initially built against `propose_shielding` + `TransparentOutputFilter::CoinbaseOnly`.
2. `fix(rpc): accumulate standalone transparent keys per address` — replaces an overwriting `keys.insert(...)` with `entry().or_default().push(...)` so duplicate addresses don't drop signing keys. Applied in both `z_sendmany` and `z_shieldcoinbase`.
3. `feat(rpc): match zcashd's z_shieldcoinbase pre-flight return shape` — returns the 5-field object instead of a bare opid string.
4. `fix(sync): record tx_index for coinbase transactions during transparent ingest` — `fetch_transparent_utxos` now routes each observed tx through `decrypt_and_store_transaction`, which sets `tx_index = 0` for coinbase. Required for `TransparentOutputFilter::CoinbaseOnly` to work. Fixes #436.
5. `fix(rpc): only decrypt standalone keys for standalone-imported addresses` — pre-filters the proposal-input loop to skip HD-derived addresses, which have no standalone-key entry. Without this, every `z_shieldcoinbase`/`z_sendmany` call with HD-derived inputs failed with `"Query returned no rows"`.
6. `deps + feat: integrate propose_shielding_coinbase upstream` — bumps librustzcash crates to a `[patch.crates-io]` pin at `zcash/librustzcash@541f5b562e` (PR #2353 merge), absorbs the API changes that came along (`WalletTransparentOutput<AccountId>` generic, `WalletUtxo` removal, `rewind_to_height` → `rewind_to_chain_state`, `from_parts` extra args), and rewrites `z_shieldcoinbase` to call `propose_shielding_coinbase`. The `memo` and `limit` parameters are now honored, and the `_memo` / `_limit` TODOs are removed.

Fixes #89
Fixes #436

The `[patch.crates-io]` block in commit 6 is temporary — drop it once librustzcash cuts a release containing `propose_shielding_coinbase`.