### PR TITLE
db: Mark 0.1.0-alpha.4 as breaking for the Zaino DB format change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ be considered breaking changes.
 
 ### Changed
 
+- **This release is not compatible with wallets created by earlier alpha
+  releases.** The embedded Zaino chain indexer made a backwards-incompatible
+  change to its database format (zingolabs/zaino#914), which this release pulls
+  in. Zallet now refuses to open wallet databases last used by `0.1.0-alpha.3`
+  or earlier; start again with a fresh Zallet wallet or a new data directory.
 - Updated the Zaino chain indexer to a pre-release `rc-0.4.0` build
   (zingolabs/zaino#1238) that retains NU 6.2 support and adds optional
   ("ephemeral") finalised state. The embedded indexer now runs in ephemeral

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,7 +7272,7 @@ dependencies = [
 
 [[package]]
 name = "zallet"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",

--- a/book/src/cli/init-wallet-encryption.md
+++ b/book/src/cli/init-wallet-encryption.md
@@ -8,7 +8,7 @@ When run, Zallet will use the [age encryption] identity stored in a wallet's dat
 initialize the wallet's encryption keys. The encryption identity file name (or path) can
 be set with the `keystore.encryption_identity` [config option].
 
-> WARNING: As of the latest Zallet alpha release (0.1.0-alpha.3), `zallet` requires the
+> WARNING: As of the latest Zallet alpha release (0.1.0-alpha.4), `zallet` requires the
 > encryption identity file to already exist. You can generate one with [`rage`].
 
 ## Identity kinds

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zallet"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/zallet/src/components/database.rs
+++ b/zallet/src/components/database.rs
@@ -30,7 +30,12 @@ pub(crate) type DbHandle = deadpool::managed::Object<connection::WalletManager>;
 
 // Old databases are accepted only if the last recorded Zallet version is at
 // least the oldest release whose wallet database this binary accepts.
-const MIN_COMPATIBLE_ZALLET_VERSION: &str = "0.1.0-alpha.3";
+//
+// Bumped to 0.1.0-alpha.4 because the embedded Zaino chain indexer made a
+// backwards-incompatible change to its database format (zingolabs/zaino#914),
+// pulled in by this release. Wallet databases last touched by 0.1.0-alpha.3 or
+// earlier must be recreated from scratch. See zcash/wallet#394.
+const MIN_COMPATIBLE_ZALLET_VERSION: &str = "0.1.0-alpha.4";
 
 /// Returns the full list of migrations defined in Zallet, to be applied alongside the
 /// migrations internal to `zcash_client_sqlite`.

--- a/zallet/src/components/database/tests.rs
+++ b/zallet/src/components/database/tests.rs
@@ -107,10 +107,34 @@ fn legacy_alpha_2_database_is_rejected_before_recording_current_version() {
 }
 
 #[test]
-fn legacy_alpha_3_database_is_allowed() {
+fn legacy_alpha_3_database_is_rejected_before_recording_current_version() {
     let datadir = tempdir().unwrap();
     let config = test_config(datadir.path(), NetworkType::Test);
     create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.3"]);
+
+    let err = open_database(&config).expect_err("legacy alpha.3 database must be rejected");
+    assert!(
+        err.to_string().contains("fresh Zallet wallet"),
+        "unexpected error: {err}",
+    );
+
+    let conn = Connection::open(config.wallet_db_path()).unwrap();
+    assert_eq!(
+        latest_recorded_version(&conn),
+        Some("0.1.0-alpha.3".to_string())
+    );
+    assert_eq!(
+        count_recorded_versions(&conn, crate::build::PKG_VERSION),
+        0,
+        "the current Zallet version should not be recorded after rejecting the database",
+    );
+}
+
+#[test]
+fn latest_alpha_4_database_is_allowed() {
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.4"]);
 
     open_database(&config).unwrap();
 
@@ -125,16 +149,16 @@ fn legacy_alpha_3_database_is_allowed() {
 fn compatibility_check_uses_latest_recorded_version() {
     let datadir = tempdir().unwrap();
     let config = test_config(datadir.path(), NetworkType::Test);
-    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.2", "0.1.0-alpha.3"]);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.3", "0.1.0-alpha.4"]);
 
     open_database(&config).unwrap();
 }
 
 #[test]
-fn latest_alpha_2_version_is_rejected_even_with_earlier_alpha_3_version() {
+fn latest_alpha_2_version_is_rejected_even_with_earlier_alpha_4_version() {
     let datadir = tempdir().unwrap();
     let config = test_config(datadir.path(), NetworkType::Test);
-    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.3", "0.1.0-alpha.2"]);
+    create_wallet_db(config.wallet_db_path(), &["0.1.0-alpha.4", "0.1.0-alpha.2"]);
 
     let err = open_database(&config).expect_err("latest alpha.2 database must be rejected");
     assert!(
@@ -182,7 +206,7 @@ fn network_mismatch_still_reports_network_error() {
     create_wallet_db_for_network(
         config.wallet_db_path(),
         Network::Consensus(consensus::Network::MainNetwork),
-        &["0.1.0-alpha.3"],
+        &["0.1.0-alpha.4"],
     );
 
     let err = open_database(&config).expect_err("network mismatch must be rejected");

--- a/zallet/tests/cmd/example_config.out/zallet.toml
+++ b/zallet/tests/cmd/example_config.out/zallet.toml
@@ -135,7 +135,7 @@ network = "main"
 # features. If this version is not compatible with `zallet --version`, most Zallet
 # commands will error and print out information about how to upgrade your wallet,
 # along with any changes you need to make to your usage of Zallet.
-as_of_version = "0.1.0-alpha.3"
+as_of_version = "0.1.0-alpha.4"
 
 # Enable "legacy `zcashd` pool of funds" semantics for the given seed.
 #

--- a/zallet/tests/cmd/migrate_zcash_conf_mainnet.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_mainnet.toml
@@ -15,7 +15,7 @@ network = "main"
 [external]
 
 [features]
-as_of_version = "0.1.0-alpha.3"
+as_of_version = "0.1.0-alpha.4"
 
 [features.deprecated]
 

--- a/zallet/tests/cmd/migrate_zcash_conf_regtest.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_regtest.toml
@@ -23,7 +23,7 @@ regtest_nuparams = [
 [external]
 
 [features]
-as_of_version = "0.1.0-alpha.3"
+as_of_version = "0.1.0-alpha.4"
 
 [features.deprecated]
 

--- a/zallet/tests/cmd/migrate_zcash_conf_testnet.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_testnet.toml
@@ -15,7 +15,7 @@ network = "test"
 [external]
 
 [features]
-as_of_version = "0.1.0-alpha.3"
+as_of_version = "0.1.0-alpha.4"
 
 [features.deprecated]
 


### PR DESCRIPTION
zingolabs/zaino#914 made a backwards-incompatible change to the embedded chain indexer's database format, which is pulled in by the current Zaino pin. Mark 0.1.0-alpha.4 as a breaking release by raising the minimum compatible wallet database version to 0.1.0-alpha.4, so Zallet refuses to open wallet databases last touched by 0.1.0-alpha.3 or earlier instead of attempting to reuse incompatible state.

The crate version is bumped to 0.1.0-alpha.4 in the same change so that the version recorded on each open stays >= the compatibility cutoff; otherwise the running binary would reject databases it had just created.

Closes zcash/wallet#394.