### PR TITLE
book: Document that z_setmigration is not implemented

### DIFF
--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -159,5 +159,12 @@ methods have been updated to replace them.
 | `z_getmigrationstatus` |
 | `z_getnewaddress`      | `z_getnewaccount`, `z_getaddressforaccount` |
 | `z_listaddresses`      | `listaddresses` |
+| `z_setmigration`       |
+
+The `z_getmigrationstatus` and `z_setmigration` methods configured and reported
+on the automatic Sprout-to-Sapling fund migration. Zallet does not support
+Sprout, so there is nothing to migrate and no equivalent method is provided. If
+you still hold Sprout funds, migrate them out of the Sprout pool before
+transitioning your wallet to Zallet.
 
 [pczts]: https://github.com/zcash/wallet/issues/99


### PR DESCRIPTION
## Issue

Closes #331

## Motivation

A user migrating from `zcashd` may reach for `z_setmigration` (which controlled
the automatic Sprout-to-Sapling fund migration) and be confused when it is
absent from Zallet. There was no documentation explaining why it is gone or what
to do instead.

## Solution

Zallet does not support Sprout, so there is no migration to configure and no
equivalent RPC is provided. This adds `z_setmigration` to the "Omitted RPC
methods" table in `book/src/zcashd/json_rpc.md` (alongside the existing
`z_getmigrationstatus` entry) and a short note explaining that any remaining
Sprout funds must be migrated out before transitioning to Zallet. The framing
mirrors the existing `migrate-warn-sprout-migration` message used by
`zallet migrate-zcash-conf`.

## Test evidence

Documentation-only change (single Markdown file); no code paths affected.
