### PR TITLE
Fix zallet zcashd migration strict mode

### DIFF
--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -122,7 +122,7 @@ impl MigrateZcashdWalletCmd {
                 })?;
 
             let zcashd_dump =
-                ZcashdDump::from_bdb_dump(&db_dump, self.allow_warnings).map_err(|e| {
+                ZcashdDump::from_bdb_dump(&db_dump, !self.allow_warnings).map_err(|e| {
                     MigrateError::Zewif {
                         error_type: ZewifError::ZcashdDump,
                         wallet_path: wallet_path.clone(),


### PR DESCRIPTION
## Summary
- pass the inverted allow_warnings flag into ZcashdDump::from_bdb_dump so the default migration path is strict in the first parser stage
- keeps the later parse_dump strictness unchanged

## Testing
- cargo fmt --check
- cargo check -p zallet *(fails in this Windows environment before checking this crate because dlltool.exe is missing for the GNU toolchain)*

Fixes #444