### PR TITLE
rpc: Implement z_exportviewingkey for Sapling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ be considered breaking changes.
   - `decodescript`
   - `verifymessage`
   - `z_converttex`
+  - `z_exportviewingkey`
   - `z_importaddress`
 
 ### Changed

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -57,6 +57,8 @@ mod validate_address;
 mod verify_message;
 mod view_transaction;
 #[cfg(zallet_build = "wallet")]
+mod z_export_viewing_key;
+#[cfg(zallet_build = "wallet")]
 mod z_get_total_balance;
 #[cfg(zallet_build = "wallet")]
 mod z_import_address;
@@ -561,6 +563,14 @@ pub(crate) trait WalletRpc {
         fee: Option<JsonValue>,
         privacy_policy: Option<String>,
     ) -> z_send_many::Response;
+
+    /// Reveals the viewing key corresponding to 'zaddr'.
+    ///
+    /// # Arguments
+    ///
+    /// - `zaddr` (string, required) The Sapling payment address.
+    #[method(name = "z_exportviewingkey")]
+    async fn export_viewing_key(&self, zaddr: &str) -> z_export_viewing_key::Response;
 }
 
 pub(crate) struct RpcImpl {
@@ -896,5 +906,9 @@ impl WalletRpcServer for WalletRpcImpl {
                 .await?,
             )
             .await)
+    }
+
+    async fn export_viewing_key(&self, zaddr: &str) -> z_export_viewing_key::Response {
+        z_export_viewing_key::call(self.wallet().await?.as_ref(), &self.keystore, zaddr).await
     }
 }

--- a/zallet/src/components/json_rpc/methods/z_export_viewing_key.rs
+++ b/zallet/src/components/json_rpc/methods/z_export_viewing_key.rs
@@ -1,0 +1,210 @@
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use secrecy::ExposeSecret;
+use serde::Serialize;
+use zcash_client_backend::data_api::{Account, WalletRead};
+use zcash_keys::{
+    address::Address, encoding::encode_extended_full_viewing_key, keys::UnifiedSpendingKey,
+};
+use zcash_protocol::consensus::NetworkConstants;
+
+use crate::components::{
+    database::DbConnection,
+    json_rpc::{server::LegacyCode, utils::ensure_wallet_is_unlocked},
+    keystore::KeyStore,
+};
+
+/// Response to a `z_exportviewingkey` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// The exported Sapling extended full viewing key.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+#[serde(transparent)]
+pub(crate) struct ResultType(String);
+
+pub(super) const PARAM_ZADDR_DESC: &str = "The Sapling payment address.";
+
+pub(crate) async fn call(wallet: &DbConnection, keystore: &KeyStore, zaddr: &str) -> Response {
+    ensure_wallet_is_unlocked(keystore).await?;
+
+    let address = Address::decode(wallet.params(), zaddr)
+        .ok_or(LegacyCode::InvalidAddressOrKey.with_static("Invalid zaddr"))?;
+
+    // Only bare Sapling addresses are supported.
+    let sapling_addr = match &address {
+        Address::Sapling(addr) => *addr,
+        Address::Unified(_) => {
+            return Err(LegacyCode::InvalidAddressOrKey
+                .with_static("z_exportviewingkey does not yet support unified addresses"));
+        }
+        _ => {
+            return Err(LegacyCode::InvalidAddressOrKey
+                .with_static("z_exportviewingkey only supports Sapling addresses"));
+        }
+    };
+
+    // Look up the account by matching the Sapling address against each UFVK's
+    // Sapling component. `get_account_for_address` doesn't find bare Sapling
+    // receivers derived from unified accounts.
+    let ufvks = wallet
+        .get_unified_full_viewing_keys()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    let account_id = ufvks
+        .iter()
+        .find_map(|(id, ufvk)| {
+            ufvk.sapling()
+                .and_then(|dfvk| dfvk.decrypt_diversifier(&sapling_addr))
+                .map(|_| *id)
+        })
+        .ok_or_else(|| {
+            LegacyCode::Wallet
+                .with_static("Wallet does not hold private key or viewing key for this zaddr")
+        })?;
+
+    let account = wallet
+        .get_account(account_id)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or(
+            LegacyCode::Wallet
+                .with_static("Wallet does not hold private key or viewing key for this zaddr"),
+        )?;
+
+    let derivation = account.source().key_derivation().ok_or_else(|| {
+        LegacyCode::Wallet
+            .with_static("Cannot export viewing key for an imported view-only account")
+    })?;
+
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+
+    let usk = UnifiedSpendingKey::from_seed(
+        wallet.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::Wallet.with_message(e.to_string()))?;
+
+    // Only ExtendedFullViewingKey carries the chain code needed for bech32 encoding;
+    // DiversifiableFullViewingKey can't be used here.
+    #[allow(deprecated)]
+    let extfvk = usk.sapling().to_extended_full_viewing_key();
+
+    let hrp = wallet.params().hrp_sapling_extended_full_viewing_key();
+    Ok(ResultType(encode_extended_full_viewing_key(hrp, &extfvk)))
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_keys::encoding::{
+        decode_extended_full_viewing_key, encode_extended_full_viewing_key, encode_payment_address,
+    };
+    use zcash_protocol::constants;
+
+    /// Derives a Sapling extended spending key from seed [0; 32] and returns
+    /// the encoded EFVK and the default payment address.
+    fn test_efvk_and_address(hrp_fvk: &str, hrp_addr: &str) -> (String, String) {
+        let extsk = sapling::zip32::ExtendedSpendingKey::master(&[0; 32]);
+        #[allow(deprecated)]
+        let extfvk = extsk.to_extended_full_viewing_key();
+        let encoded_fvk = encode_extended_full_viewing_key(hrp_fvk, &extfvk);
+        let (_, payment_address) = extfvk.default_address();
+        let encoded_addr = encode_payment_address(hrp_addr, &payment_address);
+        (encoded_fvk, encoded_addr)
+    }
+
+    #[test]
+    fn encoded_efvk_is_valid_bech32() {
+        let (encoded, _) = test_efvk_and_address(
+            constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+        );
+        assert!(encoded.starts_with("zxviews"));
+    }
+
+    #[test]
+    fn encoded_efvk_round_trips() {
+        let hrp = constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY;
+        let (encoded, _) =
+            test_efvk_and_address(hrp, constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS);
+        let decoded = decode_extended_full_viewing_key(hrp, &encoded).unwrap();
+        let re_encoded = encode_extended_full_viewing_key(hrp, &decoded);
+        assert_eq!(encoded, re_encoded);
+    }
+
+    #[test]
+    fn efvk_produces_consistent_default_address() {
+        let hrp_fvk = constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY;
+        let hrp_addr = constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS;
+
+        let (_, addr1) = test_efvk_and_address(hrp_fvk, hrp_addr);
+        let (_, addr2) = test_efvk_and_address(hrp_fvk, hrp_addr);
+        assert_eq!(addr1, addr2);
+    }
+
+    #[test]
+    fn mainnet_address_starts_with_zs() {
+        let (_, addr) = test_efvk_and_address(
+            constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+        );
+        assert!(addr.starts_with("zs"));
+    }
+
+    #[test]
+    fn testnet_efvk_has_correct_hrp() {
+        let (encoded, _) = test_efvk_and_address(
+            constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS,
+        );
+        assert!(encoded.starts_with("zxviewtestsapling"));
+    }
+
+    #[test]
+    fn testnet_efvk_round_trips() {
+        let hrp = constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY;
+        let (encoded, _) =
+            test_efvk_and_address(hrp, constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS);
+        let decoded = decode_extended_full_viewing_key(hrp, &encoded).unwrap();
+        let re_encoded = encode_extended_full_viewing_key(hrp, &decoded);
+        assert_eq!(encoded, re_encoded);
+    }
+
+    #[test]
+    fn different_seeds_produce_different_efvks() {
+        let hrp = constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY;
+
+        let extsk_a = sapling::zip32::ExtendedSpendingKey::master(&[0; 32]);
+        #[allow(deprecated)]
+        let efvk_a = encode_extended_full_viewing_key(hrp, &extsk_a.to_extended_full_viewing_key());
+
+        let extsk_b = sapling::zip32::ExtendedSpendingKey::master(&[1; 32]);
+        #[allow(deprecated)]
+        let efvk_b = encode_extended_full_viewing_key(hrp, &extsk_b.to_extended_full_viewing_key());
+
+        assert_ne!(efvk_a, efvk_b);
+    }
+
+    #[test]
+    fn efvk_default_address_matches_import_flow() {
+        // Exported EFVK, decoded back, should produce the same default address.
+        let hrp_fvk = constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY;
+        let hrp_addr = constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS;
+
+        let (encoded_fvk, original_addr) = test_efvk_and_address(hrp_fvk, hrp_addr);
+
+        let decoded = decode_extended_full_viewing_key(hrp_fvk, &encoded_fvk).unwrap();
+        let (_, reimported_payment_addr) = decoded.default_address();
+        let reimported_addr = encode_payment_address(hrp_addr, &reimported_payment_addr);
+
+        assert_eq!(original_addr, reimported_addr);
+    }
+}


### PR DESCRIPTION
Implements z_exportviewingkey, which returns the bech32-encoded Sapling extended full viewing key for a   
  given Sapling payment address. This is the export counterpart needed to support z_importviewingkey (PR  
  #431) and its integration test (zcash/integration-tests#99).                                              
                                                            
  The address lookup scans each account's UFVK Sapling component via `decrypt_diversifier`, since bare Sapling
   receivers derived from unified accounts aren't found by the standard `get_account_for_address` path. Wallet
   unlock is required for seed access to re-derive the EFVK. Imported view-only accounts are rejected (the  
  stored `DiversifiableFullViewingKey` can't reconstruct the chain-code-bearing `ExtendedFullViewingKey`).

Integration tests can be found here: https://github.com/zcash/integration-tests/pull/115
                                                                                                          
  Closes #70
  Closes COR-255