### PR TITLE
i18n: make remaining user-facing CLI error messages translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ be considered breaking changes.
   block heights and tree state are not resolved from the chain. Cannot be
   combined with `--buffer-wallet-transactions`. Useful when chain data is not
   available.
+- The remaining user-facing CLI error messages are now translatable.
 
 ### Fixed
 - `listaddresses` no longer returns an internal error when the wallet contains

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -139,6 +139,11 @@ err-init-identity-not-passphrase-encrypted = {$path} is not encrypted with a pas
 err-init-path-not-utf8 = {$path} is not currently supported (not UTF-8)
 err-init-identity-not-usable = Identity file at {$path} is not usable: {$error}
 err-init-rpc-auth-invalid = Invalid '{-cfg-rpc-auth}' configuration
+err-init-single-rpc-bind = Only one RPC bind address is supported (for now)
+
+## Chain errors
+
+err-chain-indexer-not-running = ChainState indexer is not running
 
 ## Keystore errors
 

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -161,7 +161,7 @@ impl Chain {
             .read()
             .await
             .as_ref()
-            .ok_or_else(|| ErrorKind::Generic.context("ChainState indexer is not running"))?
+            .ok_or_else(|| ErrorKind::Generic.context(crate::fl!("err-chain-indexer-not-running")))?
             .inner_ref()
             .get_subscriber())
     }

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -42,7 +42,7 @@ impl JsonRpc {
         if !rpc.bind.is_empty() {
             if rpc.bind.len() > 1 {
                 return Err(ErrorKind::Init
-                    .context("Only one RPC bind address is supported (for now)")
+                    .context(crate::fl!("err-init-single-rpc-bind"))
                     .into());
             }
             info!("Spawning RPC server");


### PR DESCRIPTION
Small contribution toward #321 (ensure all CLI messages are translatable).

I audited the CLI output for untranslated user-facing strings. Most are already wrapped in `fl!`. The remaining user-facing strings I found are two error contexts that reach the user through the `Error` `Display` impl in `error.rs`:

- `components/chain.rs`: `"ChainState indexer is not running"`
- `components/json_rpc.rs`: `"Only one RPC bind address is supported (for now)"`

This PR wraps both via `crate::fl!` and adds the corresponding entries to `i18n/en-US/zallet.ftl` (a new `## Chain errors` section, and `err-init-single-rpc-bind` alongside the other init errors).

Per the exclusions in #321, I deliberately left untranslated:
- `.expect()` panic messages (internal invariants)
- JSON-RPC error strings

Verified locally with `cargo build -p zallet`.

Happy to adjust scope per your intent for the issue (for example, if the `(for now)` bind-address message is intentionally left untranslated as a temporary limitation, I can drop that one).

Refs #321