### PR TITLE
sync: Treat an absent shielded tree state as an empty note commitment tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ be considered breaking changes.
   standalone imported transparent keys (e.g. from a `zcashd` migration).
 - No longer crashes in regtest mode when a Sapling or NU5 activation height is
   not defined.
+- The wallet sync task no longer exits with a "Missing Sapling/Orchard tree
+  state" error when a shielded pool is active but its note commitment tree is
+  still empty (e.g. on regtest, where NU5 is active from height 1). An absent
+  tree state is now correctly treated as an empty tree.
 - Zallet now refuses to open wallet databases from incompatible earlier alpha
   releases instead of attempting to migrate them.
 - `z_sendmany` no longer drop standalone transparent signing keys when the same

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -309,36 +309,25 @@ pub(super) async fn fetch_chain_state(
         .await?
         .into_parts();
 
-    let final_sapling_tree = if params.is_nu_active(NetworkUpgrade::Sapling, height.0.into()) {
-        read_frontier_v0(
-            sapling
-                .ok_or_else(|| IndexerError::InvalidData {
-                    message: "Missing Sapling tree state".into(),
-                })?
-                .as_slice(),
-        )
-        .map_err(|e| IndexerError::InvalidData {
-            message: format!("{e}"),
-        })?
-    } else {
-        // Sapling is not yet active; the Sapling tree is empty.
-        Frontier::empty()
+    // An absent tree state (`None`) means the pool's note commitment tree is empty, not an
+    // error (fetch errors surface via `?` above). Treat "active but empty" like "not yet
+    // active": an empty frontier.
+    let final_sapling_tree = match sapling {
+        Some(sapling) if params.is_nu_active(NetworkUpgrade::Sapling, height.0.into()) => {
+            read_frontier_v0(sapling.as_slice()).map_err(|e| IndexerError::InvalidData {
+                message: format!("{e}"),
+            })?
+        }
+        _ => Frontier::empty(),
     };
 
-    let final_orchard_tree = if params.is_nu_active(NetworkUpgrade::Nu5, height.0.into()) {
-        read_frontier_v0(
-            orchard
-                .ok_or_else(|| IndexerError::InvalidData {
-                    message: "Missing Orchard tree state".into(),
-                })?
-                .as_slice(),
-        )
-        .map_err(|e| IndexerError::InvalidData {
-            message: format!("{e}"),
-        })?
-    } else {
-        // NU5 is not yet active; the Orchard tree is empty.
-        Frontier::empty()
+    let final_orchard_tree = match orchard {
+        Some(orchard) if params.is_nu_active(NetworkUpgrade::Nu5, height.0.into()) => {
+            read_frontier_v0(orchard.as_slice()).map_err(|e| IndexerError::InvalidData {
+                message: format!("{e}"),
+            })?
+        }
+        _ => Frontier::empty(),
     };
 
     Ok(ChainState::new(


### PR DESCRIPTION
Closes #454

## Problem
`fetch_chain_state` errored with `"Missing Sapling/Orchard tree state"` — exiting the wallet sync task — whenever a shielded pool was active at the requested height but the indexer returned no tree state for it. This crashes sync on any chain where a pool is active while its note commitment tree is still empty, most reliably on **regtest** (NU5 active from height 1, Orchard tree empty).

## Root cause
An absent tree state is not an error: an empty incremental-Merkle tree has no frontier to serialize, so the node reports `None` for it (`zebra_rpc::z_get_treestate` maps the tree via `tree.map(|t| t.to_rpc_bytes())`, and `zebra-state`'s `read::orchard_tree()` returns `None` when no tree is stored at that height). Zaino relays this `None` faithfully. Genuine fetch failures surface separately via the `?` on `z_get_treestate`. So `None` ⟺ "empty tree", and treating it as fatal was incorrect — this is a zallet-side bug; Zaino/Zebra are behaving correctly.

## Fix
Treat "pool active but tree state absent" the same as "pool not yet active": an empty frontier. Both the Sapling and Orchard paths had this bug; both are fixed symmetrically.

## Testing
`fetch_chain_state` requires a live indexer connection and has no unit coverage. Validated end-to-end against the integration-tests suite — the `wallet.py` and `wallet_orchard_init.py` regtest scenarios sync to completion with this change (previously they hit `"Missing Orchard tree state"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
