### PR TITLE
sync: Ensure `initialize` leaves `block_metadata(tip)` populated

### DIFF
--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -38,7 +38,7 @@ use std::sync::{
 use std::time::Duration;
 
 use futures::{StreamExt as _, TryStreamExt as _};
-use jsonrpsee::tracing::{self, debug, info};
+use jsonrpsee::tracing::{self, debug, info, warn};
 use tokio::{sync::Notify, time};
 use zcash_client_backend::{
     data_api::{
@@ -223,7 +223,54 @@ async fn initialize(
             .next()
         {
             Some(r) => r,
-            None => break (current_tip, starting_boundary),
+            None => {
+                // The scan-range loop is about to exit without scanning the tip
+                // block — e.g. when the wallet has no shielded scan work and
+                // `suggest_scan_ranges` returns nothing in the bands the filter
+                // accepts. That would leave `block_metadata(chain_height)`
+                // unpopulated, which strands any caller asking the wallet for its
+                // view of the tip via `getwalletstatus.wallet_tip` (cf.
+                // integration-tests `rebuild_cache`).
+                //
+                // Best-effort: commit metadata for the tip block here, against the
+                // *same* `chain_view` snapshot we just read `current_tip` from so
+                // tree state and the block payload come from a single consistent
+                // chain view. If the indexer can't serve the block right now, log
+                // and continue — `steady_state` will populate metadata as soon as
+                // the index catches up. We skip at height 0 because `scan_block`
+                // would ask for `tree_state_as_of(height - 1)` and underflow on
+                // `BlockHeight`; there is also no useful work to do at genesis.
+                if current_tip.height > BlockHeight::from_u32(0)
+                    && db_data.block_metadata(current_tip.height)?.is_none()
+                {
+                    let attempt = async {
+                        let tip_block = chain_view
+                            .get_block(current_tip.height)
+                            .await
+                            .map_err(SyncError::Chain)?
+                            .ok_or_else(|| {
+                                SyncError::Chain(
+                                    ErrorKind::Sync
+                                        .context(format!(
+                                            "chain view did not return its own tip \
+                                             block at height {}",
+                                            current_tip.height
+                                        ))
+                                        .into(),
+                                )
+                            })?;
+                        steps::scan_block(&chain_view, db_data, params, tip_block, &decryptor).await
+                    };
+                    if let Err(e) = attempt.await {
+                        warn!(
+                            "Best-effort tip scan during initialize failed; \
+                             steady_state will populate metadata once the indexer \
+                             catches up: {e}"
+                        );
+                    }
+                }
+                break (current_tip, starting_boundary);
+            }
         };
 
         steps::scan_blocks(chain_view, db_data, params, &scan_range, &decryptor).await?;


### PR DESCRIPTION
## Bug

`getwalletstatus.wallet_tip` derives from `block_metadata(chain_height)`. For trivially-synced wallets (no shielded scan work — e.g. transparent miner accounts on regtest), `initialize()` set `chain_height` but never routed the tip through `put_blocks`, so `block_metadata` stayed `None` forever. `integration-tests` `rebuild_cache` then spun in a `while True:` wait-for-`wallet_tip` loop with no timeout — GitHub Actions cancelled at 6h. Surfaced by #476's ChainIndex migration (the old `subscribe()` path used to trigger `put_blocks` as a side effect).

## Fix

In [`zallet/src/components/sync.rs`](zallet/src/components/sync.rs)'s `initialize()`: when the scan-range loop is about to exit without scanning the tip block (`block_metadata(chain_height)` still `None`), commit metadata for the tip block before returning. New invariant: `initialize` always leaves `block_metadata(chain_height)` populated when the chain is non-empty.

Design notes:
- **Single consistent snapshot.** The tip scan reuses the same `chain_view` snapshot that just produced `current_tip`, so the block payload and `tree_state_as_of(height - 1)` are guaranteed to come from one consistent view (no TOCTOU between two snapshots).
- **Best-effort.** If the indexer can't serve the tip block right now (transient zebrad/zaino outage), we log a warning and let `steady_state` populate metadata when the indexer catches up — same recoverability as before this PR.
- **Height-0 skip.** At chain height 0 (regtest cold start before any block is mined, or a startup race where the indexer hasn't observed the first mined block yet), `scan_block` would ask for `tree_state_as_of(height - 1)` and underflow on `BlockHeight`. There's also no useful work to do at genesis.
- **Performance.** For wallets with shielded scan work: one DB query that returns `Some`, fall through with no extra work. For trivially-synced wallets: one block through `scan_block` — but a block with no notes belonging to this wallet completes decryption immediately.

## Proper fix

The deeper issue is in `zcash_client_backend`'s trait: there's no symmetric `chain_tip() -> Option<(BlockHeight, BlockHash)>` reader to pair with `chain_height()`. Adding one — plus a hash-aware `update_chain_tip_with_hash` — would close the gap properly and make this PR unnecessary. Additive (default impls), non-breaking. Draft is ready; happy to open if maintainers prefer that direction.

## CI blocker

Integration-tests CI for this PR is currently inconclusive — not because of the fix, but because of three unrelated upstream issues:

1. **`zaino:dev`'s `Cargo.lock`** pins `time = "0.3.48"` × `cookie = "0.18.1"`, which now conflicts at compile time. Kills `Build zainod (required)` on every recent dispatch including #482, #483, #484. One-line fix in [`zingolabs/zaino`](https://github.com/zingolabs/zaino).
2. **`zebrad` P2P doesn't converge** after `rebuild_cache`'s stop/restart-every-node dance — the 8 nodes end up at different heights (177/198/199/200) and never agree. Same root cause as the `sync_blocks` AssertionError that appeared on shard-1's first re-run. Existing fragility in [`integration-tests/util.py`](https://github.com/zcash/integration-tests/blob/main/qa/rpc-tests/test_framework/util.py) (cf. ZcashFoundation/zebra#10329, #10332).
3. **`zcashd_key_import_db.py` missing exec bit** — covered by [integration-tests#134](https://github.com/zcash/integration-tests/pull/134).

None of these are in #483's scope.

## Local verification

Ran the exact CI shard-0 invocation locally (`wallet.py` + `getmininginfo.py`, `jobs=2`, clean cache) against this PR's HEAD + `zaino@1f06894` (the commit #482 pins, which sidesteps the `time 0.3.48` break). Queried all 8 zallets mid-`rebuild_cache`:

```
wallet0..7: every wallet_tip populated, every wallet_tip == node_tip
```

The original failure mode is gone. `rebuild_cache` still stalls — but on the zebrad P2P non-convergence above (the 8 nodes sit at 177/198/199/200/200/200/199/199), not on `wallet_tip = None`.
