### PR TITLE
Gate incompatible alpha wallet databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ be considered breaking changes.
   standalone imported transparent keys (e.g. from a `zcashd` migration).
 - No longer crashes in regtest mode when a Sapling or NU5 activation height is
   not defined.
+- Zallet now refuses to open wallet databases from incompatible earlier alpha
+  releases instead of attempting to migrate them.
 
 ## [0.1.0-alpha.3] - 2025-12-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7563,6 +7563,7 @@ dependencies = [
  "schemerz-rusqlite",
  "secp256k1 0.29.1",
  "secrecy 0.8.0",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ spdx = "0.10"
 base64ct = "1.8"
 hex = "0.4"
 serde = { version = "1", features = ["serde_derive"] }
+semver = "1"
 serde_json = { version = "1", features = ["arbitrary_precision", "raw_value"] }
 toml = "0.8"
 zcash_address = "0.11"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -126,6 +126,7 @@ schemerz-rusqlite.workspace = true
 secp256k1.workspace = true
 secrecy.workspace = true
 serde.workspace = true
+semver.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 shadow-rs.workspace = true

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -126,6 +126,13 @@ err-init-zallet-already-running =
 err-init-config-db-mismatch =
     The wallet database was created for network type {$db_network_type}, but the
     config is using network type {$config_network_type}.
+err-init-db-incompatible-alpha =
+    This wallet database was created by an incompatible alpha version of {-zallet}.
+    To use this {-zallet} release, start again with a fresh Zallet wallet or a
+    new data directory.
+err-init-db-invalid-zallet-version =
+    The wallet database recorded an invalid {-zallet} version '{$version}':
+    {$err}
 
 err-init-identity-not-found = Encryption identity file could not be located at {$path}
 err-init-identity-not-passphrase-encrypted = {$path} is not encrypted with a passphrase

--- a/zallet/src/components/database.rs
+++ b/zallet/src/components/database.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use abscissa_core::tracing::info;
 use rusqlite::{OptionalExtension, named_params};
 use schemerz_rusqlite::RusqliteMigration;
+use semver::Version;
 use tokio::fs;
 
 use zcash_client_sqlite::wallet::init::{WalletMigrationError, WalletMigrator};
@@ -26,6 +27,10 @@ mod ext;
 mod tests;
 
 pub(crate) type DbHandle = deadpool::managed::Object<connection::WalletManager>;
+
+// Old databases are accepted only if the last recorded Zallet version is at
+// least the oldest release whose wallet database this binary accepts.
+const MIN_COMPATIBLE_ZALLET_VERSION: &str = "0.1.0-alpha.3";
 
 /// Returns the full list of migrations defined in Zallet, to be applied alongside the
 /// migrations internal to `zcash_client_sqlite`.
@@ -66,30 +71,12 @@ impl Database {
         let handle = database.handle().await?;
 
         if db_exists {
-            // Verify that the database matches the configured network type before we make
-            // any changes (including migrations, some of which make use of the network
-            // params), to avoid leaving the database in an inconsistent state. We can
-            // assume the presence of this table, as it's added by the initial migrations.
-            handle.with_raw(|conn, _| {
-                let wallet_network_type = conn
-                    .query_row(
-                        "SELECT network_type FROM ext_zallet_db_wallet_metadata",
-                        [],
-                        |row| row.get::<_, crate::network::kind::Sql>("network_type"),
-                    )
-                    .map_err(|e| ErrorKind::Init.context(e))?;
-
-                if wallet_network_type.0 == config.consensus.network {
-                    Ok(())
-                } else {
-                    Err(ErrorKind::Init.context(fl!(
-                        "err-init-config-db-mismatch",
-                        db_network_type = crate::network::kind::type_to_str(&wallet_network_type.0),
-                        config_network_type =
-                            crate::network::kind::type_to_str(&config.consensus.network),
-                    )))
-                }
-            })?;
+            // Verify that the database matches the configured network type and was
+            // last opened by a compatible alpha before we make any changes (including
+            // migrations, some of which make use of the network params), to avoid
+            // leaving the database in an inconsistent state. We can assume the network
+            // metadata table is present, as it's added by the initial migrations.
+            handle.with_raw(|conn, _| verify_existing_database(conn, config))?;
 
             info!("Applying latest database migrations");
         } else {
@@ -180,4 +167,81 @@ impl Database {
             .await
             .map_err(|e| ErrorKind::Generic.context(e).into())
     }
+}
+
+fn verify_existing_database(
+    conn: &rusqlite::Connection,
+    config: &ZalletConfig,
+) -> Result<(), Error> {
+    verify_alpha_db_compatibility(conn)?;
+    verify_wallet_network_type(conn, config)
+}
+
+fn verify_wallet_network_type(
+    conn: &rusqlite::Connection,
+    config: &ZalletConfig,
+) -> Result<(), Error> {
+    let wallet_network_type = conn
+        .query_row(
+            "SELECT network_type FROM ext_zallet_db_wallet_metadata",
+            [],
+            |row| row.get::<_, crate::network::kind::Sql>("network_type"),
+        )
+        .map_err(|e| ErrorKind::Init.context(e))?;
+
+    if wallet_network_type.0 == config.consensus.network {
+        Ok(())
+    } else {
+        Err(ErrorKind::Init
+            .context(fl!(
+                "err-init-config-db-mismatch",
+                db_network_type = crate::network::kind::type_to_str(&wallet_network_type.0),
+                config_network_type = crate::network::kind::type_to_str(&config.consensus.network),
+            ))
+            .into())
+    }
+}
+
+fn verify_alpha_db_compatibility(conn: &rusqlite::Connection) -> Result<(), Error> {
+    let latest_version = latest_recorded_zallet_version(conn)?;
+    let latest_version = Version::parse(&latest_version)
+        .map_err(|e| invalid_zallet_version_error(&latest_version, e))?;
+    let minimum_version = Version::parse(MIN_COMPATIBLE_ZALLET_VERSION)
+        .expect("minimum compatible Zallet version is valid SemVer");
+
+    if latest_version >= minimum_version {
+        Ok(())
+    } else {
+        Err(incompatible_alpha_database_error())
+    }
+}
+
+fn latest_recorded_zallet_version(conn: &rusqlite::Connection) -> Result<String, Error> {
+    conn.query_row(
+        "SELECT version
+         FROM ext_zallet_db_version_metadata
+         ORDER BY rowid DESC
+         LIMIT 1",
+        [],
+        |row| row.get("version"),
+    )
+    .optional()
+    .map_err(|_| incompatible_alpha_database_error())?
+    .ok_or_else(incompatible_alpha_database_error)
+}
+
+fn incompatible_alpha_database_error() -> Error {
+    ErrorKind::Init
+        .context(fl!("err-init-db-incompatible-alpha"))
+        .into()
+}
+
+fn invalid_zallet_version_error(version: &str, err: semver::Error) -> Error {
+    ErrorKind::Init
+        .context(fl!(
+            "err-init-db-invalid-zallet-version",
+            version = version,
+            err = err.to_string(),
+        ))
+        .into()
 }

--- a/zallet/src/components/database/tests.rs
+++ b/zallet/src/components/database/tests.rs
@@ -1,9 +1,10 @@
 use rand::rngs::OsRng;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension, named_params};
+use tempfile::tempdir;
 use zcash_client_sqlite::{WalletDb, util::SystemClock, wallet::init::WalletMigrator};
-use zcash_protocol::consensus::{self, Parameters};
+use zcash_protocol::consensus::{self, NetworkType, Parameters};
 
-use crate::{components::database, network::Network};
+use crate::{components::database, config::ZalletConfig, network::Network};
 
 #[cfg(zallet_build = "wallet")]
 use crate::components::keystore;
@@ -79,4 +80,202 @@ fn verify_schema() {
         ORDER BY tbl_name",
         &[],
     );
+}
+
+#[test]
+fn legacy_alpha_2_database_is_rejected_before_recording_current_version() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.2"]);
+
+    let err = open_database(&config).expect_err("legacy alpha.2 database must be rejected");
+    assert!(
+        err.to_string().contains("fresh Zallet wallet"),
+        "unexpected error: {err}",
+    );
+
+    let conn = Connection::open(config.wallet_db_path()).unwrap();
+    assert_eq!(
+        latest_recorded_version(&conn),
+        Some("0.1.0-alpha.2".to_string())
+    );
+    assert_eq!(
+        count_recorded_versions(&conn, crate::build::PKG_VERSION),
+        0,
+        "the current Zallet version should not be recorded after rejecting the database",
+    );
+}
+
+#[test]
+fn legacy_alpha_3_database_is_allowed() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.3"]);
+
+    open_database(&config).unwrap();
+
+    let conn = Connection::open(config.wallet_db_path()).unwrap();
+    assert_eq!(
+        latest_recorded_version(&conn),
+        Some(crate::build::PKG_VERSION.to_string()),
+    );
+}
+
+#[test]
+fn compatibility_check_uses_latest_recorded_version() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.2", "0.1.0-alpha.3"]);
+
+    open_database(&config).unwrap();
+}
+
+#[test]
+fn latest_alpha_2_version_is_rejected_even_with_earlier_alpha_3_version() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.3", "0.1.0-alpha.2"]);
+
+    let err = open_database(&config).expect_err("latest alpha.2 database must be rejected");
+    assert!(
+        err.to_string().contains("fresh Zallet wallet"),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn malformed_legacy_version_is_rejected() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &["not-a-version"]);
+
+    let err = open_database(&config).expect_err("malformed version must be rejected");
+    assert!(
+        err.to_string().contains("invalid zallet version"),
+        "unexpected error: {err}",
+    );
+
+    let conn = Connection::open(config.wallet_db_path()).unwrap();
+    assert_eq!(count_recorded_versions(&conn, crate::build::PKG_VERSION), 0);
+}
+
+#[test]
+fn missing_legacy_version_is_rejected() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &[]);
+
+    let err = open_database(&config).expect_err("missing version must be rejected");
+    assert!(
+        err.to_string().contains("fresh Zallet wallet"),
+        "unexpected error: {err}",
+    );
+
+    let conn = Connection::open(config.wallet_db_path()).unwrap();
+    assert_eq!(count_recorded_versions(&conn, crate::build::PKG_VERSION), 0);
+}
+
+#[test]
+fn network_mismatch_still_reports_network_error() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db_for_network(
+        config.wallet_db_path(),
+        Network::Consensus(consensus::Network::MainNetwork),
+        &["0.1.0-alpha.3"],
+    );
+
+    let err = open_database(&config).expect_err("network mismatch must be rejected");
+    assert!(
+        err.to_string()
+            .contains("The wallet database was created for network type"),
+        "unexpected error: {err}",
+    );
+}
+
+fn test_config(datadir: &std::path::Path, network_type: NetworkType) -> ZalletConfig {
+    ZalletConfig {
+        datadir: Some(datadir.to_path_buf()),
+        consensus: crate::config::ConsensusSection {
+            network: network_type,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn open_database(config: &ZalletConfig) -> Result<(), crate::error::Error> {
+    crate::i18n::load_languages(&[]);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let database = database::Database::open(config).await?;
+            drop(database);
+            Ok(())
+        })
+}
+
+fn create_wallet_db(path: impl AsRef<std::path::Path>, versions: &[&str]) {
+    create_wallet_db_for_network(
+        path,
+        Network::Consensus(consensus::Network::TestNetwork),
+        versions,
+    );
+}
+
+fn create_wallet_db_for_network(
+    path: impl AsRef<std::path::Path>,
+    network: Network,
+    versions: &[&str],
+) {
+    let mut conn = Connection::open(path).unwrap();
+    let mut db_data = WalletDb::from_connection(&mut conn, network, SystemClock, OsRng);
+
+    WalletMigrator::new()
+        .with_external_migrations(database::all_external_migrations(
+            db_data.params().network_type(),
+        ))
+        .init_or_migrate(&mut db_data)
+        .unwrap();
+
+    for version in versions {
+        conn.execute(
+            "INSERT INTO ext_zallet_db_version_metadata
+             VALUES (:version, NULL, NULL, :migrated)",
+            named_params! {
+                ":version": version,
+                ":migrated": "2026-01-01 00:00:00Z",
+            },
+        )
+        .unwrap();
+    }
+}
+
+fn latest_recorded_version(conn: &Connection) -> Option<String> {
+    conn.query_row(
+        "SELECT version
+         FROM ext_zallet_db_version_metadata
+         ORDER BY rowid DESC
+         LIMIT 1",
+        [],
+        |row| row.get("version"),
+    )
+    .optional()
+    .unwrap()
+}
+
+fn count_recorded_versions(conn: &Connection, version: &str) -> usize {
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM ext_zallet_db_version_metadata
+         WHERE version = :version",
+        named_params! {
+            ":version": version,
+        },
+        |row| row.get::<_, usize>(0),
+    )
+    .unwrap()
 }

--- a/zallet/src/components/database/tests.rs
+++ b/zallet/src/components/database/tests.rs
@@ -193,6 +193,23 @@ fn network_mismatch_still_reports_network_error() {
     );
 }
 
+#[test]
+fn incompatible_alpha_is_reported_before_network_mismatch() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db_for_network(
+        config.wallet_db_path(),
+        Network::Consensus(consensus::Network::MainNetwork),
+        &["0.1.0-alpha.2"],
+    );
+
+    let err = open_database(&config).expect_err("incompatible alpha database must be rejected");
+    assert!(
+        err.to_string().contains("fresh Zallet wallet"),
+        "unexpected error: {err}",
+    );
+}
+
 fn test_config(datadir: &std::path::Path, network_type: NetworkType) -> ZalletConfig {
     ZalletConfig {
         datadir: Some(datadir.to_path_buf()),


### PR DESCRIPTION
Copy of https://github.com/zcash/wallet/pull/434 on local branch to allow integration tests

Original description below:

---
Closes #264.

Summary:
- Add an early wallet SQLite compatibility gate before `WalletMigrator` can mutate an existing database.
- Use the latest recorded Zallet version in `ext_zallet_db_version_metadata` to detect databases last opened by an incompatible alpha.
- Reject existing databases whose latest recorded Zallet version is older than `0.1.0-alpha.4`, while preserving the existing network mismatch error path.
- Bump Zallet to `0.1.0-alpha.4` so accepted databases record the compatible version after opening.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p zallet components::database::tests --all-features`
- `env -u RUST_LOG cargo test --workspace --all-features`
