### PR TITLE
Fix rocksdb build error on GCC 15 systems.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+CXXFLAGS = "-include cstdint"


### PR DESCRIPTION
rocksdb 0.22.0 → librocksdb-sys 0.16.0+8.10.0 (RocksDB 8.10, early 2024) is pulled in transitively via zebra-state. That version predates GCC 15 and its headers don't #include <cstdint> where they should. On GCC 15's libstdc++, <cstdint> is no longer transitively included, so uint32_t is undefined when trace_record.h is parsed. GCC's error recovery falls back to int for the unparseable return type, which then mismatches the out-of-line definition in trace_record.cc.

To fix this, we temporarily force-include the cstdint headers via a .cargo/config.toml CXXFLAGS definition.