### PR TITLE
deps: Migrate to latest releases of the Zcash crates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,5 @@
 !.cargo
 !Cargo.toml
 !Cargo.lock
+!vendor
 !zallet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1910,7 +1911,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7639,7 +7641,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.11.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f3db1087875052b5ad0f9e7179a7e7794f0ae9cb1d6ab2b7db29f7b9a9b0b"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -7652,7 +7655,8 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d052d002ffd18bf4f129ab161e0a584c96b3578d9b9e88cd2dafef7df7db408"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7704,7 +7708,8 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.20.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5e668f550f94a913578708d2a3ac4a4f7c839247e8e14ebd672ab6b6d352b6"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bitflags 2.10.0",
@@ -7769,7 +7774,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7779,7 +7785,8 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7843,7 +7850,8 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b340e2bc20698c4d784d920dcda1f270d076bef2b0726b732ca9ca7574d61241"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7970,7 +7978,8 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.27.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59f418f8b1274a526d57dfa3b1a7b3724f04926c84712a27c1602e4b44bfacd"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8023,7 +8032,8 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.27.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c6749aeaf49a56874d915482bc03e4afb9f6e561ed476b7c906e6d9de3ef74"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8069,7 +8079,8 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ef3de16a4464a574591aa3e4ea875116372638307d7ae04415279ec187ba88"
 dependencies = [
  "corez",
  "document-features",
@@ -8158,7 +8169,8 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9ad72051b49432acd56d44ab301bb6467bd70eb23faab3f35539e4ecf2733d"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bs58",
@@ -8602,7 +8614,8 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2159ebf6e48565b2fc74a4beae8d906f06657ca61c0db21a0361f15a075feee"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "blake2b_simd",
  "core2 0.3.3",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "blake2b_simd",
 ]
@@ -5241,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5433ab8c1cd52dfad3b903143e371d5bdd514ab7952f71414e6d66a5da8223cd"
+checksum = "ddc5fda664085f3893372b703a81e03003b3be46da50952468d7f41f996208ae"
 dependencies = [
  "aes",
  "bellman",
@@ -7543,7 +7543,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "rust_decimal",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.6.2",
  "schemars",
  "schemerz",
  "schemerz-rusqlite",
@@ -7623,7 +7623,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -7636,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7661,7 +7661,7 @@ dependencies = [
  "prost 0.14.1",
  "rand_core 0.6.4",
  "rayon",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.6.2",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
  "shardtree",
@@ -7688,7 +7688,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bitflags 2.10.0",
@@ -7708,7 +7708,7 @@ dependencies = [
  "rand_distr",
  "regex",
  "rusqlite",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.6.2",
  "schemerz",
  "schemerz-rusqlite",
  "secp256k1 0.29.1",
@@ -7743,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "core2 0.3.3",
  "hex",
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7834,7 +7834,7 @@ dependencies = [
  "orchard 0.12.0",
  "rand_core 0.6.4",
  "regex",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.6.2",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
  "subtle",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7961,7 +7961,7 @@ dependencies = [
  "orchard 0.12.0",
  "rand_core 0.6.4",
  "redjubjub 0.8.0",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.6.2",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "zcash_encoding 0.3.0",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8009,7 +8009,7 @@ dependencies = [
  "known-folders",
  "rand_core 0.6.4",
  "redjubjub 0.8.0",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.6.2",
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "core2 0.3.3",
  "document-features",
@@ -8132,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bs58",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=eb70164b0ea72f87dba8ae54e5e0fd5f5be44029#eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7593,10 +7593,10 @@ dependencies = [
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding 0.4.0",
- "zcash_keys 0.12.0",
+ "zcash_keys 0.13.0",
  "zcash_note_encryption",
  "zcash_primitives 0.27.0",
- "zcash_proofs 0.26.1",
+ "zcash_proofs 0.27.0",
  "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
  "zcash_transparent 0.7.0",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.11.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -7651,8 +7651,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+version = "0.22.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7691,7 +7691,7 @@ dependencies = [
  "which 8.0.0",
  "zcash_address 0.11.0",
  "zcash_encoding 0.4.0",
- "zcash_keys 0.12.0",
+ "zcash_keys 0.13.0",
  "zcash_note_encryption",
  "zcash_primitives 0.27.0",
  "zcash_protocol 0.8.0",
@@ -7703,8 +7703,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.19.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+version = "0.20.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bitflags 2.10.0",
@@ -7738,7 +7738,7 @@ dependencies = [
  "zcash_address 0.11.0",
  "zcash_client_backend",
  "zcash_encoding 0.4.0",
- "zcash_keys 0.12.0",
+ "zcash_keys 0.13.0",
  "zcash_primitives 0.27.0",
  "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
@@ -7769,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "corez",
  "hex",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7842,8 +7842,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.27.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8022,8 +8022,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.26.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+version = "0.27.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8069,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "corez",
  "document-features",
@@ -8158,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bs58",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0268bbcf8007bff6a7a94cb7c1e229b595a6489e#0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,20 +1251,16 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+version = "0.3.99"
 dependencies = [
- "memchr",
+ "corez",
 ]
 
 [[package]]
 name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+version = "0.4.99"
 dependencies = [
- "memchr",
+ "corez",
 ]
 
 [[package]]
@@ -1868,7 +1864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
 dependencies = [
  "blake2b_simd",
- "core2 0.3.3",
+ "core2 0.3.99",
  "document-features",
 ]
 
@@ -3755,7 +3751,7 @@ dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2 0.3.3",
+ "core2 0.3.99",
  "ff",
  "fpe",
  "getset",
@@ -3790,7 +3786,7 @@ dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2 0.3.3",
+ "core2 0.3.99",
  "ff",
  "fpe",
  "getset",
@@ -5236,7 +5232,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2 0.3.3",
+ "core2 0.3.99",
  "document-features",
  "ff",
  "fpe",
@@ -7481,7 +7477,7 @@ dependencies = [
  "bs58",
  "cargo-lock",
  "chrono",
- "core2 0.4.0",
+ "core2 0.4.99",
  "dashmap",
  "derive_more",
  "futures",
@@ -7618,7 +7614,7 @@ checksum = "d32b380113014b136aec579ea1c07fef747a818b9ac97d91daa0ec3b7a642bc0"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
- "core2 0.3.3",
+ "core2 0.3.99",
  "f4jumble",
  "zcash_encoding 0.2.2",
  "zcash_protocol 0.4.3",
@@ -7632,7 +7628,7 @@ checksum = "7c984ae01367a4a3d20e9d34ae4e4cc0dca004b22d9a10a51eec43f43934612e"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
- "core2 0.3.3",
+ "core2 0.3.99",
  "f4jumble",
  "zcash_encoding 0.3.0",
  "zcash_protocol 0.6.2",
@@ -7757,7 +7753,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3654116ae23ab67dd1f849b01f8821a8a156f884807ff665eac109bf28306c4d"
 dependencies = [
- "core2 0.3.3",
+ "core2 0.3.99",
  "nonempty 0.7.0",
 ]
 
@@ -7767,7 +7763,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
- "core2 0.3.3",
+ "core2 0.3.99",
  "nonempty 0.11.0",
 ]
 
@@ -7831,7 +7827,7 @@ dependencies = [
  "blake2b_simd",
  "bls12_381",
  "bs58",
- "core2 0.3.3",
+ "core2 0.3.99",
  "document-features",
  "group",
  "memuse",
@@ -7943,7 +7939,7 @@ dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
  "bs58",
- "core2 0.3.3",
+ "core2 0.3.99",
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash 0.2.2",
@@ -8058,7 +8054,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb36b15b5a1be70b30c32ce40372dead6561df8a467e297f96b892873a63a2"
 dependencies = [
- "core2 0.3.3",
+ "core2 0.3.99",
  "document-features",
  "hex",
  "memuse",
@@ -8070,7 +8066,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cc76dd1f77be473e5829dbd34890bcd36d08b1e8dde2da0aea355c812a8f28"
 dependencies = [
- "core2 0.3.3",
+ "core2 0.3.99",
  "document-features",
  "hex",
  "memuse",
@@ -8151,7 +8147,7 @@ dependencies = [
  "bip32 0.6.0-pre.1",
  "blake2b_simd",
  "bs58",
- "core2 0.3.3",
+ "core2 0.3.99",
  "document-features",
  "getset",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,11 +1864,21 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
 dependencies = [
  "blake2b_simd",
  "core2 0.3.3",
  "document-features",
+]
+
+[[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+dependencies = [
+ "blake2b_simd",
+ "corez",
 ]
 
 [[package]]
@@ -1894,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3800,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01cd4ea711aab5f263f2b7aa6966687a2d6c7df4f78eb1b97a66a7a4e78e3b"
+checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2 0.3.3",
+ "corez",
  "ff",
  "fpe",
  "getset",
@@ -4369,7 +4385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4389,7 +4405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4409,7 +4425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -4422,7 +4438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -5241,9 +5257,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc5fda664085f3893372b703a81e03003b3be46da50952468d7f41f996208ae"
+checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
  "aes",
  "bellman",
@@ -5251,7 +5267,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2 0.3.3",
+ "corez",
  "document-features",
  "ff",
  "fpe",
@@ -7534,7 +7550,7 @@ dependencies = [
  "known-folders",
  "nix",
  "once_cell",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "phf 0.12.1",
  "quote",
  "rand 0.8.5",
@@ -7543,7 +7559,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "rust_decimal",
- "sapling-crypto 0.6.2",
+ "sapling-crypto 0.7.0",
  "schemars",
  "schemerz",
  "schemerz-rusqlite",
@@ -7573,17 +7589,17 @@ dependencies = [
  "zaino-fetch",
  "zaino-proto",
  "zaino-state",
- "zcash_address 0.10.1",
+ "zcash_address 0.11.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0",
  "zcash_keys 0.12.0",
  "zcash_note_encryption",
- "zcash_primitives 0.26.4",
+ "zcash_primitives 0.27.0",
  "zcash_proofs 0.26.1",
- "zcash_protocol 0.7.2",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -7622,21 +7638,21 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+version = "0.11.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
- "core2 0.3.3",
+ "corez",
  "f4jumble",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.8.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7655,13 +7671,13 @@ dependencies = [
  "incrementalmerkletree 0.8.2",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "pasta_curves",
  "percent-encoding",
  "prost 0.14.1",
  "rand_core 0.6.4",
  "rayon",
- "sapling-crypto 0.6.2",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
  "shardtree",
@@ -7673,14 +7689,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which 8.0.0",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0",
  "zcash_keys 0.12.0",
  "zcash_note_encryption",
- "zcash_primitives 0.26.4",
- "zcash_protocol 0.7.2",
+ "zcash_primitives 0.27.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
  "zip32 0.2.1",
  "zip321",
 ]
@@ -7688,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.19.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bitflags 2.10.0",
@@ -7701,14 +7717,14 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "prost 0.14.1",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_distr",
  "regex",
  "rusqlite",
- "sapling-crypto 0.6.2",
+ "sapling-crypto 0.7.0",
  "schemerz",
  "schemerz-rusqlite",
  "secp256k1 0.29.1",
@@ -7719,14 +7735,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.10.1",
+ "zcash_address 0.11.0",
  "zcash_client_backend",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0",
  "zcash_keys 0.12.0",
- "zcash_primitives 0.26.4",
- "zcash_protocol 0.7.2",
+ "zcash_primitives 0.27.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
  "zip32 0.2.1",
 ]
 
@@ -7743,9 +7759,19 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
  "core2 0.3.3",
+ "nonempty 0.11.0",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
+dependencies = [
+ "corez",
  "hex",
  "nonempty 0.11.0",
 ]
@@ -7753,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7817,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7826,23 +7852,23 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "core2 0.3.3",
+ "corez",
  "document-features",
  "group",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "rand_core 0.6.4",
  "regex",
- "sapling-crypto 0.6.2",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
- "zcash_transparent 0.6.3",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.8.0",
+ "zcash_transparent 0.7.0",
  "zeroize",
  "zip32 0.2.1",
 ]
@@ -7872,7 +7898,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "document-features",
- "equihash",
+ "equihash 0.2.2",
  "ff",
  "fpe",
  "group",
@@ -7912,7 +7938,7 @@ dependencies = [
  "core2 0.3.3",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.2.2",
  "ff",
  "fpe",
  "getset",
@@ -7943,32 +7969,32 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+version = "0.27.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "core2 0.3.3",
+ "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0",
  "ff",
  "hex",
  "incrementalmerkletree 0.8.2",
  "jubjub",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.12.0",
+ "orchard 0.13.1",
  "rand_core 0.6.4",
  "redjubjub 0.8.0",
- "sapling-crypto 0.6.2",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0",
  "zcash_note_encryption",
- "zcash_protocol 0.7.2",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
- "zcash_transparent 0.6.3",
+ "zcash_transparent 0.7.0",
 ]
 
 [[package]]
@@ -7997,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8009,11 +8035,11 @@ dependencies = [
  "known-folders",
  "rand_core 0.6.4",
  "redjubjub 0.8.0",
- "sapling-crypto 0.6.2",
+ "sapling-crypto 0.7.0",
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.26.4",
+ "zcash_primitives 0.27.0",
 ]
 
 [[package]]
@@ -8042,14 +8068,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.7.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+version = "0.8.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
- "core2 0.3.3",
+ "corez",
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0",
 ]
 
 [[package]]
@@ -8131,12 +8157,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+version = "0.7.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "bip32 0.6.0-pre.1",
  "bs58",
- "core2 0.3.3",
+ "corez",
  "document-features",
  "getset",
  "hex",
@@ -8145,9 +8171,9 @@ dependencies = [
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.8.0",
  "zcash_script 0.4.3",
  "zcash_spec 0.2.1",
  "zip32 0.2.1",
@@ -8170,7 +8196,7 @@ dependencies = [
  "chrono",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.2",
  "futures",
  "group",
  "halo2_proofs",
@@ -8575,12 +8601,12 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb#cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb"
+version = "0.7.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=976efa76ca2195d693f373aeaa201a2c50b6e0ab#976efa76ca2195d693f373aeaa201a2c50b6e0ab"
 dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.10.1",
- "zcash_protocol 0.7.2",
+ "zcash_address 0.11.0",
+ "zcash_protocol 0.8.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,19 +152,6 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
-
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 
 zewif = { git = "https://github.com/zcash/zewif.git", rev = "f84f80612813ba00a0a8a9a5f060bd217fa981cc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 members = [
     "zallet",
 ]
+# `vendor/core2-shim-0.3` and `vendor/core2-shim-0.4` are referenced from the
+# `[patch.crates-io]` table below, but excluded from the workspace because
+# Cargo requires workspace member crate names to be unique and both shims must
+# be named `core2` to satisfy the resolver.
+exclude = [
+    "vendor/core2-shim-0.3",
+    "vendor/core2-shim-0.4",
+]
 resolver = "2"
 
 [workspace.package]
@@ -152,6 +160,16 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
+# TEMPORARY: All `core2` versions on crates.io were yanked by upstream on
+# 2026-04-14, breaking fresh dependency resolution because we still pull
+# `core2 ^0.3` (via `equihash 0.2.2`) and `core2 ^0.4` (via `zaino-state`)
+# transitively. Both entries below redirect those `core2` requests to local
+# shims that re-export `corez` (the Zcash ecosystem's clean-room replacement,
+# https://github.com/zcash/corez). See `vendor/core2-shim-0.3/README.md` for
+# context and removal criteria.
+core2 = { path = "vendor/core2-shim-0.3" }
+core2_v04 = { package = "core2", path = "vendor/core2-shim-0.4" }
+
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 
 zewif = { git = "https://github.com/zcash/zewif.git", rev = "f84f80612813ba00a0a8a9a5f060bd217fa981cc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,9 +110,9 @@ orchard = "0.13"
 sapling = { package = "sapling-crypto", version = "0.7" }
 transparent = { package = "zcash_transparent", version = "0.7" }
 zcash_encoding = "0.4"
-zcash_keys = { version = "0.12", features = ["transparent-inputs", "sapling", "orchard", "transparent-key-encoding"] }
+zcash_keys = { version = "0.13", features = ["transparent-inputs", "sapling", "orchard", "transparent-key-encoding"] }
 zcash_primitives = "0.27"
-zcash_proofs = "0.26"
+zcash_proofs = "0.27"
 zcash_script = "0.4.3"
 secp256k1 = { version = "0.29", features = ["recovery"] }
 
@@ -136,8 +136,8 @@ schemerz-rusqlite = "0.370.0"
 shardtree = "0.6"
 time = "0.3"
 uuid = "1"
-zcash_client_backend = "0.21"
-zcash_client_sqlite = "0.19"
+zcash_client_backend = "0.22"
+zcash_client_sqlite = "0.20"
 zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
@@ -152,18 +152,18 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0268bbcf8007bff6a7a94cb7c1e229b595a6489e" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hex = "0.4"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision", "raw_value"] }
 toml = "0.8"
-zcash_address = "0.10"
+zcash_address = "0.11"
 
 # Randomness
 rand = "0.8"
@@ -103,15 +103,15 @@ tracing-log = "0.2"
 tracing-subscriber = "0.3"
 
 # Zcash consensus
-zcash_protocol = "0.7"
+zcash_protocol = "0.8"
 
 # Zcash payment protocols
-orchard = "0.12"
-sapling = { package = "sapling-crypto", version = "0.6" }
-transparent = { package = "zcash_transparent", version = "0.6" }
-zcash_encoding = "0.3.0"
+orchard = "0.13"
+sapling = { package = "sapling-crypto", version = "0.7" }
+transparent = { package = "zcash_transparent", version = "0.7" }
+zcash_encoding = "0.4"
 zcash_keys = { version = "0.12", features = ["transparent-inputs", "sapling", "orchard", "transparent-key-encoding"] }
-zcash_primitives = "0.26"
+zcash_primitives = "0.27"
 zcash_proofs = "0.26"
 zcash_script = "0.4.3"
 secp256k1 = { version = "0.29", features = ["recovery"] }
@@ -152,18 +152,18 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "976efa76ca2195d693f373aeaa201a2c50b6e0ab" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,18 +152,18 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "eb70164b0ea72f87dba8ae54e5e0fd5f5be44029" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "cb6c182f9ba0f5c29d8e43bb8aee4c3ae37d0dcb" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -200,7 +200,7 @@ delta = "1.0.19 -> 1.0.20"
 notes = """
 Changes to `unsafe` code:
 - Migrating to `core::ptr::addr_of_mut!()` with MSRV bump.
-- Gating a function that uses `unsafe` behind `target_has_atomic = "ptr"`.
+- Gating a function that uses `unsafe` behind `target_has_atomic = \"ptr\"`.
 """
 
 [[audits.errno]]
@@ -390,7 +390,7 @@ delta = "1.2.2 -> 1.2.3"
 notes = """
 Changes to `unsafe` code are to replace individual `target_os` cfg flags for
 Apple targets that gate functions containing `unsafe` blocks, with a
-`target_vendor = "apple"`.
+`target_vendor = \"apple\"`.
 """
 
 [[audits.pkg-config]]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -200,7 +200,7 @@ delta = "1.0.19 -> 1.0.20"
 notes = """
 Changes to `unsafe` code:
 - Migrating to `core::ptr::addr_of_mut!()` with MSRV bump.
-- Gating a function that uses `unsafe` behind `target_has_atomic = \"ptr\"`.
+- Gating a function that uses `unsafe` behind `target_has_atomic = "ptr"`.
 """
 
 [[audits.errno]]
@@ -390,7 +390,7 @@ delta = "1.2.2 -> 1.2.3"
 notes = """
 Changes to `unsafe` code are to replace individual `target_os` cfg flags for
 Apple targets that gate functions containing `unsafe` blocks, with a
-`target_vendor = \"apple\"`.
+`target_vendor = "apple"`.
 """
 
 [[audits.pkg-config]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,12 +28,6 @@ audit-as-crates-io = true
 [policy.age-core]
 audit-as-crates-io = true
 
-[policy.equihash]
-audit-as-crates-io = true
-
-[policy.f4jumble]
-audit-as-crates-io = true
-
 [policy.zaino-common]
 audit-as-crates-io = true
 
@@ -46,31 +40,13 @@ audit-as-crates-io = true
 [policy.zaino-state]
 audit-as-crates-io = true
 
-[policy."zcash_address:0.11.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
-
 [policy."zcash_address:0.6.3"]
 
 [policy."zcash_address:0.9.0"]
 
-[policy.zcash_client_backend]
-audit-as-crates-io = true
-
-[policy.zcash_client_sqlite]
-audit-as-crates-io = true
-
 [policy."zcash_encoding:0.2.2"]
 
-[policy."zcash_encoding:0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
-
-[policy.zcash_history]
-audit-as-crates-io = true
-
 [policy."zcash_keys:0.10.1"]
-
-[policy."zcash_keys:0.13.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
 
 [policy."zcash_keys:0.4.1"]
 
@@ -78,28 +54,13 @@ audit-as-crates-io = true
 
 [policy."zcash_primitives:0.24.1"]
 
-[policy."zcash_primitives:0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
-
 [policy."zcash_proofs:0.24.0"]
-
-[policy."zcash_proofs:0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
 
 [policy."zcash_protocol:0.4.3"]
 
 [policy."zcash_protocol:0.6.2"]
 
-[policy."zcash_protocol:0.8.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
-
 [policy."zcash_transparent:0.4.0"]
-
-[policy."zcash_transparent:0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
-audit-as-crates-io = true
-
-[policy.zip321]
-audit-as-crates-io = true
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -642,15 +603,11 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.3.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
 version = "0.6.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.f4jumble]]
-version = "0.1.1@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.fallible-iterator]]
@@ -1974,15 +1931,15 @@ version = "0.1.2@git:15b81f110349b34090341b3ab8b7cd58c7b9aeef"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_address]]
-version = "0.11.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_backend]]
-version = "0.22.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.22.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_sqlite]]
-version = "0.20.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.20.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
@@ -1990,27 +1947,23 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
-version = "0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
-criteria = "safe-to-deploy"
-
-[[exemptions.zcash_history]]
-version = "0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_keys]]
-version = "0.13.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_primitives]]
-version = "0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_proofs]]
-version = "0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_protocol]]
-version = "0.8.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_spec]]
@@ -2018,7 +1971,7 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_transparent]]
-version = "0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
@@ -2070,5 +2023,5 @@ version = "0.11.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zip321]]
-version = "0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
+version = "0.7.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -46,7 +46,7 @@ audit-as-crates-io = true
 [policy.zaino-state]
 audit-as-crates-io = true
 
-[policy."zcash_address:0.10.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_address:0.11.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_address:0.6.3"]
@@ -61,7 +61,7 @@ audit-as-crates-io = true
 
 [policy."zcash_encoding:0.2.2"]
 
-[policy."zcash_encoding:0.3.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_encoding:0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy.zcash_history]
@@ -69,7 +69,7 @@ audit-as-crates-io = true
 
 [policy."zcash_keys:0.10.1"]
 
-[policy."zcash_keys:0.12.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_keys:0.13.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_keys:0.4.1"]
@@ -78,24 +78,24 @@ audit-as-crates-io = true
 
 [policy."zcash_primitives:0.24.1"]
 
-[policy."zcash_primitives:0.26.4@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_primitives:0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_proofs:0.24.0"]
 
-[policy."zcash_proofs:0.26.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_proofs:0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_protocol:0.4.3"]
 
 [policy."zcash_protocol:0.6.2"]
 
-[policy."zcash_protocol:0.7.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_protocol:0.8.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy."zcash_transparent:0.4.0"]
 
-[policy."zcash_transparent:0.6.3@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"]
+[policy."zcash_transparent:0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"]
 audit-as-crates-io = true
 
 [policy.zip321]
@@ -453,6 +453,10 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.corez]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.cpufeatures]]
 version = "0.2.17"
 criteria = "safe-to-deploy"
@@ -638,7 +642,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.equihash]]
-version = "0.2.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.3.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
@@ -646,7 +650,7 @@ version = "0.6.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.f4jumble]]
-version = "0.1.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.1.1@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.fallible-iterator]]
@@ -1105,6 +1109,10 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.orchard]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.ordered-map]]
 version = "0.4.2"
 criteria = "safe-to-deploy"
@@ -1471,6 +1479,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.same-file]]
 version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.sapling-crypto]]
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars]]
@@ -1962,15 +1974,15 @@ version = "0.1.2@git:15b81f110349b34090341b3ab8b7cd58c7b9aeef"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_address]]
-version = "0.10.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.11.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_backend]]
-version = "0.21.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.22.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_client_sqlite]]
-version = "0.19.5@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.20.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
@@ -1978,27 +1990,27 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
-version = "0.3.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_history]]
-version = "0.4.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.4.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_keys]]
-version = "0.12.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.13.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_primitives]]
-version = "0.26.4@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_proofs]]
-version = "0.26.1@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.27.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_protocol]]
-version = "0.7.2@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.8.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_spec]]
@@ -2006,7 +2018,7 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_transparent]]
-version = "0.6.3@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
@@ -2058,5 +2070,5 @@ version = "0.11.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zip321]]
-version = "0.6.0@git:eb70164b0ea72f87dba8ae54e5e0fd5f5be44029"
+version = "0.7.0@git:0268bbcf8007bff6a7a94cb7c1e229b595a6489e"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -406,14 +406,6 @@ criteria = "safe-to-deploy"
 version = "0.21.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.core2]]
-version = "0.3.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.core2]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.corez]]
 version = "0.1.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -22,6 +22,13 @@ user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
 
+[[publisher.f4jumble]]
+version = "0.1.1"
+when = "2024-12-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.halo2_gadgets]]
 version = "0.3.1"
 when = "2024-12-16"
@@ -363,6 +370,13 @@ when = "2025-02-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_history]]
+version = "0.4.0"
+when = "2024-03-01"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
 
 [[publisher.zcash_keys]]
 version = "0.4.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -15,6 +15,13 @@ user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
+[[publisher.equihash]]
+version = "0.2.2"
+when = "2025-03-05"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.halo2_gadgets]]
 version = "0.3.1"
 when = "2024-12-16"
@@ -64,13 +71,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.orchard]]
-version = "0.12.0"
-when = "2025-12-05"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
-
 [[publisher.sapling-crypto]]
 version = "0.3.0"
 when = "2024-10-02"
@@ -84,13 +84,6 @@ when = "2025-02-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
-
-[[publisher.sapling-crypto]]
-version = "0.6.0"
-when = "2025-12-05"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
 
 [[publisher.schemerz-rusqlite]]
 version = "0.370.0"
@@ -360,6 +353,13 @@ user-name = "Kris Nuttycombe"
 [[publisher.zcash_address]]
 version = "0.9.0"
 when = "2025-07-31"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_encoding]]
+version = "0.3.0"
+when = "2025-02-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -1171,7 +1171,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.0"
-notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
+notes = "The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = \"std\")]`."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.equivalent]]
@@ -1463,8 +1463,8 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.35"
 notes = """
-Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
-(except for benign "net" hit in tests and "fs" hit in README.md)
+Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
+(except for benign \"net\" hit in tests and \"fs\" hit in README.md)
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -1582,7 +1582,7 @@ and there were no hits except for:
 * Using `unsafe` in a string:
 
     ```
-    src/constfn.rs:            "unsafe" => Qualifiers::Unsafe,
+    src/constfn.rs:            \"unsafe\" => Qualifiers::Unsafe,
     ```
 
 * Using `std::fs` in `build/build.rs` to write `${OUT_DIR}/version.expr`
@@ -1764,7 +1764,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.197"
-notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
+notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -1783,7 +1783,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.202 -> 1.0.203"
-notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
+notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -4023,7 +4023,7 @@ Uses `unsafe` blocks to interact with `windows-sys` crate.
 - The slice constructed from the `PWSTR` correctly goes out of scope before
   `guard` is dropped.
 - A code comment says that `path_ptr` is valid for `len` bytes, but `PCWSTR` is
-  a `*const u16` and `lstrlenW` returns its length "in characters" (which the
+  a `*const u16` and `lstrlenW` returns its length \"in characters\" (which the
   Windows documentation confirms means the number of `WCHAR` values). This is
   likely a typo; the code checks that `len * size_of::<u16>() <= isize::MAX`.
 """

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1185,7 +1185,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.0"
-notes = "The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = \"std\")]`."
+notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.equivalent]]
@@ -1477,8 +1477,8 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.35"
 notes = """
-Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
-(except for benign \"net\" hit in tests and \"fs\" hit in README.md)
+Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
+(except for benign "net" hit in tests and "fs" hit in README.md)
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -1596,7 +1596,7 @@ and there were no hits except for:
 * Using `unsafe` in a string:
 
     ```
-    src/constfn.rs:            \"unsafe\" => Qualifiers::Unsafe,
+    src/constfn.rs:            "unsafe" => Qualifiers::Unsafe,
     ```
 
 * Using `std::fs` in `build/build.rs` to write `${OUT_DIR}/version.expr`
@@ -1778,7 +1778,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.197"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -1797,7 +1797,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.202 -> 1.0.203"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -4037,7 +4037,7 @@ Uses `unsafe` blocks to interact with `windows-sys` crate.
 - The slice constructed from the `PWSTR` correctly goes out of scope before
   `guard` is dropped.
 - A code comment says that `path_ptr` is valid for `len` bytes, but `PCWSTR` is
-  a `*const u16` and `lstrlenW` returns its length \"in characters\" (which the
+  a `*const u16` and `lstrlenW` returns its length "in characters" (which the
   Windows documentation confirms means the number of `WCHAR` values). This is
   likely a typo; the code checks that `len * size_of::<u16>() <= isize::MAX`.
 """

--- a/vendor/core2-shim-0.3/Cargo.toml
+++ b/vendor/core2-shim-0.3/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "core2"
+version = "0.3.99"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Temporary local shim providing the core2 0.3.x API by re-exporting `corez`. See README.md for context and removal criteria."
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+corez = { version = "0.1.1", default-features = false }
+
+[features]
+default = ["std"]
+std = ["alloc", "corez/std"]
+alloc = ["corez/alloc"]

--- a/vendor/core2-shim-0.3/Cargo.toml
+++ b/vendor/core2-shim-0.3/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.3.99"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Temporary local shim providing the core2 0.3.x API by re-exporting `corez`. See README.md for context and removal criteria."
+# Required by `embed_licensing::collect()` (invoked from Zallet's build.rs in
+# release builds via `generate_debian_copyright`); the shim sources live in
+# this repo at `vendor/core2-shim-0.3/`.
+repository = "https://github.com/zcash/wallet"
 publish = false
 
 [lib]

--- a/vendor/core2-shim-0.3/README.md
+++ b/vendor/core2-shim-0.3/README.md
@@ -1,0 +1,71 @@
+# core2-shim-0.3 (TEMPORARY)
+
+Local shim that re-exports [`corez`](https://github.com/zcash/corez) under the
+`core2` name to satisfy transitive dependencies pinned to `core2 ^0.3`. This
+crate exists **solely** to keep `cargo build` working without a committed
+`Cargo.lock` while the dependency graph still contains crates that haven't
+migrated to `corez`.
+
+A sibling shim `vendor/core2-shim-0.4/` provides the same workaround for
+`core2 ^0.4` consumers.
+
+## Background
+
+All `core2` versions on crates.io were yanked by their author on 2026-04-14.
+Cargo refuses to resolve to yanked versions during a fresh resolve (one
+without a `Cargo.lock`), which broke the `Latest build on macOS-latest` CI
+job in `zcash/wallet`.
+
+`corez` is the Zcash ecosystem's clean-room replacement for `core2`,
+maintained at <https://github.com/zcash/corez>. It is API-compatible with the
+subset of `core2::io` that downstream crates use (when the `std` feature is
+enabled, `corez::io` re-exports `std::io::*` directly, identical to what
+`core2 0.4`'s `std` feature does).
+
+## Who currently relies on this shim
+
+Run `cargo tree --workspace --all-features -i core2` to inspect. As of when
+this shim was added, the chains were:
+
+- `equihash 0.2.2` (transitively pulled in via `zcash_primitives 0.24.1`,
+  `zcash_proofs 0.24.0`, and `zebra-chain 2.0.0` → `zcash_primitives 0.26`)
+  declares `core2 = "^0.3"`. **This shim covers that case.**
+- `zaino-state 0.1.2` declares `core2 = "0.4"` directly. The
+  `vendor/core2-shim-0.4/` shim covers that case.
+
+## When to remove this shim (and `core2-shim-0.4`)
+
+Both shims and their `[patch.crates-io]` entries can be deleted once **every**
+transitive path to `core2` has been eliminated. Concretely:
+
+1. **`equihash 0.2.x` must drop out of the dep graph.** This requires either:
+   - Bumping our `zaino-*` git patches to a revision that depends on
+     `zcash_primitives >= 0.27` (which uses `equihash 0.3.0` → `corez`).
+     Currently blocked: zaino's `dev` branch already requires
+     `zebra-chain >= 4.x`, incompatible with our `zebra-chain 2.0.0`
+     workspace dep.
+   - Bumping our direct `zebra-chain`, `zebra-rpc`, `zebra-state` workspace
+     deps to a major release that uses `zcash_primitives >= 0.27`. The latest
+     `zebra-chain 6.0.2` on crates.io still uses `equihash 0.2.2`, so this
+     also requires upstream zebra to migrate.
+2. **`zaino-state`'s direct `core2 = "0.4"` workspace dep must be removed.**
+   Already done in zaino dev commit
+   [`47356af0`](https://github.com/zingolabs/zaino/commit/47356af0)
+   (2026-04-20, "core2 --> corez"). Pulling that requires the same zebra
+   bump as above.
+
+To verify removal is safe at any point in the future:
+
+```sh
+cargo tree --workspace --all-features -i core2
+```
+
+If the command reports "package ID specification `core2` did not match any
+packages", both shims can be deleted along with their `[patch.crates-io]`
+entries in the workspace-root `Cargo.toml`.
+
+## Do not depend on this crate from any Zallet code
+
+Importing `core2` directly from Zallet sources defeats the purpose: when the
+shim is removed, those imports will silently break or pull a different crate.
+Use `std::io` (or `corez` directly, behind a `cfg`) instead.

--- a/vendor/core2-shim-0.3/src/lib.rs
+++ b/vendor/core2-shim-0.3/src/lib.rs
@@ -1,0 +1,12 @@
+//! Temporary `core2` 0.3.x shim that re-exports [`corez`].
+//!
+//! See `README.md` and the workspace-root `[patch.crates-io]` table for
+//! context and removal criteria. This crate exists solely to satisfy
+//! transitive dependencies pinned to `core2 ^0.3` while all `core2`
+//! releases on crates.io are yanked.
+//!
+//! Do not depend on this crate from any Zallet code.
+
+#![no_std]
+
+pub use corez::*;

--- a/vendor/core2-shim-0.4/Cargo.toml
+++ b/vendor/core2-shim-0.4/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "core2"
+version = "0.4.99"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Temporary local shim providing the core2 0.4.x API by re-exporting `corez`. See README.md for context and removal criteria."
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+corez = { version = "0.1.1", default-features = false }
+
+[features]
+default = ["std"]
+std = ["alloc", "corez/std"]
+alloc = ["corez/alloc"]

--- a/vendor/core2-shim-0.4/Cargo.toml
+++ b/vendor/core2-shim-0.4/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.4.99"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Temporary local shim providing the core2 0.4.x API by re-exporting `corez`. See README.md for context and removal criteria."
+# Required by `embed_licensing::collect()` (invoked from Zallet's build.rs in
+# release builds via `generate_debian_copyright`); the shim sources live in
+# this repo at `vendor/core2-shim-0.4/`.
+repository = "https://github.com/zcash/wallet"
 publish = false
 
 [lib]

--- a/vendor/core2-shim-0.4/README.md
+++ b/vendor/core2-shim-0.4/README.md
@@ -1,0 +1,5 @@
+# core2-shim-0.4 (TEMPORARY)
+
+Sibling of `vendor/core2-shim-0.3/` covering `core2 ^0.4` consumers. See
+[`../core2-shim-0.3/README.md`](../core2-shim-0.3/README.md) for the full
+rationale and the criteria for removing both shims.

--- a/vendor/core2-shim-0.4/src/lib.rs
+++ b/vendor/core2-shim-0.4/src/lib.rs
@@ -1,0 +1,12 @@
+//! Temporary `core2` 0.4.x shim that re-exports [`corez`].
+//!
+//! See `../core2-shim-0.3/README.md` and the workspace-root
+//! `[patch.crates-io]` table for context and removal criteria. This crate
+//! exists solely to satisfy transitive dependencies pinned to `core2 ^0.4`
+//! while all `core2` releases on crates.io are yanked.
+//!
+//! Do not depend on this crate from any Zallet code.
+
+#![no_std]
+
+pub use corez::*;

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -697,6 +697,13 @@ impl WalletWrite for DbConnection {
     ) -> Result<(), Self::Error> {
         self.with_mut(|mut db_data| db_data.notify_address_checked(request, as_of_height))
     }
+
+    fn mark_transparent_addresses_exposed(
+        &mut self,
+        exposures: &[(TransparentAddress, BlockHeight)],
+    ) -> Result<(), Self::Error> {
+        self.with_mut(|mut db_data| db_data.mark_transparent_addresses_exposed(exposures))
+    }
 }
 
 impl WalletCommitmentTrees for DbConnection {

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -15,6 +15,7 @@ use zcash_client_backend::{
         SAPLING_SHARD_HEIGHT, TargetValue, TransparentKeyOrigin, TransparentOutputFilter,
         WalletCommitmentTrees, WalletRead, WalletUtxo, WalletWrite, Zip32Derivation,
         chain::ChainState,
+        error::FindAccountForAddressError,
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
@@ -434,6 +435,14 @@ impl WalletRead for DbConnection {
     ) -> Result<Vec<ReceivedTransactionOutput>, Self::Error> {
         self.with(|db_data| db_data.get_received_outputs(txid, target_height, confirmations_policy))
     }
+
+    fn find_account_for_address<P: zcash_protocol::consensus::Parameters>(
+        &self,
+        params: &P,
+        address: &zcash_keys::address::Address,
+    ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
+        self.with(|db_data| db_data.find_account_for_address(params, address))
+    }
 }
 
 impl InputSource for DbConnection {
@@ -651,6 +660,10 @@ impl WalletWrite for DbConnection {
 
     fn truncate_to_chain_state(&mut self, chain_state: ChainState) -> Result<(), Self::Error> {
         self.with_mut(|mut db_data| db_data.truncate_to_chain_state(chain_state))
+    }
+
+    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        self.with_mut(|mut db_data| db_data.rewind_to_height(max_height))
     }
 
     fn reserve_next_n_ephemeral_addresses(

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -12,8 +12,8 @@ use zcash_client_backend::{
     data_api::{
         AccountBirthday, AccountMeta, AddressInfo, Balance, DecryptedTransaction, InputSource,
         NoteFilter, ORCHARD_SHARD_HEIGHT, ReceivedNotes, ReceivedTransactionOutput,
-        SAPLING_SHARD_HEIGHT, TargetValue, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
-        WalletUtxo, WalletWrite, Zip32Derivation,
+        SAPLING_SHARD_HEIGHT, TargetValue, TransparentKeyOrigin, TransparentOutputFilter,
+        WalletCommitmentTrees, WalletRead, WalletUtxo, WalletWrite, Zip32Derivation,
         chain::ChainState,
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
@@ -498,9 +498,15 @@ impl InputSource for DbConnection {
         address: &TransparentAddress,
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
+        output_filter: TransparentOutputFilter,
     ) -> Result<Vec<WalletUtxo>, Self::Error> {
         self.with(|db_data| {
-            db_data.get_spendable_transparent_outputs(address, target_height, confirmations_policy)
+            db_data.get_spendable_transparent_outputs(
+                address,
+                target_height,
+                confirmations_policy,
+                output_filter,
+            )
         })
     }
 

--- a/zallet/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet/src/components/json_rpc/methods/list_unspent.rs
@@ -12,7 +12,7 @@ use transparent::keys::TransparentKeyScope;
 use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
-        Account, AccountPurpose, InputSource, WalletRead,
+        Account, AccountPurpose, InputSource, TransparentOutputFilter, WalletRead,
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     encoding::AddressCodec,
@@ -192,7 +192,12 @@ pub(crate) fn call(
             .iter()
             .try_fold(vec![], |mut acc, (addr, _)| {
                 let mut outputs = wallet
-                    .get_spendable_transparent_outputs(addr, target_height, confirmations_policy)
+                    .get_spendable_transparent_outputs(
+                        addr,
+                        target_height,
+                        confirmations_policy,
+                        TransparentOutputFilter::All,
+                    )
                     .map_err(|e| {
                         RpcError::owned(
                             LegacyCode::Database.into(),

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -217,6 +217,7 @@ impl BuilderSection {
             NonZeroU32::new(self.untrusted_confirmations()).unwrap_or(NonZeroU32::MIN),
             allow_zero_conf_shielding,
         )
+        .map_err(|_| ())
     }
 }
 


### PR DESCRIPTION
Migrates Zallet to use the published crates.io releases of the Zcash crates that match what was previously pinned via `[patch.crates-io]` to commit `0268bbc` of librustzcash. All 12 librustzcash crates (`equihash 0.3.0`, `f4jumble 0.1.1`, `zcash_address 0.11.0`, `zcash_client_backend 0.22.0`, `zcash_client_sqlite 0.20.0`, `zcash_encoding 0.4.0`, `zcash_history 0.4.0`, `zcash_keys 0.13.0`, `zcash_primitives 0.27.0`, `zcash_proofs 0.27.0`, `zcash_protocol 0.8.0`, `zcash_transparent 0.7.0`) have been published to crates.io at versions matching the git rev's content.

## Changes

- **`Cargo.toml`**: Drop the 12 librustzcash entries from `[patch.crates-io]`. The `age`, `zewif`, `zewif-zcashd`, and `zaino-*` patches remain since those crates are not published at the revisions we need. Add two new `[patch.crates-io]` entries pointing `core2` (^0.3 and ^0.4) at local shim crates that re-export `corez` (see Notes for review below).
- **Workspace dep version specifiers** (in `[workspace.dependencies]`): Already at the now-published versions from earlier commits in this PR — no further changes.
- **`zallet/src/components/database/connection.rs`** (from prior commits): Forwarders for three trait methods that became required at this librustzcash revision:
  - `WalletRead::find_account_for_address`
  - `WalletWrite::rewind_to_height`
  - `WalletWrite::mark_transparent_addresses_exposed`
- **`Cargo.lock`**: Regenerated. The librustzcash crates now resolve from `registry+...` instead of `git+...`.
- **`vendor/core2-shim-0.3/`** and **`vendor/core2-shim-0.4/`**: New temporary shim crates (~10 lines of Rust each) that re-export `corez` under the `core2` name to work around the upstream yanking of all `core2` registry versions on 2026-04-14. See "Notes for review" and `vendor/core2-shim-0.3/README.md` for full context and removal criteria.
- **`supply-chain/config.toml`**: Drop the `@git:0268bbc...` qualifiers from policy entries and exemptions; remove the obsolete `audit-as-crates-io = true` policy stubs that existed only to support the git-pinned versions; prune stale `core2` registry exemptions (no longer needed since the shims provide first-party `core2`). New exemptions for `orchard 0.13.1`, `sapling-crypto 0.7.0`, and `corez 0.1.1` (added in earlier commits of this PR) are retained.
- **`supply-chain/imports.lock`** and **`supply-chain/audits.toml`**: Refreshed via `cargo vet regenerate imports` and `cargo vet fmt` (the latter to match cargo-vet 0.10.2's preferred string serialization, used by CI).
- **`list_unspent.rs`** (from prior commit): Add required `TransparentOutputFilter::All` parameter to `get_spendable_transparent_outputs` calls -- preserves previous behavior (returns all transparent outputs, not coinbase-only).
- **`config.rs`** (from prior commit): Adapt `ConfirmationsPolicy::new(...)` error handling to match updated return type while keeping Zallet's existing `Result<_, ()>` API.

## Notes for review

### `core2` shim crates (TEMPORARY)

All `core2` versions on crates.io were yanked by their author on 2026-04-14, breaking fresh dependency resolution (and thus the `Latest build on macOS-latest` CI job, which deletes `Cargo.lock` before building). Two transitive paths still request `core2`:

- `equihash 0.2.2` requires `core2 ^0.3` — pulled in via `zcash_primitives 0.24.1` / `zcash_proofs 0.24.0` (zaino's pinned librustzcash) and `zebra-chain 2.0.0` (our direct dep).
- `zaino-state 0.1.2` requires `core2 ^0.4` directly.

`vendor/core2-shim-0.3/` and `vendor/core2-shim-0.4/` are minimal vendored crates (~10 lines of Rust each) that re-export `corez` (the Zcash ecosystem's clean-room replacement at https://github.com/zcash/corez) under the `core2` name. `[patch.crates-io]` entries direct the resolver to these shims for `^0.3` and `^0.4` consumers respectively, using the `package = ...` rename trick from [Cargo's overriding-dependencies docs](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#using-patch-with-multiple-versions) to disambiguate two patch entries for the same crate name. The shims are excluded from the workspace so that two members named `core2` can coexist.

The shims are TEMPORARY and **must be removed** once `cargo tree --workspace --all-features -i core2` reports no results. Removal requires bumping our `zebra-chain`/`zaino-*` deps to revisions that use `zcash_primitives >= 0.27` (which uses `equihash 0.3.0` -> `corez`). Bumping zaino alone is currently blocked because zaino's `dev` branch requires `zebra-chain >= 4.x`, incompatible with our pinned `zebra-chain 2.0.0`. See `vendor/core2-shim-0.3/README.md` for the full removal criteria.

### Other behavioral notes

- **`OvkPolicy::Sender` semantics changed upstream.** Per the `zcash_client_backend` 0.22.0 changelog, when `OvkPolicy::Sender` is used (the only `OvkPolicy` site in Zallet, in `z_send_many.rs`), wallet-internal change outputs are now decrypted via the wallet's internal IVK rather than the sender's OVK. For Zallet's SQLite-backed `z_sendmany`, change remains recoverable via wallet sync, so user-visible behavior should be equivalent -- but worth confirming this is the desired semantic for Zallet's `z_sendmany`.
- **`NoteFilter::ExceedsMinValue` semantics changed from `>=` to `>`.** The single Zallet call site (`zallet/src/components/json_rpc/methods/get_notes_count.rs:54`) uses `Zatoshis::ZERO`, which previously matched all notes and now excludes 0-value (uneconomic) notes. Small behavioral change to `z_getnotescount`. Flagged for awareness; left as-is since 0-value notes are uneconomic.
- **All commits are folded as additions on top of prior commits** rather than amended/squashed, because each commit must pass `cargo clippy --all-targets -- -D warnings` per `AGENTS.md`, and the rev bumps introduce required trait methods that prevent intermediate "dep bump only" commits from building.

## CI failures unrelated to this PR

- **`Test NU7 on Linux`**: pre-existing failure on `main` since 2026-04-07. With `--cfg zcash_unstable="nu7"`, registry `zebra-chain 2.0.0` does a non-exhaustive match on `NetworkUpgrade` missing the `Nu7` variant. `continue-on-error: true` so doesn't block the PR.

## Verification

```
cargo fmt --all -- --check                                # clean
cargo clippy --all-targets -- -D warnings                 # clean
cargo test --workspace --all-features                     # 64 passed; 0 failed
cargo +beta clippy --tests --all-features --all-targets   # one pre-existing warning (migrate_zcashd_wallet.rs:301), unrelated
cargo vet --locked                                         # Vetting Succeeded (256 fully audited, 91 partially audited, 409 exempted)
rm Cargo.lock && cargo +stable build --workspace --all-targets --all-features  # succeeds (verified locally; this is the Latest build on macOS-latest CI job)
```