### PR TITLE
deps: update Zaino pin to zingolabs/zaino#1238

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ be considered breaking changes.
 
 ### Changed
 
-- Updated the Zaino chain indexer to a pre-release `dev`-branch build
-  (zingolabs/zaino#1200) that retains NU 6.2 support and adds optional
+- Updated the Zaino chain indexer to a pre-release `rc-0.4.0` build
+  (zingolabs/zaino#1238) that retains NU 6.2 support and adds optional
   ("ephemeral") finalised state. The embedded indexer now runs in ephemeral
   mode, serving finalised chain data directly from the validator instead of
   maintaining a persistent finalised-state database.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "zaino-common"
 version = "0.1.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=021fbf32ea373a684c5dec9fff187c8e1c7004b0#021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+source = "git+https://github.com/zingolabs/zaino.git?rev=1f06894587914c063f612b575e6b86296d62c0c4#1f06894587914c063f612b575e6b86296d62c0c4"
 dependencies = [
  "hex",
  "nu-ansi-term",
@@ -7180,8 +7180,8 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.1.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=021fbf32ea373a684c5dec9fff187c8e1c7004b0#021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+version = "0.2.0"
+source = "git+https://github.com/zingolabs/zaino.git?rev=1f06894587914c063f612b575e6b86296d62c0c4#1f06894587914c063f612b575e6b86296d62c0c4"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "zaino-proto"
 version = "0.1.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=021fbf32ea373a684c5dec9fff187c8e1c7004b0#021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+source = "git+https://github.com/zingolabs/zaino.git?rev=1f06894587914c063f612b575e6b86296d62c0c4#1f06894587914c063f612b575e6b86296d62c0c4"
 dependencies = [
  "prost",
  "tonic",
@@ -7222,8 +7222,8 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.2.0"
-source = "git+https://github.com/zingolabs/zaino.git?rev=021fbf32ea373a684c5dec9fff187c8e1c7004b0#021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+version = "0.3.0"
+source = "git+https://github.com/zingolabs/zaino.git?rev=1f06894587914c063f612b575e6b86296d62c0c4#1f06894587914c063f612b575e6b86296d62c0c4"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ secp256k1 = { version = "0.29", features = ["recovery"] }
 
 # Zcash chain state
 zaino-common = "0.1.1"
-zaino-fetch = "0.1"
-zaino-state = "0.2"
+zaino-fetch = "0.2"
+zaino-state = "0.3"
 zebra-rpc = "9.0"
 
 # Zcash wallet
@@ -172,11 +172,11 @@ age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633
 zewif = { git = "https://github.com/zcash/zewif.git", rev = "798d7b3554ebada05bea63b67ee66f9c2558a21a" }
 zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "22f8219bb2cb741b72683cbee170b6667c7da7b0" }
 
-# Pinned to the zingolabs/zaino#1200. Bump to the final `0.4.0` tag once it is
+# Pinned to the zingolabs/zaino#1238. Bump to the final `0.4.0` tag once it is
 # published. See https://github.com/zcash/wallet/issues/471.
-zaino-common = { git = "https://github.com/zingolabs/zaino.git", rev = "021fbf32ea373a684c5dec9fff187c8e1c7004b0" }
-zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "021fbf32ea373a684c5dec9fff187c8e1c7004b0" }
-zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "021fbf32ea373a684c5dec9fff187c8e1c7004b0" }
+zaino-common = { git = "https://github.com/zingolabs/zaino.git", rev = "1f06894587914c063f612b575e6b86296d62c0c4" }
+zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "1f06894587914c063f612b575e6b86296d62c0c4" }
+zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "1f06894587914c063f612b575e6b86296d62c0c4" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1897,19 +1897,19 @@ version = "3.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-common]]
-version = "0.1.1@git:021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+version = "0.1.1@git:1f06894587914c063f612b575e6b86296d62c0c4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-fetch]]
-version = "0.1.1@git:021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+version = "0.2.0@git:1f06894587914c063f612b575e6b86296d62c0c4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-proto]]
-version = "0.1.1@git:021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+version = "0.1.1@git:1f06894587914c063f612b575e6b86296d62c0c4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zaino-state]]
-version = "0.2.0@git:021fbf32ea373a684c5dec9fff187c8e1c7004b0"
+version = "0.3.0@git:1f06894587914c063f612b575e6b86296d62c0c4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_script]]

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -8,7 +8,7 @@ use tokio::net::lookup_host;
 use zaino_common::{CacheConfig, DatabaseConfig, StorageConfig};
 use zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector;
 use zaino_state::{
-    ChainIndex as _, ChainIndexConfig, ChainIndexSnapshot, NodeBackedChainIndex,
+    BlockCacheConfig, ChainIndex as _, ChainIndexSnapshot, NodeBackedChainIndex,
     NodeBackedChainIndexSubscriber, StatusType,
     chain_index::{
         ShieldedPool,
@@ -48,7 +48,7 @@ fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
 /// The Zaino finalised-state database schema version to target.
 ///
 /// `1` selects Zaino's latest v1 finalised-state schema. We run the indexer in ephemeral
-/// mode (see [`ChainIndexConfig::new`] below), so no persistent finalised-state database
+/// mode (see [`BlockCacheConfig::new`] below), so no persistent finalised-state database
 /// is actually opened and this value has no on-disk effect; it is set to the current
 /// schema version for forward-compatibility if ephemeral mode is ever disabled.
 const ZAINO_FINALISED_DB_VERSION: u32 = 1;
@@ -139,7 +139,7 @@ impl Chain {
         .await
         .map_err(|e| ErrorKind::Init.context(e))?;
 
-        let indexer_config = ChainIndexConfig::new(
+        let indexer_config = BlockCacheConfig::new(
             StorageConfig {
                 cache: CacheConfig::default(),
                 database: DatabaseConfig {
@@ -147,6 +147,9 @@ impl Chain {
                     // Unused in ephemeral mode (no persistent finalised-state
                     // database is opened).
                     size: zaino_common::DatabaseSize(0),
+                    // Unused in ephemeral mode (the finalised-state bulk-sync
+                    // write path is never exercised); inherit Zaino's default.
+                    ..Default::default()
                 },
             },
             ZAINO_FINALISED_DB_VERSION,


### PR DESCRIPTION
Bumps the temporary Zaino git pin from zingolabs/zaino#1200 to the latest commit on the rc-0.4.0 branch (zingolabs/zaino#1238), which speeds up finalised-state sync and the v1.1->v1.2 migration. This remains a temporary pin and should be moved to the `0.4.0` release tag once it is published (see zcash/wallet#471).

The pin bumped `zaino-fetch` to 0.2 and `zaino-state` to 0.3, so the workspace dependency requirements are updated to match. Adapts the embedded indexer setup to two upstream API changes:

- `ChainIndexConfig` was renamed to `BlockCacheConfig` (same constructor signature).
- `DatabaseConfig` gained a `sync_write_batch_bytes` field, which is unused in our ephemeral-mode configuration; inherit Zaino's default.

Closes COR-1360