### PR TITLE
fix: Use zcashd transaction data to estimate address exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,7 @@ be considered breaking changes.
   `zcashd` didn't include in its response.
 - Significant performance improvements to `zallet migrate-zcashd-wallet`.
 - `zallet migrate-zcashd-wallet` now accepts `--no-scan` to skip chain scanning
-  during migration. Keys, accounts, and transaction data are still imported, but
-  block heights and tree state are not resolved from the chain. Cannot be
-  combined with `--buffer-wallet-transactions`. Useful when chain data is not
-  available.
+  during migration.
 
 ### Fixed
 - `listaddresses` no longer returns an internal error when the wallet contains

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,8 +1252,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "core2"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+source = "git+https://github.com/bbqsrc/core2.git?rev=7bf2611bd9a52b438300c640e142ad5c1298b05b#7bf2611bd9a52b438300c640e142ad5c1298b05b"
 dependencies = [
  "memchr",
 ]
@@ -1261,11 +1260,16 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+source = "git+https://github.com/bbqsrc/core2.git?rev=545e84bcb0f235b12e21351e0c69767958efe2a7#545e84bcb0f235b12e21351e0c69767958efe2a7"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
 
 [[package]]
 name = "cpufeatures"
@@ -1858,11 +1862,21 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
 dependencies = [
  "blake2b_simd",
  "core2 0.3.3",
  "document-features",
+]
+
+[[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+dependencies = [
+ "blake2b_simd",
+ "corez",
 ]
 
 [[package]]
@@ -1894,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3800,14 +3814,14 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01cd4ea711aab5f263f2b7aa6966687a2d6c7df4f78eb1b97a66a7a4e78e3b"
+checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2 0.3.3",
+ "corez",
  "ff",
  "fpe",
  "getset",
@@ -4369,7 +4383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4389,7 +4403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4409,7 +4423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -4422,7 +4436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -5241,9 +5255,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5433ab8c1cd52dfad3b903143e371d5bdd514ab7952f71414e6d66a5da8223cd"
+checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
  "aes",
  "bellman",
@@ -5251,7 +5265,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2 0.3.3",
+ "corez",
  "document-features",
  "ff",
  "fpe",
@@ -7534,7 +7548,7 @@ dependencies = [
  "known-folders",
  "nix",
  "once_cell",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "phf 0.12.1",
  "quote",
  "rand 0.8.5",
@@ -7543,7 +7557,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "rust_decimal",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "schemars",
  "schemerz",
  "schemerz-rusqlite",
@@ -7573,17 +7587,17 @@ dependencies = [
  "zaino-fetch",
  "zaino-proto",
  "zaino-state",
- "zcash_address 0.10.1",
+ "zcash_address 0.11.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding 0.3.0",
- "zcash_keys 0.12.0",
+ "zcash_encoding 0.4.0",
+ "zcash_keys 0.13.0",
  "zcash_note_encryption",
- "zcash_primitives 0.26.4",
- "zcash_proofs 0.26.1",
- "zcash_protocol 0.7.2",
+ "zcash_primitives 0.27.0",
+ "zcash_proofs 0.27.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -7622,21 +7636,21 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.11.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
- "core2 0.3.3",
+ "corez",
  "f4jumble",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.8.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.22.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7655,13 +7669,13 @@ dependencies = [
  "incrementalmerkletree 0.8.2",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "pasta_curves",
  "percent-encoding",
  "prost 0.14.1",
  "rand_core 0.6.4",
  "rayon",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
  "shardtree",
@@ -7673,22 +7687,22 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which 8.0.0",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_keys 0.12.0",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0",
+ "zcash_keys 0.13.0",
  "zcash_note_encryption",
- "zcash_primitives 0.26.4",
- "zcash_protocol 0.7.2",
+ "zcash_primitives 0.27.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
  "zip32 0.2.1",
  "zip321",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.19.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.20.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bitflags 2.10.0",
@@ -7701,14 +7715,14 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "prost 0.14.1",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_distr",
  "regex",
  "rusqlite",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "schemerz",
  "schemerz-rusqlite",
  "secp256k1 0.29.1",
@@ -7719,14 +7733,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.10.1",
+ "zcash_address 0.11.0",
  "zcash_client_backend",
- "zcash_encoding 0.3.0",
- "zcash_keys 0.12.0",
- "zcash_primitives 0.26.4",
- "zcash_protocol 0.7.2",
+ "zcash_encoding 0.4.0",
+ "zcash_keys 0.13.0",
+ "zcash_primitives 0.27.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
  "zip32 0.2.1",
 ]
 
@@ -7743,9 +7757,19 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
  "core2 0.3.3",
+ "nonempty 0.11.0",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+dependencies = [
+ "corez",
  "hex",
  "nonempty 0.11.0",
 ]
@@ -7753,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7816,8 +7840,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7826,23 +7850,23 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "core2 0.3.3",
+ "corez",
  "document-features",
  "group",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "rand_core 0.6.4",
  "regex",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
- "zcash_transparent 0.6.3",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.8.0",
+ "zcash_transparent 0.7.0",
  "zeroize",
  "zip32 0.2.1",
 ]
@@ -7872,7 +7896,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "document-features",
- "equihash",
+ "equihash 0.2.2",
  "ff",
  "fpe",
  "group",
@@ -7912,7 +7936,7 @@ dependencies = [
  "core2 0.3.3",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.2.2",
  "ff",
  "fpe",
  "getset",
@@ -7943,32 +7967,32 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.27.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "core2 0.3.3",
+ "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0",
  "ff",
  "hex",
  "incrementalmerkletree 0.8.2",
  "jubjub",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "rand_core 0.6.4",
  "redjubjub 0.8.0",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0",
  "zcash_note_encryption",
- "zcash_protocol 0.7.2",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
 ]
 
 [[package]]
@@ -7996,8 +8020,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.26.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.27.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8009,11 +8033,11 @@ dependencies = [
  "known-folders",
  "rand_core 0.6.4",
  "redjubjub 0.8.0",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.26.4",
+ "zcash_primitives 0.27.0",
 ]
 
 [[package]]
@@ -8042,14 +8066,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.7.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.8.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
- "core2 0.3.3",
+ "corez",
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0",
 ]
 
 [[package]]
@@ -8131,12 +8155,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.7.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bs58",
- "core2 0.3.3",
+ "corez",
  "document-features",
  "getset",
  "hex",
@@ -8145,9 +8169,9 @@ dependencies = [
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
  "zcash_spec 0.2.1",
  "zip32 0.2.1",
@@ -8170,7 +8194,7 @@ dependencies = [
  "chrono",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.2",
  "futures",
  "group",
  "halo2_proofs",
@@ -8575,12 +8599,12 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.7.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.10.1",
- "zcash_protocol 0.7.2",
+ "zcash_address 0.11.0",
+ "zcash_protocol 0.8.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hex = "0.4"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision", "raw_value"] }
 toml = "0.8"
-zcash_address = "0.10"
+zcash_address = "0.11"
 
 # Randomness
 rand = "0.8"
@@ -103,16 +103,16 @@ tracing-log = "0.2"
 tracing-subscriber = "0.3"
 
 # Zcash consensus
-zcash_protocol = "0.7"
+zcash_protocol = "0.8"
 
 # Zcash payment protocols
-orchard = "0.12"
-sapling = { package = "sapling-crypto", version = "0.6" }
-transparent = { package = "zcash_transparent", version = "0.6" }
-zcash_encoding = "0.3.0"
-zcash_keys = { version = "0.12", features = ["transparent-inputs", "sapling", "orchard", "transparent-key-encoding"] }
-zcash_primitives = "0.26"
-zcash_proofs = "0.26"
+orchard = "0.13"
+sapling = { package = "sapling-crypto", version = "0.7" }
+transparent = { package = "zcash_transparent", version = "0.7" }
+zcash_encoding = "0.4"
+zcash_keys = { version = "0.13", features = ["transparent-inputs", "sapling", "orchard", "transparent-key-encoding"] }
+zcash_primitives = "0.27"
+zcash_proofs = "0.27"
 zcash_script = "0.4.3"
 secp256k1 = { version = "0.29", features = ["recovery"] }
 
@@ -136,8 +136,8 @@ schemerz-rusqlite = "0.370.0"
 shardtree = "0.6"
 time = "0.3"
 uuid = "1"
-zcash_client_backend = "0.21"
-zcash_client_sqlite = "0.19"
+zcash_client_backend = "0.22"
+zcash_client_sqlite = "0.20"
 zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
@@ -152,18 +152,25 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
+# Workaround: every crates.io version of `core2` is yanked, so a fresh build
+# (e.g. `cargo build` after `rm Cargo.lock`) cannot resolve `core2`. We patch
+# both the `^0.3` requirement (from unpatched `equihash 0.2.x` via
+# `zebra-chain 2.0.0`) and the `^0.4` requirement (from `zaino-state`) using
+# git sources, until upstream deps drop their dependency on `core2`.
+core2 = { git = "https://github.com/bbqsrc/core2.git", rev = "7bf2611bd9a52b438300c640e142ad5c1298b05b" }
+core2_04 = { package = "core2", git = "https://github.com/bbqsrc/core2.git", rev = "545e84bcb0f235b12e21351e0c69767958efe2a7" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,6 +28,12 @@ audit-as-crates-io = true
 [policy.age-core]
 audit-as-crates-io = true
 
+[policy."core2:0.3.3@git:7bf2611bd9a52b438300c640e142ad5c1298b05b"]
+audit-as-crates-io = true
+
+[policy."core2:0.4.0@git:545e84bcb0f235b12e21351e0c69767958efe2a7"]
+audit-as-crates-io = true
+
 [policy.equihash]
 audit-as-crates-io = true
 
@@ -46,7 +52,7 @@ audit-as-crates-io = true
 [policy.zaino-state]
 audit-as-crates-io = true
 
-[policy."zcash_address:0.10.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_address:0.11.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_address:0.6.3"]
@@ -61,7 +67,7 @@ audit-as-crates-io = true
 
 [policy."zcash_encoding:0.2.2"]
 
-[policy."zcash_encoding:0.3.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_encoding:0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy.zcash_history]
@@ -69,7 +75,7 @@ audit-as-crates-io = true
 
 [policy."zcash_keys:0.10.1"]
 
-[policy."zcash_keys:0.12.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_keys:0.13.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_keys:0.4.1"]
@@ -78,24 +84,24 @@ audit-as-crates-io = true
 
 [policy."zcash_primitives:0.24.1"]
 
-[policy."zcash_primitives:0.26.4@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_primitives:0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_proofs:0.24.0"]
 
-[policy."zcash_proofs:0.26.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_proofs:0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_protocol:0.4.3"]
 
 [policy."zcash_protocol:0.6.2"]
 
-[policy."zcash_protocol:0.7.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_protocol:0.8.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_transparent:0.4.0"]
 
-[policy."zcash_transparent:0.6.3@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_transparent:0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy.zip321]
@@ -450,7 +456,19 @@ version = "0.3.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.core2]]
+version = "0.3.3@git:7bf2611bd9a52b438300c640e142ad5c1298b05b"
+criteria = "safe-to-deploy"
+
+[[exemptions.core2]]
 version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.core2]]
+version = "0.4.0@git:545e84bcb0f235b12e21351e0c69767958efe2a7"
+criteria = "safe-to-deploy"
+
+[[exemptions.corez]]
+version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cpufeatures]]
@@ -638,7 +656,11 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.2.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.equihash]]
+version = "0.3.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
@@ -646,7 +668,7 @@ version = "0.6.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.f4jumble]]
-version = "0.1.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.1.1@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.fallible-iterator]]
@@ -1105,6 +1127,10 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.orchard]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.ordered-map]]
 version = "0.4.2"
 criteria = "safe-to-deploy"
@@ -1471,6 +1497,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.same-file]]
 version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.sapling-crypto]]
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars]]
@@ -1962,15 +1992,15 @@ version = "0.1.2@git:15b81f110349b34090341b3ab8b7cd58c7b9aeef"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_address]]
-version = "0.10.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.11.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_backend]]
-version = "0.21.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.22.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_sqlite]]
-version = "0.19.5@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.20.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
@@ -1978,27 +2008,27 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
-version = "0.3.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_history]]
-version = "0.4.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_keys]]
-version = "0.12.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.13.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_primitives]]
-version = "0.26.4@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_proofs]]
-version = "0.26.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_protocol]]
-version = "0.7.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.8.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_spec]]
@@ -2006,7 +2036,7 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_transparent]]
-version = "0.6.3@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
@@ -2058,5 +2088,5 @@ version = "0.11.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zip321]]
-version = "0.6.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -364,6 +364,13 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_encoding]]
+version = "0.3.0"
+when = "2025-02-21"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_keys]]
 version = "0.4.1"
 when = "2025-05-09"

--- a/zallet/src/cli.rs
+++ b/zallet/src/cli.rs
@@ -199,7 +199,7 @@ pub(crate) struct MigrateZcashdWalletCmd {
     /// Skip chain scanning during migration. Keys, accounts, and transaction data are
     /// still imported, but block heights and tree state are not resolved from the chain.
     /// Useful when the corresponding chain data is not available.
-    #[arg(long, conflicts_with = "buffer_wallet_transactions")]
+    #[arg(long)]
     pub(crate) no_scan: bool,
 
     /// Temporary flag ensuring any alpha users are aware the migration is not stable.

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -11,6 +11,7 @@ use bip0039::{English, Mnemonic};
 use secp256k1::PublicKey;
 use secrecy::{ExposeSecret, SecretVec};
 use shardtree::error::ShardTreeError;
+use transparent::address::TransparentAddress;
 use zaino_fetch::jsonrpsee::response::block_header::GetBlockHeader;
 use zaino_state::{FetchServiceError, LightWalletIndexer, ZcashIndexer};
 use zcash_client_backend::{
@@ -26,7 +27,7 @@ use zcash_keys::keys::{
     zcashd::{PathParseError, ZcashdHdDerivation},
 };
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
-use zcash_protocol::consensus::{BlockHeight, BranchId, NetworkType, Parameters};
+use zcash_protocol::consensus::{BlockHeight, BranchId, NetworkType, NetworkUpgrade, Parameters};
 use zewif_zcashd::{BDBDump, ZcashdDump, ZcashdParser, ZcashdWallet};
 use zip32::{AccountId, fingerprint::SeedFingerprint};
 
@@ -81,6 +82,7 @@ impl AsyncRunnable for MigrateZcashdWalletCmd {
             wallet,
             self.buffer_wallet_transactions,
             self.allow_multiple_wallet_imports,
+            self.no_scan,
         )
         .await?;
 
@@ -223,6 +225,7 @@ impl MigrateZcashdWalletCmd {
         wallet: ZcashdWallet,
         buffer_wallet_transactions: bool,
         allow_multiple_wallet_imports: bool,
+        no_scan: bool,
     ) -> Result<(), MigrateError> {
         let mut db_data = db.handle().await?;
         let network_params = *db_data.params();
@@ -282,11 +285,14 @@ impl MigrateZcashdWalletCmd {
             (None, None)
         };
         let sapling_activation = network_params
-            .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
+            .activation_height(NetworkUpgrade::Sapling)
             .expect("Sapling activation height is defined.");
 
-        // Collect an index from txid to block height for all transactions known to the wallet that
-        // appear in the main chain.
+        // Collect an index from block hash to block height for all transactions known to the
+        // wallet that appear in the main chain. This only runs when we have a chain subscriber;
+        // without one, all transactions are stored as unmined and a later scan will assign
+        // accurate heights. Address exposure is handled separately via
+        // `mark_transparent_addresses_exposed` below.
         info!(
             "Wallet contains {} transactions",
             wallet.transactions().len(),
@@ -351,10 +357,13 @@ impl MigrateZcashdWalletCmd {
             )
             .await?
         } else {
-            // In no-scan mode, approximate the wallet birthday from transaction expiry
-            // heights. Expiry heights are typically creation_height + 40 (the default
-            // TX_EXPIRY_DELTA in zcashd). Subtracting 1000 gives a conservative lower
-            // bound on the earliest mined height.
+            // In no-scan mode, no chain is available, and we cannot determine actual transaction
+            // mined hieghts. Instead, we estimate the wallet's birthday, and then conservatively
+            // mark each address with a mined transaction as exposed at that birthday height.
+            //
+            // We approximate the wallet birthday from transaction expiry heights. Expiry heights
+            // are typically creation_height + 40 (the default TX_EXPIRY_DELTA in zcashd).
+            // Subtracting 1000 gives a conservative lower bound on the earliest mined height.
             let birthday_height = wallet
                 .transactions()
                 .values()
@@ -614,6 +623,58 @@ impl MigrateZcashdWalletCmd {
                 .into_iter()
                 .map(|key| *key.pubkey()),
         )?;
+
+        // In no-scan mode, we need to collect all observed transactions and manually mark them as
+        // exposed, since the chain will not be scanned to detect their exposure heights.
+        if no_scan {
+            let mut observed: HashSet<TransparentAddress> = HashSet::new();
+            let mut buf = vec![];
+            for wallet_tx in wallet.transactions().values() {
+                buf.clear();
+                wallet_tx.transaction().write(&mut buf)?;
+                // For v5+ txs the embedded branch id overrides this value; for earlier
+                // versions the branch id is only stored as metadata and does not affect
+                // parsing. Any value works.
+                let tx = Transaction::read(buf.as_slice(), BranchId::Sprout)?;
+                if let Some(bundle) = tx.transparent_bundle() {
+                    for vout in &bundle.vout {
+                        if let Some(addr) = vout
+                            .script_kind()
+                            .as_ref()
+                            .and_then(TransparentAddress::from_script_kind)
+                        {
+                            observed.insert(addr);
+                        }
+                    }
+                }
+            }
+
+            // The upstream API rolls back the whole batch if any address is not tracked,
+            // so filter to just the wallet's known receivers (external counterparties drop
+            // out here).
+            let mut known: HashSet<TransparentAddress> = HashSet::new();
+            for account_id in db_data.get_account_ids()? {
+                known.extend(
+                    db_data
+                        .get_transparent_receivers(account_id, true, true)?
+                        .into_keys(),
+                );
+            }
+
+            let birthday_height = wallet_birthday.height();
+            let to_mark: Vec<(TransparentAddress, BlockHeight)> = observed
+                .intersection(&known)
+                .map(|addr| (*addr, birthday_height))
+                .collect();
+            if !to_mark.is_empty() {
+                db_data.mark_transparent_addresses_exposed(&to_mark)?;
+                info!(
+                    "Marked {} transparent addresses as exposed at birthday height {}",
+                    to_mark.len(),
+                    birthday_height,
+                );
+            }
+        }
 
         // Since we've retrieved the raw transaction data anyway, preemptively store it for faster
         // access to balance & to set priorities in the scan queue.

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -262,6 +262,17 @@ impl WalletRead for DbConnection {
         self.with(|db_data| db_data.get_account_for_ufvk(ufvk))
     }
 
+    fn find_account_for_address<P: zcash_protocol::consensus::Parameters>(
+        &self,
+        params: &P,
+        address: &zcash_keys::address::Address,
+    ) -> Result<
+        Option<Self::AccountId>,
+        zcash_client_backend::data_api::error::FindAccountForAddressError<Self::Error>,
+    > {
+        self.with(|db_data| db_data.find_account_for_address(params, address))
+    }
+
     fn list_addresses(&self, account: Self::AccountId) -> Result<Vec<AddressInfo>, Self::Error> {
         self.with(|db_data| db_data.list_addresses(account))
     }
@@ -498,9 +509,15 @@ impl InputSource for DbConnection {
         address: &TransparentAddress,
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
+        output_filter: zcash_client_backend::data_api::TransparentOutputFilter,
     ) -> Result<Vec<WalletUtxo>, Self::Error> {
         self.with(|db_data| {
-            db_data.get_spendable_transparent_outputs(address, target_height, confirmations_policy)
+            db_data.get_spendable_transparent_outputs(
+                address,
+                target_height,
+                confirmations_policy,
+                output_filter,
+            )
         })
     }
 
@@ -643,6 +660,10 @@ impl WalletWrite for DbConnection {
         self.with_mut(|mut db_data| db_data.truncate_to_height(max_height))
     }
 
+    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        self.with_mut(|mut db_data| db_data.rewind_to_height(max_height))
+    }
+
     fn truncate_to_chain_state(&mut self, chain_state: ChainState) -> Result<(), Self::Error> {
         self.with_mut(|mut db_data| db_data.truncate_to_chain_state(chain_state))
     }
@@ -677,6 +698,13 @@ impl WalletWrite for DbConnection {
         as_of_height: BlockHeight,
     ) -> Result<(), Self::Error> {
         self.with_mut(|mut db_data| db_data.notify_address_checked(request, as_of_height))
+    }
+
+    fn mark_transparent_addresses_exposed(
+        &mut self,
+        exposures: &[(TransparentAddress, BlockHeight)],
+    ) -> Result<(), Self::Error> {
+        self.with_mut(|mut db_data| db_data.mark_transparent_addresses_exposed(exposures))
     }
 }
 

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -192,7 +192,12 @@ pub(crate) fn call(
             .iter()
             .try_fold(vec![], |mut acc, (addr, _)| {
                 let mut outputs = wallet
-                    .get_spendable_transparent_outputs(addr, target_height, confirmations_policy)
+                    .get_spendable_transparent_outputs(
+                        addr,
+                        target_height,
+                        confirmations_policy,
+                        zcash_client_backend::data_api::TransparentOutputFilter::All,
+                    )
                     .map_err(|e| {
                         RpcError::owned(
                             LegacyCode::Database.into(),

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use documented::{Documented, DocumentedFields};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use zcash_client_backend::data_api::wallet::ConfirmationsPolicy;
+use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, ConfirmationsPolicyError};
 use zcash_protocol::consensus::NetworkType;
 
 use crate::commands::{lock_datadir, resolve_datadir_path};
@@ -209,8 +209,7 @@ impl BuilderSection {
     ///
     /// This will return an error if the number of confirmations required for spending untrusted
     /// TXOs is less than the number of confirmations required for spending trusted TXOs
-    #[allow(clippy::result_unit_err)]
-    pub fn confirmations_policy(&self) -> Result<ConfirmationsPolicy, ()> {
+    pub fn confirmations_policy(&self) -> Result<ConfirmationsPolicy, ConfirmationsPolicyError> {
         let allow_zero_conf_shielding = self.untrusted_confirmations() == 0;
         ConfirmationsPolicy::new(
             NonZeroU32::new(self.trusted_confirmations()).unwrap_or(NonZeroU32::MIN),


### PR DESCRIPTION
This PR augments the `migrate-zcashd-wallet` command's `--no-scan` mode to use transaction data stored in the wallet to infer address exposure.

Previously in `--no-scan` mode, addresses were imported, but not marked as exposed.

Resolves: https://github.com/zcash/wallet/issues/421
Resolves: [COR-1182](https://linear.app/zodl/issue/COR-1182/bug-zcashd-wallet-migration-transaction-buffer-does-not-update-key)