### PR TITLE
fix(rpc): bound async operation queue to prevent memory DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- JSON-RPC async operations (`z_sendmany`, `z_shieldcoinbase`) are now bounded
+  to 64 in-flight operations, and finished operations are pruned automatically
+  when new async RPCs are started. This prevents authenticated callers from
+  exhausting wallet memory by flooding the operation queue.
+
 ## [0.1.0-beta.1] - 2026-07-12
 
 ### Added

--- a/zallet-core/src/components/json_rpc/asyncop.rs
+++ b/zallet-core/src/components/json_rpc/asyncop.rs
@@ -15,6 +15,12 @@ use uuid::Uuid;
 
 use super::server::LegacyCode;
 
+/// Maximum number of in-flight async operations.
+///
+/// Matches Bitcoin Core's `DEFAULT_HTTP_WORKQUEUE` (64), which bounds the depth of
+/// the RPC work queue in `zcashd`.
+pub(super) const MAX_ASYNC_OPERATIONS: usize = 64;
+
 /// An async operation ID.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Documented, JsonSchema)]
 #[serde(try_from = "String")]
@@ -71,6 +77,10 @@ impl OperationState {
             "success" => Some(Self::Success),
             _ => None,
         }
+    }
+
+    pub(super) fn is_finished(self) -> bool {
+        matches!(self, Self::Success | Self::Failed | Self::Cancelled)
     }
 }
 

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -11,7 +11,10 @@ use crate::components::{
 
 #[cfg(zallet_build = "wallet")]
 use {
-    super::asyncop::{AsyncOperation, ContextInfo, OperationId},
+    super::{
+        asyncop::{AsyncOperation, ContextInfo, MAX_ASYNC_OPERATIONS, OperationId},
+        server::LegacyCode,
+    },
     crate::components::{
         json_rpc::payments::AmountParameter, keystore::KeyStore, sync::WalletDecryptorHandle,
     },
@@ -779,16 +782,23 @@ impl<C: Chain> WalletRpcImpl<C> {
         self.general.chain().await
     }
 
-    async fn start_async<F, T>(&self, (context, f): (Option<ContextInfo>, F)) -> OperationId
+    async fn start_async<F, T>(
+        &self,
+        (context, f): (Option<ContextInfo>, F),
+    ) -> RpcResult<OperationId>
     where
         F: Future<Output = RpcResult<T>> + Send + 'static,
         T: Serialize + Send + 'static,
     {
         let mut async_ops = self.async_ops.write().await;
+        get_operation::prune_finished(&mut async_ops).await;
+        if async_ops.len() >= MAX_ASYNC_OPERATIONS {
+            return Err(LegacyCode::Misc.with_static("Too many async operations in progress"));
+        }
         let op = AsyncOperation::new(context, f).await;
         let op_id = op.operation_id().clone();
         async_ops.push(op);
-        op_id
+        Ok(op_id)
     }
 }
 
@@ -1082,21 +1092,20 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         fee: Option<JsonValue>,
         privacy_policy: Option<String>,
     ) -> z_send_many::Response {
-        Ok(self
-            .start_async(
-                z_send_many::call(
-                    self.wallet().await?,
-                    self.keystore.clone(),
-                    self.chain().await?,
-                    fromaddress,
-                    amounts,
-                    minconf,
-                    fee,
-                    privacy_policy,
-                )
-                .await?,
+        self.start_async(
+            z_send_many::call(
+                self.wallet().await?,
+                self.keystore.clone(),
+                self.chain().await?,
+                fromaddress,
+                amounts,
+                minconf,
+                fee,
+                privacy_policy,
             )
-            .await)
+            .await?,
+        )
+        .await
     }
 
     async fn z_shieldcoinbase(
@@ -1120,7 +1129,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             privacy_policy,
         )
         .await?;
-        let opid = self.start_async((context, fut)).await;
+        let opid = self.start_async((context, fut)).await?;
         Ok(z_shieldcoinbase::ShieldCoinbaseResult::new(preflight, opid))
     }
 }

--- a/zallet-core/src/components/json_rpc/methods/get_operation.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_operation.rs
@@ -5,9 +5,7 @@ use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use crate::components::json_rpc::asyncop::{
-    AsyncOperation, OperationId, OperationState, OperationStatus,
-};
+use crate::components::json_rpc::asyncop::{AsyncOperation, OperationId, OperationStatus};
 
 /// Response to a `z_getoperationstatus` or `z_getoperationresult` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -19,6 +17,18 @@ pub(crate) struct ResultType(Vec<OperationStatus>);
 
 pub(super) const PARAM_OPERATIONID_DESC: &str = "A list of operation ids we are interested in.";
 pub(super) const PARAM_OPERATIONID_REQUIRED: bool = false;
+
+/// Removes finished operations from the queue.
+pub(super) async fn prune_finished(async_ops: &mut Vec<AsyncOperation>) {
+    let mut pending = Vec::with_capacity(async_ops.len());
+    for op in async_ops.drain(..) {
+        if op.state().await.is_finished() {
+            continue;
+        }
+        pending.push(op);
+    }
+    *async_ops = pending;
+}
 
 pub(crate) async fn status(
     async_ops: &[AsyncOperation],
@@ -45,10 +55,7 @@ pub(crate) async fn result(
     let mut remove = HashSet::new();
 
     for op in filtered(async_ops, filter) {
-        if matches!(
-            op.state().await,
-            OperationState::Success | OperationState::Failed | OperationState::Cancelled
-        ) {
+        if op.state().await.is_finished() {
             ret.push(op.to_status().await);
             remove.insert(op.operation_id().clone());
         }
@@ -66,4 +73,48 @@ fn filtered(
     async_ops
         .iter()
         .filter(move |op| filter.is_empty() || filter.contains(op.operation_id()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tokio::time::sleep;
+
+    use super::*;
+    use crate::components::json_rpc::asyncop::{ContextInfo, MAX_ASYNC_OPERATIONS};
+
+    async fn wait_until_finished(op: &AsyncOperation) {
+        while !op.state().await.is_finished() {
+            sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn prune_finished_removes_completed_operations() {
+        let finished = AsyncOperation::new(Some(ContextInfo::new("test", json!({}))), async {
+            Ok::<(), _>(())
+        })
+        .await;
+        wait_until_finished(&finished).await;
+
+        let pending = AsyncOperation::new(Some(ContextInfo::new("test", json!({}))), async {
+            sleep(Duration::from_secs(60)).await;
+            Ok::<(), _>(())
+        })
+        .await;
+        let pending_id = pending.operation_id().clone();
+
+        let mut ops = vec![finished, pending];
+        prune_finished(&mut ops).await;
+
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].operation_id(), &pending_id);
+    }
+
+    #[test]
+    fn max_async_operations_matches_bitcoin_rpc_workqueue() {
+        assert_eq!(MAX_ASYNC_OPERATIONS, 64);
+    }
 }


### PR DESCRIPTION
## Summary

- Confirms and fixes GHSA-3wr9-v982-59fj: `WalletRpcImpl::async_ops` was an unbounded `Vec<AsyncOperation>` with no automatic pruning.
- Prunes finished operations (`success`, `failed`, `cancelled`) before enqueueing new async RPCs.
- Rejects new async RPCs when 64 in-flight operations are already queued, matching Bitcoin Core's `DEFAULT_HTTP_WORKQUEUE` used by `zcashd`'s RPC layer.
- Checks the limit **before** spawning the background Tokio task, so rejected calls do not leak work.

## Vulnerability analysis

An authenticated JSON-RPC caller (HTTP basic auth) could call `z_sendmany` or `z_shieldcoinbase` repeatedly without calling `z_getoperationresult`. Each call appended an `AsyncOperation` retaining full RPC parameters (`ContextInfo.params` as `JsonValue`) until explicitly removed. There was no maximum size, expiration, or background cleanup — enabling linear memory growth until OOM.