### PR TITLE
i18n: Wire remaining hardcoded CLI error strings through Fluent

### DIFF
--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -139,6 +139,14 @@ err-init-identity-not-passphrase-encrypted = {$path} is not encrypted with a pas
 err-init-path-not-utf8 = {$path} is not currently supported (not UTF-8)
 err-init-identity-not-usable = Identity file at {$path} is not usable: {$error}
 err-init-rpc-auth-invalid = Invalid '{-cfg-rpc-auth}' configuration
+err-init-rpc-single-bind-only = Only one RPC bind address is supported (for now)
+err-init-validator-no-addresses =
+    validator_address '{$addr}' resolved to no IP addresses
+err-init-validator-resolve-failed =
+    Failed to resolve validator_address '{$addr}': {$error}
+err-init-validator-parse-default-failed =
+    Failed to parse default validator_address '{$addr}': {$error}
+err-init-seed-required-migration = Seed-required wallet migrations are not yet supported
 
 ## Keystore errors
 
@@ -214,6 +222,7 @@ err-migrate-wallet-invalid-chain-data =
     programming error; please report the following error to (TBD): '{$err}'
 err-migrate-wallet-key-decoding =
     An error occurred decoding key material: '{$err}'.
+err-migrate-wallet-key-decoding-der-failed = failed DER decoding
 err-migrate-wallet-tx-fetch =
     An error occurred fetching transaction data: '{$err}'.
 err-migrate-wallet-data-parse=
@@ -287,6 +296,16 @@ err-rpc-cli-conn-failed = Failed to connect to the Zallet wallet's JSON-RPC port
 err-rpc-cli-invalid-param = Invalid parameter '{$parameter}'
 err-rpc-cli-no-server = No JSON-RPC port is available.
 err-rpc-cli-request-failed = JSON-RPC request failed: {$error}
+
+## Regtest CLI errors
+
+err-regtest-not-regtest-wallet = Command only works on a regtest wallet
+err-regtest-fresh-wallet-only = Command only works on a fresh wallet
+err-regtest-need-mnemonic-first = Need to call generate-mnemonic or import-mnemonic first
+err-regtest-multi-seed-unsupported = This regtest API is not supported with multiple seeds
+err-regtest-miner-address-failed = Failed to generate miner address: {$error}
+
+err-chain-indexer-not-running = ChainState indexer is not running
 
 ## zallet manpage
 

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -585,7 +585,7 @@ impl MigrateZcashdWalletCmd {
             .map_err(|_| {
                 ErrorKind::Generic.context(fl!(
                     "err-migrate-wallet-key-decoding",
-                    err = "failed DER decoding"
+                    err = fl!("err-migrate-wallet-key-decoding-der-failed")
                 ))
             })?;
 

--- a/zallet/src/commands/regtest/generate_account_and_miner_address.rs
+++ b/zallet/src/commands/regtest/generate_account_and_miner_address.rs
@@ -10,6 +10,7 @@ use crate::{
     commands::AsyncRunnable,
     components::{database::Database, keystore::KeyStore},
     error::{Error, ErrorKind},
+    fl,
     network::Network,
     prelude::*,
 };
@@ -22,7 +23,7 @@ impl AsyncRunnable for GenerateAccountAndMinerAddressCmd {
         let params = config.consensus.network();
         if !matches!(params, Network::RegTest(_)) {
             return Err(ErrorKind::Init
-                .context("Command only works on a regtest wallet")
+                .context(fl!("err-regtest-not-regtest-wallet"))
                 .into());
         }
 
@@ -33,7 +34,7 @@ impl AsyncRunnable for GenerateAccountAndMinerAddressCmd {
         match wallet.chain_height() {
             Ok(None) => Ok(()),
             Ok(Some(_)) | Err(_) => {
-                Err(ErrorKind::Init.context("Command only works on a fresh wallet"))
+                Err(ErrorKind::Init.context(fl!("err-regtest-fresh-wallet-only")))
             }
         }?;
 
@@ -41,10 +42,10 @@ impl AsyncRunnable for GenerateAccountAndMinerAddressCmd {
         let mut seed_fps = seed_fps.into_iter();
         match (seed_fps.next(), seed_fps.next()) {
             (None, _) => Err(ErrorKind::Init
-                .context("Need to call generate-mnemonic or import-mnemonic first")
+                .context(fl!("err-regtest-need-mnemonic-first"))
                 .into()),
             (_, Some(_)) => Err(ErrorKind::Init
-                .context("This regtest API is not supported with multiple seeds")
+                .context(fl!("err-regtest-multi-seed-unsupported"))
                 .into()),
             (Some(seed_fp), None) => {
                 let seed = keystore.decrypt_seed(&seed_fp).await?;
@@ -61,7 +62,10 @@ impl AsyncRunnable for GenerateAccountAndMinerAddressCmd {
                 let (_, usk) = wallet
                     .create_account("Default account", &seed, &birthday, None)
                     .map_err(|e| {
-                        ErrorKind::Generic.context(format!("Failed to generate miner address: {e}"))
+                        ErrorKind::Generic.context(fl!(
+                            "err-regtest-miner-address-failed",
+                            error = e.to_string()
+                        ))
                     })?;
 
                 let (addr, _) = usk
@@ -69,7 +73,10 @@ impl AsyncRunnable for GenerateAccountAndMinerAddressCmd {
                     .to_account_pubkey()
                     .derive_internal_ivk()
                     .map_err(|e| {
-                        ErrorKind::Generic.context(format!("Failed to generate miner address: {e}"))
+                        ErrorKind::Generic.context(fl!(
+                            "err-regtest-miner-address-failed",
+                            error = e.to_string()
+                        ))
                     })?
                     .default_address();
 

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -15,6 +15,7 @@ use zaino_state::{
 use crate::{
     config::ZalletConfig,
     error::{Error, ErrorKind},
+    fl,
 };
 
 use super::TaskHandle;
@@ -48,15 +49,16 @@ impl Chain {
                             "validator_address '{}' resolved to no IP addresses",
                             addr_str
                         );
-                        Err(ErrorKind::Init.context(format!(
-                            "validator_address '{addr_str}' resolved to no IP addresses"
-                        )))
+                        Err(ErrorKind::Init
+                            .context(fl!("err-init-validator-no-addresses", addr = addr_str)))
                     }
                 },
                 Err(e) => {
                     error!("Failed to resolve validator_address '{}': {}", addr_str, e);
-                    Err(ErrorKind::Init.context(format!(
-                        "Failed to resolve validator_address '{addr_str}': {e}"
+                    Err(ErrorKind::Init.context(fl!(
+                        "err-init-validator-resolve-failed",
+                        addr = addr_str,
+                        error = e.to_string()
                     )))
                 }
             },
@@ -81,8 +83,10 @@ impl Chain {
                             "Failed to parse default validator_address '{}': {}",
                             default_addr_str, e
                         );
-                        Err(ErrorKind::Init.context(format!(
-                            "Failed to parse default validator_address '{default_addr_str}': {e}"
+                        Err(ErrorKind::Init.context(fl!(
+                            "err-init-validator-parse-default-failed",
+                            addr = default_addr_str,
+                            error = e.to_string()
                         )))
                     }
                 }
@@ -161,7 +165,7 @@ impl Chain {
             .read()
             .await
             .as_ref()
-            .ok_or_else(|| ErrorKind::Generic.context("ChainState indexer is not running"))?
+            .ok_or_else(|| ErrorKind::Generic.context(fl!("err-chain-indexer-not-running")))?
             .inner_ref()
             .get_subscriber())
     }

--- a/zallet/src/components/database.rs
+++ b/zallet/src/components/database.rs
@@ -101,7 +101,7 @@ impl Database {
                 Err(schemerz::MigratorError::Migration {
                     error: WalletMigrationError::SeedRequired,
                     ..
-                }) => Err(ErrorKind::Init.context("TODO: Support seed-required migrations")),
+                }) => Err(ErrorKind::Init.context(fl!("err-init-seed-required-migration"))),
                 Err(e) => Err(ErrorKind::Init.context(e)),
             }?;
 

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -12,6 +12,7 @@ use jsonrpsee::tracing::Instrument;
 use crate::{
     config::ZalletConfig,
     error::{Error, ErrorKind},
+    fl,
 };
 
 use super::{TaskHandle, chain::Chain, database::Database};
@@ -42,7 +43,7 @@ impl JsonRpc {
         if !rpc.bind.is_empty() {
             if rpc.bind.len() > 1 {
                 return Err(ErrorKind::Init
-                    .context("Only one RPC bind address is supported (for now)")
+                    .context(fl!("err-init-rpc-single-bind-only"))
                     .into());
             }
             info!("Spawning RPC server");


### PR DESCRIPTION
Closes #321

First contribution on my side — picked this as a small i18n cleanup.

Wired the last hardcoded CLI error strings I found through `fl!()` (regtest, migration, chain/indexer, RPC bind, DB migration). Logs, zcashd-matched RPC errors, and `--help` left as-is per the issue.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo check -p zallet`