### PR TITLE
Makefile: delete duplicate .PHONY for build and import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 IMAGE_NAME := zallet
 IMAGE_TAG := latest
 
-.PHONY: all build import
+.PHONY: all
 all: build import
 
 .PHONY: build


### PR DESCRIPTION
.PHONY for the targets `build` and `import` are already appended later.

Duplications don't hurt, but they are useless. 