### PR TITLE
rpc: Add cookie file authentication for the JSON-RPC interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ be considered breaking changes.
 ## [0.1.0-alpha.4] - PLANNED
 
 ### Added
-
+- Cookie file authentication for the JSON-RPC interface. A random credential
+  is generated on startup and written to `{datadir}/.cookie`, enabling
+  `zallet rpc` to authenticate automatically without manual password setup.
+  Cookie auth coexists with configured `[[rpc.auth]]` users.
 - RPC methods:
   - `decoderawtransaction`
   - `decodescript`
@@ -33,6 +36,8 @@ be considered breaking changes.
 - Significant performance improvements to `zallet migrate-zcashd-wallet`.
 - `zallet migrate-zcashd-wallet` now accepts `--no-scan` to skip chain scanning
   during migration.
+- `zallet rpc` now sends credentials via the `Authorization` header instead of
+  embedding them in the HTTP URL.
 
 ### Fixed
 

--- a/book/src/cli/rpc.md
+++ b/book/src/cli/rpc.md
@@ -10,6 +10,16 @@ command-line shell.
 - `zallet rpc <method>` will call that JSON-RPC method. Parameters can be provided via
   additional CLI arguments (`zallet rpc <method> <param>`).
 
+## Authentication
+
+When Zallet starts its JSON-RPC server, it generates a random cookie credential and
+writes it to `{datadir}/.cookie`. The `zallet rpc` command automatically reads this
+cookie file to authenticate, so no manual password configuration is needed for local
+access.
+
+If `[[rpc.auth]]` users are configured in `zallet.toml`, `zallet rpc` will prefer
+those credentials over the cookie file. Cookie-based auth and configured users coexist.
+
 ## Comparison to `zcash-cli`
 
 The `zcashd` full node came bundled with a `zcash-cli` binary, which served an equivalent
@@ -24,8 +34,8 @@ below:
 | `zcash-cli -rpcconnect=<ip>`      | `rpc.bind` setting in config file  |
 | `zcash-cli -rpcport=<port>`       | `rpc.bind` setting in config file  |
 | `zcash-cli -rpcwait`              | Not implemented                    |
-| `zcash-cli -rpcuser=<user>`       | Not implemented                    |
-| `zcash-cli -rpcpassword=<pw>`     | Not implemented                    |
+| `zcash-cli -rpcuser=<user>`       | `[[rpc.auth]]` in config file      |
+| `zcash-cli -rpcpassword=<pw>`     | `[[rpc.auth]]` in config file      |
 | `zcash-cli -rpcclienttimeout=<n>` | `zallet rpc --timeout <n>`         |
 | Hostname, domain, or IP address   | Only IP address                    |
 | `zcash-cli <method> [<param> ..]` | `zallet rpc <method> [<param> ..]` |

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -59,6 +59,10 @@ rpc-bare-password-auth-warn =
     '{-zallet-add-rpc-user}'.
 rpc-pwhash-auth-info = Using '{-cfg-rpc-auth-pwhash}' authorization
 
+rpc-cookie-generated = Generated RPC authentication cookie {$path}
+rpc-cookie-read-failed = Failed to read cookie file: {$error}
+rpc-cookie-user-conflict = Configured user conflicts with cookie auth username, skipping cookie generation
+
 ## zallet.toml example messages
 
 example-alpha-code =

--- a/zallet/src/commands/rpc_cli.rs
+++ b/zallet/src/commands/rpc_cli.rs
@@ -4,11 +4,17 @@ use std::fmt;
 use std::time::Duration;
 
 use abscissa_core::Runnable;
+use base64ct::{Base64, Encoding};
+use hyper::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use jsonrpsee::core::{client::ClientT, params::ArrayParams};
 use jsonrpsee_http_client::HttpClientBuilder;
 use secrecy::{ExposeSecret, SecretString};
+use tracing::warn;
 
-use crate::{cli::RpcCliCmd, commands::AsyncRunnable, error::Error, prelude::*};
+use crate::{
+    cli::RpcCliCmd, commands::AsyncRunnable, components::json_rpc::server::cookie, error::Error,
+    fl, prelude::*,
+};
 
 const DEFAULT_HTTP_CLIENT_TIMEOUT: u64 = 900;
 
@@ -43,31 +49,51 @@ impl AsyncRunnable for RpcCliCmd {
             None => DEFAULT_HTTP_CLIENT_TIMEOUT,
         });
 
-        // Find a password we can use. If none are configured, we assume none is needed.
-        let auth_prefix = config
+        // Find credentials: prefer configured password, fall back to cookie file.
+        let credentials = config
             .rpc
             .auth
             .iter()
             .find_map(|auth| {
                 auth.password
                     .as_ref()
-                    .map(|pw| SecretString::new(format!("{}:{}@", auth.user, pw.expose_secret())))
+                    .map(|pw| SecretString::new(format!("{}:{}", auth.user, pw.expose_secret())))
             })
-            .unwrap_or_else(|| SecretString::new(String::new()));
+            .or_else(|| {
+                // Fall back to cookie-based auth.
+                cookie::read_cookie(config.datadir())
+                    .map_err(|err| {
+                        warn!("{}", fl!("rpc-cookie-read-failed", error = err.to_string()));
+                    })
+                    .ok()
+                    .map(SecretString::new)
+            });
+
+        // Build auth header if credentials are available.
+        let mut headers = HeaderMap::new();
+        if let Some(creds) = &credentials {
+            let encoded = Base64::encode_string(creds.expose_secret().as_bytes());
+            let mut value = HeaderValue::from_str(&format!("Basic {encoded}"))
+                .map_err(|_| RpcCliError::FailedToConnect)?;
+            value.set_sensitive(true);
+            headers.insert(AUTHORIZATION, value);
+        }
 
         // Connect to the Zallet wallet.
         let client = match config.rpc.bind.as_slice() {
             &[] => Err(RpcCliError::WalletHasNoRpcServer),
             &[bind] => HttpClientBuilder::default()
                 .request_timeout(timeout)
-                .build(format!("http://{}{bind}", auth_prefix.expose_secret()))
+                .set_headers(headers.clone())
+                .build(format!("http://{bind}"))
                 .map_err(|_| RpcCliError::FailedToConnect),
             addrs => addrs
                 .iter()
                 .find_map(|bind| {
                     HttpClientBuilder::default()
                         .request_timeout(timeout)
-                        .build(format!("http://{}{bind}", auth_prefix.expose_secret()))
+                        .set_headers(headers.clone())
+                        .build(format!("http://{bind}"))
                         .ok()
                 })
                 .ok_or(RpcCliError::FailedToConnect),

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -49,6 +49,7 @@ impl JsonRpc {
             info!("Trying to open RPC endpoint at {}...", rpc.bind[0]);
             server::spawn(
                 rpc,
+                config.datadir().to_path_buf(),
                 db,
                 #[cfg(zallet_build = "wallet")]
                 keystore,

--- a/zallet/src/components/json_rpc/server.rs
+++ b/zallet/src/components/json_rpc/server.rs
@@ -2,8 +2,9 @@
 
 use jsonrpsee::{
     server::{RpcServiceBuilder, Server},
-    tracing::info,
+    tracing::{info, warn},
 };
+use std::path::PathBuf;
 use tokio::task::JoinHandle;
 
 use crate::{
@@ -25,6 +26,7 @@ mod error;
 pub(crate) use error::LegacyCode;
 
 pub(crate) mod authorization;
+pub(crate) mod cookie;
 mod http_request_compatibility;
 mod rpc_call_compatibility;
 
@@ -32,6 +34,7 @@ type ServerTask = JoinHandle<Result<(), Error>>;
 
 pub(crate) async fn spawn(
     config: RpcSection,
+    datadir: PathBuf,
     wallet: Database,
     #[cfg(zallet_build = "wallet")] keystore: KeyStore,
     chain: Chain,
@@ -52,9 +55,18 @@ pub(crate) async fn spawn(
 
     let timeout = config.timeout();
 
+    let has_cookie_user = config.auth.iter().any(|a| a.user == cookie::COOKIE_USER);
+    let (cookie, _cookie_guard) = if has_cookie_user {
+        warn!("{}", fl!("rpc-cookie-user-conflict"));
+        (None, None)
+    } else {
+        let (user, hash, guard) = cookie::generate_cookie(&datadir)?;
+        (Some((user, hash)), Some(guard))
+    };
+
     let http_middleware = tower::ServiceBuilder::new()
         .layer(
-            authorization::AuthorizationLayer::new(config.auth)
+            authorization::AuthorizationLayer::new(config.auth, cookie)
                 .map_err(|()| ErrorKind::Init.context(fl!("err-init-rpc-auth-invalid")))?,
         )
         .layer(http_request_compatibility::HttpRequestMiddlewareLayer::new())
@@ -84,6 +96,9 @@ pub(crate) async fn spawn(
         .map_err(|e| ErrorKind::Init.context(e))?;
 
     let server_task = crate::spawn!("JSON-RPC server", async move {
+        // Hold the cookie guard until the server stops (or the task is cancelled).
+        // When dropped, it deletes the cookie file.
+        let _cookie_guard = _cookie_guard;
         server_instance.start(rpc_module).stopped().await;
         Ok(())
     });

--- a/zallet/src/components/json_rpc/server/authorization.rs
+++ b/zallet/src/components/json_rpc/server/authorization.rs
@@ -152,11 +152,14 @@ pub struct AuthorizationLayer {
 
 impl AuthorizationLayer {
     /// Creates a new `AuthorizationLayer`.
-    pub fn new(auth: Vec<RpcAuthSection>) -> Result<Self, ()> {
+    pub fn new(
+        auth: Vec<RpcAuthSection>,
+        cookie: Option<(String, PasswordHash)>,
+    ) -> Result<Self, ()> {
         let mut using_bare_password = false;
         let mut using_pwhash = false;
 
-        let users = auth
+        let mut users: HashMap<String, PasswordHash> = auth
             .into_iter()
             .map(|a| match (a.password, a.pwhash) {
                 (Some(password), None) => {
@@ -177,6 +180,10 @@ impl AuthorizationLayer {
         }
         if using_pwhash {
             info!("{}", fl!("rpc-pwhash-auth-info"));
+        }
+
+        if let Some((cookie_user, cookie_hash)) = cookie {
+            users.insert(cookie_user, cookie_hash);
         }
 
         Ok(Self { users })
@@ -232,8 +239,26 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
 
-    use super::PasswordHash;
+    use hyper::header::HeaderValue;
+
+    use tower::Layer;
+
+    use super::{Authorization, AuthorizationLayer, PasswordHash};
+    use crate::components::json_rpc::server::cookie;
+
+    /// Constructs an `Authorization` with the given users and a dummy service.
+    fn auth_with_users(users: HashMap<String, PasswordHash>) -> Authorization<()> {
+        Authorization::new((), users)
+    }
+
+    /// Encodes credentials as a Basic auth header value.
+    fn basic_auth_header(user: &str, password: &str) -> HeaderValue {
+        use base64ct::{Base64, Encoding};
+        let encoded = Base64::encode_string(format!("{user}:{password}").as_bytes());
+        HeaderValue::from_str(&format!("Basic {encoded}")).unwrap()
+    }
 
     #[test]
     fn pwhash_round_trip() {
@@ -244,5 +269,80 @@ mod tests {
         let pwhash_str = pwhash.to_string();
         let parsed_pwhash = pwhash_str.parse::<PasswordHash>().unwrap();
         assert!(parsed_pwhash.check(password));
+    }
+
+    #[test]
+    fn cookie_user_authenticates() {
+        let cookie_password = "K4b8H3nS7vJ2mQ9pR1wX5yA0cE6fG8iL";
+        let mut users = HashMap::new();
+        users.insert(
+            cookie::COOKIE_USER.to_string(),
+            PasswordHash::from_bare(cookie_password),
+        );
+        let auth = auth_with_users(users);
+        let header = basic_auth_header(cookie::COOKIE_USER, cookie_password);
+        assert!(auth.is_authorized(&header));
+    }
+
+    #[test]
+    fn cookie_and_configured_user_coexist() {
+        let mut users = HashMap::new();
+        let password = "abadpassword";
+        let cookie_password = "K4b8H3nS7vJ2mQ9pR1wX5yA0cE6fG8iL";
+        users.insert("user1".to_string(), PasswordHash::from_bare(password));
+        users.insert(
+            cookie::COOKIE_USER.to_string(),
+            PasswordHash::from_bare(cookie_password),
+        );
+        let auth = auth_with_users(users);
+        let user_header = basic_auth_header("user1", password);
+        let cookie_header = basic_auth_header(cookie::COOKIE_USER, cookie_password);
+        assert!(auth.is_authorized(&user_header));
+        assert!(auth.is_authorized(&cookie_header));
+    }
+
+    #[test]
+    fn wrong_cookie_password_rejected() {
+        let mut users = HashMap::new();
+        let cookie_password = "K4b8H3nS7vJ2mQ9pR1wX5yA0cE6fG8iL";
+        let wrong_cookie_password = "wrongcookiepassword";
+        users.insert(
+            cookie::COOKIE_USER.to_string(),
+            PasswordHash::from_bare(cookie_password),
+        );
+        let auth = auth_with_users(users);
+        let header = basic_auth_header(cookie::COOKIE_USER, wrong_cookie_password);
+        assert!(!auth.is_authorized(&header));
+    }
+
+    #[test]
+    fn configured_cookie_user_works_without_generated_cookie() {
+        use crate::config::RpcAuthSection;
+        use secrecy::SecretString;
+
+        let password = "mypassword";
+        let auth = vec![RpcAuthSection {
+            user: cookie::COOKIE_USER.to_string(),
+            password: Some(SecretString::new(password.to_string())),
+            pwhash: None,
+        }];
+        let layer = AuthorizationLayer::new(auth, None).unwrap();
+        let auth = layer.layer(());
+        let header = basic_auth_header(cookie::COOKIE_USER, password);
+        assert!(auth.is_authorized(&header));
+    }
+
+    #[cfg(feature = "rpc-cli")]
+    #[test]
+    fn generated_cookie_hash_validates_against_file() {
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let (user, hash, _guard) = cookie::generate_cookie(dir.path()).unwrap();
+        let file_contents = cookie::read_cookie(dir.path()).unwrap();
+        let password = file_contents
+            .strip_prefix(&format!("{user}:"))
+            .expect("cookie file should have expected prefix");
+        assert!(hash.check(password));
     }
 }

--- a/zallet/src/components/json_rpc/server/cookie.rs
+++ b/zallet/src/components/json_rpc/server/cookie.rs
@@ -1,0 +1,196 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base64ct::{Base64, Encoding};
+use rand::{Rng, rngs::OsRng};
+use tracing::{info, warn};
+
+use super::authorization::PasswordHash;
+use crate::error::{Error, ErrorKind};
+use crate::fl;
+
+/// Username for cookie-based auth, matching zcashd convention.
+pub(crate) const COOKIE_USER: &str = "__cookie__";
+
+/// Default cookie filename within the data directory.
+const COOKIE_FILENAME: &str = ".cookie";
+
+/// Guard that deletes the cookie file when dropped.
+///
+/// This ensures the cookie is cleaned up on normal shutdown or task cancellation.
+pub(crate) struct CookieGuard {
+    path: PathBuf,
+}
+
+impl Drop for CookieGuard {
+    fn drop(&mut self) {
+        if let Err(e) = fs::remove_file(&self.path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!(
+                    "Failed to remove cookie file {}: {}",
+                    self.path.display(),
+                    e
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn cookie_path(datadir: &Path) -> PathBuf {
+    datadir.join(COOKIE_FILENAME)
+}
+
+pub(crate) fn generate_cookie(
+    datadir: &Path,
+) -> Result<(String, PasswordHash, CookieGuard), Error> {
+    let password: [u8; 32] = OsRng.r#gen();
+    let password = Base64::encode_string(&password);
+    let cookie = format!("{COOKIE_USER}:{password}");
+
+    let cookie_path = cookie_path(datadir);
+    let tmp_path = datadir.join(format!("{COOKIE_FILENAME}.tmp"));
+
+    // Clean up any leftover tmp file from a previous crash.
+    let _ = fs::remove_file(&tmp_path);
+
+    // Write to temp file with restricted permissions for atomic creation.
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp_path)
+            .map_err(|e| ErrorKind::Init.context(e))?;
+        f.write_all(cookie.as_bytes()).map_err(|e| {
+            let _ = fs::remove_file(&tmp_path);
+            ErrorKind::Init.context(e)
+        })?;
+    }
+
+    #[cfg(not(unix))]
+    fs::write(&tmp_path, cookie.as_bytes()).map_err(|e| {
+        let _ = fs::remove_file(&tmp_path);
+        ErrorKind::Init.context(e)
+    })?;
+
+    // Atomic rename into place.
+    if let Err(e) = fs::rename(&tmp_path, &cookie_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(ErrorKind::Init.context(e).into());
+    }
+
+    info!(
+        "{}",
+        fl!(
+            "rpc-cookie-generated",
+            path = cookie_path.display().to_string()
+        )
+    );
+
+    let password_hash = PasswordHash::from_bare(&password);
+    let guard = CookieGuard { path: cookie_path };
+    Ok((COOKIE_USER.to_string(), password_hash, guard))
+}
+
+#[cfg(feature = "rpc-cli")]
+pub(crate) fn read_cookie(datadir: &Path) -> Result<String, Error> {
+    let path = cookie_path(datadir);
+    let cookie = fs::read_to_string(&path)
+        .map_err(|e| ErrorKind::Init.context(e))?
+        .trim()
+        .to_string();
+    if !cookie.starts_with(&format!("{COOKIE_USER}:")) {
+        return Err(ErrorKind::Init.context("Invalid cookie file format").into());
+    }
+    Ok(cookie)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn generate_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let _guard = generate_cookie(dir.path()).unwrap();
+        assert!(dir.path().join(COOKIE_FILENAME).exists());
+    }
+
+    #[test]
+    fn generate_file_contents_valid() {
+        let dir = TempDir::new().unwrap();
+        let _guard = generate_cookie(dir.path()).unwrap();
+        let contents = fs::read_to_string(dir.path().join(COOKIE_FILENAME)).unwrap();
+        assert!(contents.starts_with(&format!("{COOKIE_USER}:")));
+        assert!(contents.len() > format!("{COOKIE_USER}:").len());
+    }
+
+    #[test]
+    fn generate_no_tmp_leftover() {
+        let dir = TempDir::new().unwrap();
+        let _guard = generate_cookie(dir.path()).unwrap();
+        assert!(!dir.path().join(".cookie.tmp").exists());
+    }
+
+    #[test]
+    fn generate_different_each_call() {
+        let dir = TempDir::new().unwrap();
+        let _guard1 = generate_cookie(dir.path()).unwrap();
+        let contents_1 = fs::read_to_string(dir.path().join(COOKIE_FILENAME)).unwrap();
+        let _guard2 = generate_cookie(dir.path()).unwrap();
+        let contents_2 = fs::read_to_string(dir.path().join(COOKIE_FILENAME)).unwrap();
+        assert_ne!(contents_1, contents_2);
+    }
+
+    #[cfg(feature = "rpc-cli")]
+    #[test]
+    fn read_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let _guard = generate_cookie(dir.path()).unwrap();
+        let contents = fs::read_to_string(dir.path().join(COOKIE_FILENAME)).unwrap();
+        let read_val = read_cookie(dir.path()).unwrap();
+        assert_eq!(contents, read_val);
+    }
+
+    #[cfg(feature = "rpc-cli")]
+    #[test]
+    fn read_invalid_format_errors() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(COOKIE_FILENAME), "invalid_cookie").unwrap();
+        assert!(read_cookie(dir.path()).is_err());
+    }
+
+    #[cfg(feature = "rpc-cli")]
+    #[test]
+    fn read_missing_file_errors() {
+        let dir = TempDir::new().unwrap();
+        assert!(read_cookie(dir.path()).is_err());
+    }
+
+    #[test]
+    fn guard_deletes_on_drop() {
+        let dir = TempDir::new().unwrap();
+        {
+            let _guard = generate_cookie(dir.path()).unwrap();
+            assert!(dir.path().join(COOKIE_FILENAME).exists());
+        }
+        // Guard dropped here — file should be gone.
+        assert!(!dir.path().join(COOKIE_FILENAME).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let _guard = generate_cookie(dir.path()).unwrap();
+        let perms = fs::metadata(dir.path().join(COOKIE_FILENAME))
+            .unwrap()
+            .permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}


### PR DESCRIPTION
Generate an RPC cookie on startup and write it to {datadir}/.cookie. The server loads that credential into the auth layer alongside any configured users, and removes the cookie file on clean shutdown.

When no RPC password is configured, `zallet rpc` now reads the cookie file so local RPC works without extra setup.

Closes #305