### PR TITLE
chain: abstract the chain-data backend behind Chain/ChainView traits

### DIFF
--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -132,7 +132,7 @@ sha2.workspace = true
 shadow-rs.workspace = true
 shardtree.workspace = true
 time.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "io-std", "io-util", "rt-multi-thread"] }
 toml.workspace = true
 tonic.workspace = true
 tower = { workspace = true, features = ["timeout"] }

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -113,6 +113,7 @@ migrate-wallet-legacy-seed-fp =
 
 err-kind-generic = Error
 err-kind-init = Failed to initialize {-zallet}
+err-kind-chain = An error occurred while accessing chain data.
 err-kind-sync = Failed to synchronize {-zallet}
 
 err-init-cannot-find-home-dir =

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -32,7 +32,7 @@ use zip32::{AccountId, fingerprint::SeedFingerprint};
 
 use crate::{
     cli::MigrateZcashdWalletCmd,
-    components::{chain::Chain, database::Database, keystore::KeyStore},
+    components::{chain::ZainoChain, database::Database, keystore::KeyStore},
     error::{Error, ErrorKind},
     fl,
     prelude::*,
@@ -63,7 +63,7 @@ impl AsyncRunnable for MigrateZcashdWalletCmd {
         let (chain, _chain_indexer_task_handle) = if self.no_scan {
             (None, None)
         } else {
-            let (c, h) = Chain::new(&config).await?;
+            let (c, h) = ZainoChain::new(&config).await?;
             (Some(c), Some(h))
         };
         let db = Database::open(&config).await?;
@@ -176,7 +176,7 @@ impl MigrateZcashdWalletCmd {
     async fn migrate_zcashd_wallet(
         db: Database,
         keystore: KeyStore,
-        chain: Option<Chain>,
+        chain: Option<ZainoChain>,
         wallet: ZcashdWallet,
         buffer_wallet_transactions: bool,
         allow_multiple_wallet_imports: bool,

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -33,7 +33,7 @@ use zip32::{AccountId, fingerprint::SeedFingerprint};
 use crate::{
     cli::MigrateZcashdWalletCmd,
     components::{
-        chain::{ChainError, ZainoChain},
+        chain::{Chain, ChainError, ChainView, ZainoChain},
         database::Database,
         keystore::KeyStore,
     },

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -32,7 +32,11 @@ use zip32::{AccountId, fingerprint::SeedFingerprint};
 
 use crate::{
     cli::MigrateZcashdWalletCmd,
-    components::{chain::ZainoChain, database::Database, keystore::KeyStore},
+    components::{
+        chain::{ChainError, ZainoChain},
+        database::Database,
+        keystore::KeyStore,
+    },
     error::{Error, ErrorKind},
     fl,
     prelude::*,
@@ -1126,6 +1130,12 @@ impl From<Error> for MigrateError {
 
 impl From<abscissa_core::error::Context<ErrorKind>> for MigrateError {
     fn from(value: abscissa_core::error::Context<ErrorKind>) -> Self {
+        MigrateError::Wrapped(value.into())
+    }
+}
+
+impl From<ChainError> for MigrateError {
+    fn from(value: ChainError) -> Self {
         MigrateError::Wrapped(value.into())
     }
 }

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -177,10 +177,10 @@ impl MigrateZcashdWalletCmd {
             .transpose()
     }
 
-    async fn migrate_zcashd_wallet(
+    async fn migrate_zcashd_wallet<C: Chain>(
         db: Database,
         keystore: KeyStore,
-        chain: Option<ZainoChain>,
+        chain: Option<C>,
         wallet: ZcashdWallet,
         buffer_wallet_transactions: bool,
         allow_multiple_wallet_imports: bool,

--- a/zallet/src/commands/start.rs
+++ b/zallet/src/commands/start.rs
@@ -6,7 +6,7 @@ use tokio::{pin, select};
 use crate::{
     cli::StartCmd,
     commands::AsyncRunnable,
-    components::{chain::Chain, database::Database, json_rpc::JsonRpc, sync::WalletSync},
+    components::{chain::ZainoChain, database::Database, json_rpc::JsonRpc, sync::WalletSync},
     config::ZalletConfig,
     error::Error,
     fl,
@@ -48,7 +48,7 @@ impl AsyncRunnable for StartCmd {
         let keystore = KeyStore::new(&config, db.clone())?;
 
         // Start monitoring the chain.
-        let (chain, chain_indexer_task_handle) = Chain::new(&config).await?;
+        let (chain, chain_indexer_task_handle) = ZainoChain::new(&config).await?;
 
         // Launch RPC server.
         let rpc_task_handle = JsonRpc::spawn(

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -1,636 +1,220 @@
-use std::fmt;
+//! The wallet's view of the Zcash chain.
+//!
+//! [`Chain`] and [`ChainView`] are the backend-neutral interface the rest of the wallet
+//! uses to read chain data. The Zaino-backed implementation lives in [`zaino`].
+
 use std::ops::Range;
 
-use futures::StreamExt;
-use incrementalmerkletree::frontier::CommitmentTree;
-use jsonrpsee::tracing::{error, info, warn};
-use tokio::net::lookup_host;
-use zaino_common::{CacheConfig, DatabaseConfig, StorageConfig};
-use zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector;
-use zaino_state::{
-    BlockCacheConfig, ChainIndex as _, ChainIndexSnapshot, NodeBackedChainIndex,
-    NodeBackedChainIndexSubscriber, StatusType,
-    chain_index::{
-        ShieldedPool,
-        source::ValidatorConnector,
-        types::{BestChainLocation, NonBestChainLocation},
-    },
-};
+use futures::stream::BoxStream;
 use zcash_client_backend::data_api::{
     TransactionStatus,
     chain::{ChainState, CommitmentTreeRoot},
 };
 use zcash_primitives::{
     block::{Block, BlockHash, BlockHeader},
-    merkle_tree::read_commitment_tree,
     transaction::Transaction,
 };
-use zcash_protocol::{
-    TxId,
-    consensus::{self, BlockHeight},
-};
-
-use crate::{
-    config::ZalletConfig,
-    error::{Error, ErrorKind},
-    network::Network,
-};
-
-use super::TaskHandle;
+use zcash_protocol::{TxId, consensus::BlockHeight};
 
 mod error;
 pub(crate) use error::ChainError;
 
-/// Converts a `zcash_protocol` block height into a Zaino block height.
-fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
-    u32::from(height)
-        .try_into()
-        .expect("we won't hit max height for a while")
-}
+mod zaino;
+pub(crate) use zaino::{ZainoChain, ZainoChainView};
 
-/// The Zaino finalised-state database schema version to target.
+/// A handle to a source of Zcash chain data.
 ///
-/// `1` selects Zaino's latest v1 finalised-state schema. We run the indexer in ephemeral
-/// mode (see [`BlockCacheConfig::new`] below), so no persistent finalised-state database
-/// is actually opened and this value has no on-disk effect; it is set to the current
-/// schema version for forward-compatibility if ephemeral mode is ever disabled.
-const ZAINO_FINALISED_DB_VERSION: u32 = 1;
+/// Cheap to clone; clones share the underlying source.
+pub(crate) trait Chain: Clone + Send + Sync + 'static {
+    /// A consistent, reorg-immune view of the chain captured by [`Chain::snapshot`].
+    type View: ChainView;
 
-#[derive(Clone)]
-pub(crate) struct ZainoChain {
-    subscriber: NodeBackedChainIndexSubscriber,
-    /// Used for submitting transactions to the network (`ChainIndex` is a read-only view
-    /// of the chain).
-    fetcher: JsonRpSeeConnector,
-    params: Network,
-}
+    /// Broadcasts a transaction to the network's mempool.
+    async fn broadcast_transaction(&self, tx: &Transaction) -> Result<(), ChainError>;
 
-impl fmt::Debug for ZainoChain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ZainoChain").finish_non_exhaustive()
-    }
-}
-
-impl ZainoChain {
-    pub(crate) async fn new(config: &ZalletConfig) -> Result<(Self, TaskHandle), Error> {
-        let params = config.consensus.network();
-
-        let resolved_validator_address = match config.indexer.validator_address.as_deref() {
-            Some(addr_str) => match lookup_host(addr_str).await {
-                Ok(mut addrs) => match addrs.next() {
-                    Some(socket_addr) => {
-                        info!(
-                            "Resolved validator_address '{}' to {}",
-                            addr_str, socket_addr
-                        );
-                        Ok(socket_addr)
-                    }
-                    None => {
-                        error!(
-                            "validator_address '{}' resolved to no IP addresses",
-                            addr_str
-                        );
-                        Err(ErrorKind::Init.context(format!(
-                            "validator_address '{addr_str}' resolved to no IP addresses"
-                        )))
-                    }
-                },
-                Err(e) => {
-                    error!("Failed to resolve validator_address '{}': {}", addr_str, e);
-                    Err(ErrorKind::Init.context(format!(
-                        "Failed to resolve validator_address '{addr_str}': {e}"
-                    )))
-                }
-            },
-            None => {
-                // Default to localhost and standard port based on network
-                let default_port = match params {
-                    Network::Consensus(consensus::Network::MainNetwork) => 8232, // Mainnet default RPC port for Zebra/zcashd
-                    _ => 18232, // Testnet/Regtest default RPC port for Zebra/zcashd
-                };
-                let default_addr_str = format!("127.0.0.1:{default_port}");
-                info!(
-                    "validator_address not set, defaulting to {}",
-                    default_addr_str
-                );
-                match default_addr_str.parse::<std::net::SocketAddr>() {
-                    Ok(socket_addr) => Ok(socket_addr),
-                    Err(e) => {
-                        // This should ideally not happen with a hardcoded IP and port
-                        error!(
-                            "Failed to parse default validator_address '{}': {}",
-                            default_addr_str, e
-                        );
-                        Err(ErrorKind::Init.context(format!(
-                            "Failed to parse default validator_address '{default_addr_str}': {e}"
-                        )))
-                    }
-                }
-            }
-        }?;
-
-        let fetcher = JsonRpSeeConnector::new_from_config_parts(
-            &resolved_validator_address.to_string(),
-            config.indexer.validator_user.clone().unwrap_or_default(),
-            config
-                .indexer
-                .validator_password
-                .clone()
-                .unwrap_or_default(),
-            config.indexer.validator_cookie_path.clone(),
-        )
-        .await
-        .map_err(|e| ErrorKind::Init.context(e))?;
-
-        let indexer_config = BlockCacheConfig::new(
-            StorageConfig {
-                cache: CacheConfig::default(),
-                database: DatabaseConfig {
-                    path: config.indexer_db_path().to_path_buf(),
-                    // Unused in ephemeral mode (no persistent finalised-state
-                    // database is opened).
-                    size: zaino_common::DatabaseSize(0),
-                    // Unused in ephemeral mode (the finalised-state bulk-sync
-                    // write path is never exercised); inherit Zaino's default.
-                    ..Default::default()
-                },
-            },
-            ZAINO_FINALISED_DB_VERSION,
-            params.to_zaino(),
-            // Run the finalised state ephemerally: no persistent database, finalised
-            // reads are served from the backing validator.
-            true,
-        );
-
-        info!("Starting Zaino indexer");
-        let indexer =
-            NodeBackedChainIndex::new(ValidatorConnector::Fetch(fetcher.clone()), indexer_config)
-                .await
-                .map_err(|e| ErrorKind::Init.context(e))?;
-        info!("Started Zaino indexer");
-
-        let chain = Self {
-            subscriber: indexer.subscriber(),
-            fetcher,
-            params,
-        };
-
-        // Spawn a task that stops the indexer when appropriate internal signals occur.
-        let task = crate::spawn!("Indexer shutdown", async move {
-            let mut server_interval =
-                tokio::time::interval(tokio::time::Duration::from_millis(100));
-
-            loop {
-                server_interval.tick().await;
-
-                match indexer.status() {
-                    // Check for errors.
-                    StatusType::Offline | StatusType::CriticalError => {
-                        indexer
-                            .shutdown()
-                            .await
-                            .map_err(|e| ErrorKind::Generic.context(e))?;
-                        return Err(ErrorKind::Generic.into());
-                    }
-
-                    // Check for shutdown signals.
-                    StatusType::Closing => return Ok(()),
-
-                    _ => (),
-                }
-            }
-        });
-
-        Ok((chain, task))
-    }
-
-    /// Broadcasts a transaction to the mempool.
-    ///
-    /// Returns an error if the transaction failed to be submitted to a single node. No
-    /// broadcast guarantees are provided beyond this; transactions should be periodically
-    /// rebroadcast while they are unmined and unexpired.
-    pub(crate) async fn broadcast_transaction(&self, tx: &Transaction) -> Result<(), ChainError> {
-        let mut tx_bytes = vec![];
-        tx.write(&mut tx_bytes).map_err(ChainError::backend)?;
-
-        self.fetcher
-            .send_raw_transaction(hex::encode(&tx_bytes))
-            .await
-            .map_err(ChainError::backend)?;
-
-        Ok(())
-    }
-
-    /// Returns a stable view of the chain as of the current chain tip.
-    ///
-    /// The data viewable through the returned [`ZainoChainView`] is guaranteed to be available
-    /// as long as (any clone of) the returned instance is live, regardless of what new
-    /// blocks or reorgs are observed by the underlying chain indexer.
-    pub(crate) async fn snapshot(&self) -> Result<ZainoChainView, ChainError> {
-        let snapshot = self
-            .subscriber
-            .snapshot_nonfinalized_state()
-            .await
-            .map_err(ChainError::backend)?;
-
-        Ok(ZainoChainView {
-            chain: self.subscriber.clone(),
-            snapshot,
-            params: self.params,
-        })
-    }
-
-    pub(crate) async fn get_sapling_subtree_roots(
+    /// Returns the Sapling note commitment subtree roots, in index order.
+    async fn get_sapling_subtree_roots(
         &self,
-    ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError> {
-        self.subscriber
-            .get_subtree_roots(ShieldedPool::Sapling, 0, None)
-            .await
-            .map_err(ChainError::backend)?
-            .into_iter()
-            .map(|(root_hash, end_height)| {
-                Ok(CommitmentTreeRoot::from_parts(
-                    BlockHeight::from_u32(end_height),
-                    sapling::Node::from_bytes(root_hash)
-                        .expect("zaino should provide canonical encodings"),
-                ))
-            })
-            .collect::<Result<Vec<_>, ChainError>>()
-    }
+    ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError>;
 
-    pub(crate) async fn get_orchard_subtree_roots(
+    /// Returns the Orchard note commitment subtree roots, in index order.
+    async fn get_orchard_subtree_roots(
         &self,
-    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
-        self.subscriber
-            .get_subtree_roots(ShieldedPool::Orchard, 0, None)
-            .await
-            .map_err(ChainError::backend)?
-            .into_iter()
-            .map(|(root_hash, end_height)| {
-                Ok(CommitmentTreeRoot::from_parts(
-                    BlockHeight::from_u32(end_height),
-                    orchard::tree::MerkleHashOrchard::from_bytes(&root_hash)
-                        .expect("zaino should provide canonical encodings"),
-                ))
-            })
-            .collect::<Result<Vec<_>, ChainError>>()
-    }
+    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError>;
+
+    /// Captures a consistent view of the chain as of the current tip.
+    ///
+    /// Every read through the returned [`ChainView`] reflects one fixed chain history for
+    /// the lifetime of the view, regardless of reorgs or new blocks observed afterward.
+    async fn snapshot(&self) -> Result<Self::View, ChainError>;
 }
 
-/// A stable view of the chain as of a particular chain tip.
+/// A consistent, reorg-immune view of the chain as of a fixed tip.
 ///
-/// The data viewable through an instance of `ZainoChainView` is guaranteed to be available
-/// as long as (any clone of) the instance is live, regardless of what new blocks or
-/// reorgs are observed by the underlying chain indexer.
-#[derive(Clone)]
-pub(crate) struct ZainoChainView {
-    chain: NodeBackedChainIndexSubscriber,
-    snapshot: ChainIndexSnapshot,
-    params: Network,
-}
+/// A sequence of reads through one `ChainView` is mutually consistent.
+pub(crate) trait ChainView: Clone + Send + Sync + 'static {
+    /// Returns this view's chain tip.
+    async fn tip(&self) -> Result<ChainBlock, ChainError>;
 
-impl ZainoChainView {
-    /// Returns the current chain tip.
-    pub(crate) async fn tip(&self) -> Result<ChainBlock, ChainError> {
-        let best_tip = self
-            .chain
-            .best_chaintip(&self.snapshot)
-            .await
-            .map_err(ChainError::backend)?;
-
-        Ok(ChainBlock::from_zaino((best_tip.hash, best_tip.height)))
-    }
-
-    /// Returns the height of the given block, if it is in the main chain within this
-    /// chain view.
-    #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
-    pub(crate) async fn block_height(
+    /// Returns the most recent ancestor of the caller's chain (identified by `known_tip`)
+    /// that lies on this view's best chain, or `None` if it cannot be located.
+    async fn find_fork_point(
         &self,
-        hash: &BlockHash,
-    ) -> Result<Option<BlockHeight>, ChainError> {
-        Ok(self
-            .chain
-            .get_block_height(&self.snapshot, zaino_state::BlockHash(hash.0))
-            .await
-            .map_err(ChainError::backend)?
-            .map(|height| BlockHeight::from_u32(height.into())))
-    }
+        known_tip: &BlockHash,
+    ) -> Result<Option<ChainBlock>, ChainError>;
 
-    /// Finds the most recent common ancestor of the given block within this chain view.
-    ///
-    /// Returns the given block itself if it is on the main chain.
-    pub(crate) async fn find_fork_point(
-        &self,
-        other: &BlockHash,
-    ) -> Result<Option<ChainBlock>, ChainError> {
-        Ok(self
-            .chain
-            .find_fork_point(&self.snapshot, &zaino_state::BlockHash(other.0))
-            .await
-            .map_err(ChainError::backend)?
-            .map(ChainBlock::from_zaino))
-    }
+    /// Returns the final note commitment tree state for each shielded pool as of `height`,
+    /// or `None` if `height` is above this view's tip.
+    async fn tree_state_as_of(&self, height: BlockHeight)
+    -> Result<Option<ChainState>, ChainError>;
 
-    /// Returns the final note commitment tree state for each shielded pool, as of the
-    /// given block height.
-    ///
-    /// Returns `None` if the height is greater than the chain tip for this chain view.
-    pub(crate) async fn tree_state_as_of(
+    /// Returns the block header at `height`, or `None` if above this view's tip.
+    async fn get_block_header(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<ChainState>, ChainError> {
-        let block_hash = self
-            .chain
-            .get_block_hash(&self.snapshot, to_zaino_height(height))
-            .await
-            .map_err(ChainError::backend)?;
+    ) -> Result<Option<BlockHeader>, ChainError>;
 
-        let chain_state = if let Some(hash) = block_hash {
-            let (sapling_treestate, orchard_treestate) = self
-                .chain
-                .get_treestate(&hash)
-                .await
-                .map_err(ChainError::backend)?;
+    /// Returns the block at `height`, or `None` if above this view's tip.
+    async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, ChainError>;
 
-            let final_sapling_tree = match sapling_treestate {
-                None => CommitmentTree::empty(),
-                Some(sapling_tree_bytes) => read_commitment_tree::<
-                    sapling::Node,
-                    _,
-                    { sapling::NOTE_COMMITMENT_TREE_DEPTH },
-                >(&sapling_tree_bytes[..])
-                .map_err(ChainError::backend)?,
-            }
-            .to_frontier();
+    /// Streams blocks from `start` to this view's tip, inclusive.
+    fn stream_blocks_to_tip(&self, start: BlockHeight) -> BoxStream<'_, Result<Block, ChainError>>;
 
-            let final_orchard_tree = match orchard_treestate {
-                None => CommitmentTree::empty(),
-                Some(orchard_tree_bytes) => read_commitment_tree::<
-                    orchard::tree::MerkleHashOrchard,
-                    _,
-                    { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-                >(&orchard_tree_bytes[..])
-                .map_err(ChainError::backend)?,
-            }
-            .to_frontier();
+    /// Streams blocks over `range`.
+    fn stream_blocks(&self, range: &Range<BlockHeight>)
+    -> BoxStream<'_, Result<Block, ChainError>>;
 
-            Some(ChainState::new(
-                height,
-                BlockHash(hash.0),
-                final_sapling_tree,
-                final_orchard_tree,
-            ))
-        } else {
-            None
-        };
-
-        Ok(chain_state)
-    }
-
-    /// Returns the block header at the given height, or `None` if the height is above
-    /// this view's chain tip.
-    pub(crate) async fn get_block_header(
-        &self,
-        height: BlockHeight,
-    ) -> Result<Option<BlockHeader>, ChainError> {
-        self.get_block_inner(height, |block_bytes| {
-            // Read the header, ignore the transactions.
-            BlockHeader::read(block_bytes.as_slice()).map_err(ChainError::backend)
-        })
-        .await
-    }
-
-    /// Returns the block at the given height, or `None` if the height is above this
-    /// view's chain tip.
-    pub(crate) async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, ChainError> {
-        self.get_block_inner(height, |block_bytes| {
-            Block::read(block_bytes.as_slice(), &self.params).map_err(ChainError::backend)
-        })
-        .await
-    }
-
-    async fn get_block_inner<T>(
-        &self,
-        height: BlockHeight,
-        f: impl FnOnce(Vec<u8>) -> Result<T, ChainError>,
-    ) -> Result<Option<T>, ChainError> {
-        let height = to_zaino_height(height);
-        // TODO: Should return `impl futures::TryStream` if it is to be fallible.
-        if let Some(stream) = self
-            .chain
-            .get_block_range(&self.snapshot, height, Some(height))
-        {
-            tokio::pin!(stream);
-            let block_bytes = match stream.next().await {
-                None => return Ok(None),
-                Some(ret) => ret.map_err(ChainError::backend),
-            }?;
-
-            f(block_bytes).map(Some)
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Produces a contiguous stream of blocks from the given start height to this view's
-    /// chain tip, inclusive.
+    /// Streams the current mempool. The stream ends when this view's tip changes.
     ///
-    /// Returns an empty stream if `start` is greater than this view's chain tip.
-    pub(crate) fn stream_blocks_to_tip(
-        &self,
-        start: BlockHeight,
-    ) -> impl futures::Stream<Item = Result<Block, ChainError>> {
-        self.stream_blocks_inner(start, None)
-    }
-
-    /// Produces a contiguous stream of blocks over the given range.
-    ///
-    /// Returns an empty stream if `range` includes block heights greater than this view's
-    /// chain tip.
-    pub(crate) fn stream_blocks(
-        &self,
-        range: &Range<BlockHeight>,
-    ) -> impl futures::Stream<Item = Result<Block, ChainError>> {
-        self.stream_blocks_inner(range.start, Some(range.end - 1))
-    }
-
-    /// Produces a contiguous stream of blocks from `start` to `end` inclusive.
-    fn stream_blocks_inner(
-        &self,
-        start: BlockHeight,
-        end: Option<BlockHeight>,
-    ) -> impl futures::Stream<Item = Result<Block, ChainError>> {
-        // TODO: Should return `impl futures::TryStream` if it is to be fallible.
-        if let Some(stream) = self.chain.get_block_range(
-            &self.snapshot,
-            to_zaino_height(start),
-            end.map(to_zaino_height),
-        ) {
-            stream
-                .map(|res| {
-                    res.map_err(ChainError::backend).and_then(|block_bytes| {
-                        Block::read(block_bytes.as_slice(), &self.params)
-                            .map_err(ChainError::invalid_data)
-                    })
-                })
-                .boxed()
-        } else {
-            futures::stream::empty().boxed()
-        }
-    }
-
-    /// Returns a stream of the current transactions within the mempool.
-    ///
-    /// The stream ends when the chain tip block hash changes, signalling that either a
-    /// new block has been mined or a reorg has occurred.
-    ///
-    /// Returns `None` if the chain tip has changed since this view was captured.
-    pub(crate) async fn get_mempool_stream(
-        &self,
-    ) -> Result<Option<impl futures::Stream<Item = Transaction>>, ChainError> {
-        let mempool_height = self.tip().await?.height + 1;
-        let consensus_branch_id = consensus::BranchId::for_height(&self.params, mempool_height);
-
-        Ok(self
-            .chain
-            .get_mempool_stream(Some(&self.snapshot))
-            .map(move |stream| {
-                stream.filter_map(move |result| async move {
-                    result
-                        .inspect_err(|e| warn!("Error receiving transaction: {e}"))
-                        .ok()
-                        .and_then(|raw_tx| {
-                            Transaction::read(raw_tx.as_slice(), consensus_branch_id)
-                                .inspect_err(|e| {
-                                    warn!("Received invalid transaction from mempool: {e}");
-                                })
-                                .ok()
-                        })
-                })
-            }))
-    }
+    /// Returns `None` if the tip has already changed since the view was captured.
+    async fn get_mempool_stream(&self) -> Result<Option<BoxStream<'_, Transaction>>, ChainError>;
 
     /// Returns the transaction with the given txid, if known.
-    pub(crate) async fn get_transaction(&self, txid: TxId) -> Result<Option<ChainTx>, ChainError> {
-        let zaino_txid = zaino_state::TransactionHash::from(*txid.as_ref());
-
-        let (inner, raw) = match self
-            .chain
-            .get_raw_transaction(&self.snapshot, &zaino_txid)
-            .await
-            .map_err(ChainError::backend)?
-        {
-            None => return Ok(None),
-            Some((raw_tx, branch_id)) => {
-                let consensus_branch_id = match branch_id {
-                    // If `try_from` fails, it indicates a dependency versioning problem.
-                    Some(id) => consensus::BranchId::try_from(id).map_err(ChainError::backend)?,
-                    // Zaino could not determine the consensus branch ID. This happens for
-                    // mempool transactions (when the snapshot's mempool height is unknown)
-                    // and for pre-Overwinter transactions (which predate consensus branch
-                    // IDs). A transaction cannot be mined across a network upgrade
-                    // boundary, and an unmined transaction must be minable at the current
-                    // chain tip, so the branch ID at the mempool height (tip + 1) is the
-                    // correct parsing target. This matches the fallback used by
-                    // `get_mempool_stream`.
-                    None => {
-                        let mempool_height = self.tip().await?.height + 1;
-                        consensus::BranchId::for_height(&self.params, mempool_height)
-                    }
-                };
-
-                let tx = Transaction::read(raw_tx.as_slice(), consensus_branch_id)
-                    .map_err(ChainError::backend)?;
-
-                (tx, raw_tx)
-            }
-        };
-
-        let (block_hash, mined_height, in_best_chain) = match self
-            .chain
-            .get_transaction_status(&self.snapshot, &zaino_txid)
-            .await
-            .map_err(ChainError::backend)?
-        {
-            (Some(BestChainLocation::Block(hash, height)), _) => (
-                Some(BlockHash(hash.0)),
-                Some(BlockHeight::from_u32(height.into())),
-                true,
-            ),
-            (Some(BestChainLocation::Mempool(_)), _) => (None, None, false),
-            (None, orphans) => match orphans.into_iter().next() {
-                Some(NonBestChainLocation::Block(hash, height)) => (
-                    Some(BlockHash(hash.0)),
-                    Some(BlockHeight::from_u32(height.into())),
-                    false,
-                ),
-                Some(NonBestChainLocation::Mempool(_)) | None => (None, None, false),
-            },
-        };
-
-        // Only populate the block time for transactions mined into the main chain. The
-        // time of an orphaned block is misleading (the transaction is not in the main
-        // chain) and can differ from the canonical block at the same height.
-        let block_time = match (in_best_chain, mined_height) {
-            (true, Some(height)) => self
-                .get_block_header(height)
-                .await?
-                .map(|header| header.time),
-            _ => None,
-        };
-
-        Ok(Some(ChainTx {
-            inner,
-            raw,
-            block_hash,
-            mined_height,
-            block_time,
-        }))
-    }
+    async fn get_transaction(&self, txid: TxId) -> Result<Option<ChainTx>, ChainError>;
 
     /// Returns the current status of the given transaction.
-    pub(crate) async fn get_transaction_status(
-        &self,
-        txid: TxId,
-    ) -> Result<TransactionStatus, ChainError> {
-        let zaino_txid = zaino_state::TransactionHash::from(*txid.as_ref());
+    async fn get_transaction_status(&self, txid: TxId) -> Result<TransactionStatus, ChainError>;
 
-        let status = self
-            .chain
-            .get_transaction_status(&self.snapshot, &zaino_txid)
-            .await
-            .map_err(ChainError::backend)?;
-
-        Ok(match status {
-            (Some(BestChainLocation::Block(_, height)), _) => {
-                TransactionStatus::Mined(BlockHeight::from_u32(height.into()))
-            }
-            (Some(BestChainLocation::Mempool(_)), _) => TransactionStatus::NotInMainChain,
-            (None, orphans) if orphans.is_empty() => TransactionStatus::TxidNotRecognized,
-            (None, _) => TransactionStatus::NotInMainChain,
-        })
-    }
+    /// Returns the height of the given block if it is on this view's main chain.
+    #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+    async fn block_height(&self, hash: &BlockHash) -> Result<Option<BlockHeight>, ChainError>;
 }
 
+/// A block's height and hash.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ChainBlock {
     pub(crate) height: BlockHeight,
     pub(crate) hash: BlockHash,
 }
 
-impl ChainBlock {
-    fn from_zaino((hash, height): (zaino_state::BlockHash, zaino_state::Height)) -> Self {
-        Self {
-            height: BlockHeight::from_u32(height.into()),
-            hash: BlockHash(hash.0),
-        }
-    }
-}
-
+/// A transaction together with the chain metadata the wallet needs to ingest it.
 pub(crate) struct ChainTx {
     pub(crate) inner: Transaction,
     pub(crate) raw: Vec<u8>,
     pub(crate) block_hash: Option<BlockHash>,
     pub(crate) mined_height: Option<BlockHeight>,
     pub(crate) block_time: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use futures::{
+        StreamExt as _,
+        stream::{self, BoxStream},
+    };
+    use zcash_client_backend::data_api::{TransactionStatus, chain::ChainState};
+    use zcash_primitives::{
+        block::{Block, BlockHash, BlockHeader},
+        transaction::Transaction,
+    };
+    use zcash_protocol::{TxId, consensus::BlockHeight};
+
+    use super::{ChainBlock, ChainError, ChainTx, ChainView};
+
+    /// A trivial in-memory [`ChainView`], proving the trait is implementable by a non-Zaino
+    /// backend and locking the contract.
+    #[derive(Clone)]
+    struct MockChainView {
+        tip: ChainBlock,
+    }
+
+    impl ChainView for MockChainView {
+        async fn tip(&self) -> Result<ChainBlock, ChainError> {
+            Ok(self.tip)
+        }
+
+        async fn find_fork_point(
+            &self,
+            _known_tip: &BlockHash,
+        ) -> Result<Option<ChainBlock>, ChainError> {
+            Ok(Some(self.tip))
+        }
+
+        async fn tree_state_as_of(
+            &self,
+            _height: BlockHeight,
+        ) -> Result<Option<ChainState>, ChainError> {
+            Ok(None)
+        }
+
+        async fn get_block_header(
+            &self,
+            _height: BlockHeight,
+        ) -> Result<Option<BlockHeader>, ChainError> {
+            Ok(None)
+        }
+
+        async fn get_block(&self, _height: BlockHeight) -> Result<Option<Block>, ChainError> {
+            Ok(None)
+        }
+
+        fn stream_blocks_to_tip(
+            &self,
+            _start: BlockHeight,
+        ) -> BoxStream<'_, Result<Block, ChainError>> {
+            stream::empty().boxed()
+        }
+
+        fn stream_blocks(
+            &self,
+            _range: &Range<BlockHeight>,
+        ) -> BoxStream<'_, Result<Block, ChainError>> {
+            stream::empty().boxed()
+        }
+
+        async fn get_mempool_stream(
+            &self,
+        ) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+            Ok(None)
+        }
+
+        async fn get_transaction(&self, _txid: TxId) -> Result<Option<ChainTx>, ChainError> {
+            Ok(None)
+        }
+
+        async fn get_transaction_status(
+            &self,
+            _txid: TxId,
+        ) -> Result<TransactionStatus, ChainError> {
+            Ok(TransactionStatus::TxidNotRecognized)
+        }
+
+        #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+        async fn block_height(&self, _hash: &BlockHash) -> Result<Option<BlockHeight>, ChainError> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_view_reports_its_tip() {
+        let tip = ChainBlock {
+            height: BlockHeight::from_u32(42),
+            hash: BlockHash([7u8; 32]),
+        };
+        let view = MockChainView { tip };
+        assert_eq!(view.tip().await.unwrap(), tip);
+        assert_eq!(view.find_fork_point(&tip.hash).await.unwrap(), Some(tip));
+    }
 }

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -21,7 +21,7 @@ mod error;
 pub(crate) use error::ChainError;
 
 mod zaino;
-pub(crate) use zaino::{ZainoChain, ZainoChainView};
+pub(crate) use zaino::ZainoChain;
 
 /// A handle to a source of Zcash chain data.
 ///

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -54,7 +54,7 @@ fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
 const ZAINO_FINALISED_DB_VERSION: u32 = 1;
 
 #[derive(Clone)]
-pub(crate) struct Chain {
+pub(crate) struct ZainoChain {
     subscriber: NodeBackedChainIndexSubscriber,
     /// Used for submitting transactions to the network (`ChainIndex` is a read-only view
     /// of the chain).
@@ -62,13 +62,13 @@ pub(crate) struct Chain {
     params: Network,
 }
 
-impl fmt::Debug for Chain {
+impl fmt::Debug for ZainoChain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Chain").finish_non_exhaustive()
+        f.debug_struct("ZainoChain").finish_non_exhaustive()
     }
 }
 
-impl Chain {
+impl ZainoChain {
     pub(crate) async fn new(config: &ZalletConfig) -> Result<(Self, TaskHandle), Error> {
         let params = config.consensus.network();
 
@@ -221,17 +221,17 @@ impl Chain {
 
     /// Returns a stable view of the chain as of the current chain tip.
     ///
-    /// The data viewable through the returned [`ChainView`] is guaranteed to be available
+    /// The data viewable through the returned [`ZainoChainView`] is guaranteed to be available
     /// as long as (any clone of) the returned instance is live, regardless of what new
     /// blocks or reorgs are observed by the underlying chain indexer.
-    pub(crate) async fn snapshot(&self) -> Result<ChainView, Error> {
+    pub(crate) async fn snapshot(&self) -> Result<ZainoChainView, Error> {
         let snapshot = self
             .subscriber
             .snapshot_nonfinalized_state()
             .await
             .map_err(|e| ErrorKind::Generic.context(e))?;
 
-        Ok(ChainView {
+        Ok(ZainoChainView {
             chain: self.subscriber.clone(),
             snapshot,
             params: self.params,
@@ -277,17 +277,17 @@ impl Chain {
 
 /// A stable view of the chain as of a particular chain tip.
 ///
-/// The data viewable through an instance of `ChainView` is guaranteed to be available
+/// The data viewable through an instance of `ZainoChainView` is guaranteed to be available
 /// as long as (any clone of) the instance is live, regardless of what new blocks or
 /// reorgs are observed by the underlying chain indexer.
 #[derive(Clone)]
-pub(crate) struct ChainView {
+pub(crate) struct ZainoChainView {
     chain: NodeBackedChainIndexSubscriber,
     snapshot: ChainIndexSnapshot,
     params: Network,
 }
 
-impl ChainView {
+impl ZainoChainView {
     /// Returns the current chain tip.
     pub(crate) async fn tip(&self) -> Result<ChainBlock, Error> {
         let best_tip = self

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -3,6 +3,7 @@
 //! [`Chain`] and [`ChainView`] are the backend-neutral interface the rest of the wallet
 //! uses to read chain data. The Zaino-backed implementation lives in [`zaino`].
 
+use std::future::Future;
 use std::ops::Range;
 
 use futures::stream::BoxStream;
@@ -30,23 +31,28 @@ pub(crate) trait Chain: Clone + Send + Sync + 'static {
     type View: ChainView;
 
     /// Broadcasts a transaction to the network's mempool.
-    async fn broadcast_transaction(&self, tx: &Transaction) -> Result<(), ChainError>;
+    fn broadcast_transaction(
+        &self,
+        tx: &Transaction,
+    ) -> impl Future<Output = Result<(), ChainError>> + Send;
 
     /// Returns the Sapling note commitment subtree roots, in index order.
-    async fn get_sapling_subtree_roots(
+    fn get_sapling_subtree_roots(
         &self,
-    ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError>;
+    ) -> impl Future<Output = Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError>> + Send;
 
     /// Returns the Orchard note commitment subtree roots, in index order.
-    async fn get_orchard_subtree_roots(
+    fn get_orchard_subtree_roots(
         &self,
-    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError>;
+    ) -> impl Future<
+        Output = Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError>,
+    > + Send;
 
     /// Captures a consistent view of the chain as of the current tip.
     ///
     /// Every read through the returned [`ChainView`] reflects one fixed chain history for
     /// the lifetime of the view, regardless of reorgs or new blocks observed afterward.
-    async fn snapshot(&self) -> Result<Self::View, ChainError>;
+    fn snapshot(&self) -> impl Future<Output = Result<Self::View, ChainError>> + Send;
 }
 
 /// A consistent, reorg-immune view of the chain as of a fixed tip.
@@ -54,28 +60,33 @@ pub(crate) trait Chain: Clone + Send + Sync + 'static {
 /// A sequence of reads through one `ChainView` is mutually consistent.
 pub(crate) trait ChainView: Clone + Send + Sync + 'static {
     /// Returns this view's chain tip.
-    async fn tip(&self) -> Result<ChainBlock, ChainError>;
+    fn tip(&self) -> impl Future<Output = Result<ChainBlock, ChainError>> + Send;
 
     /// Returns the most recent ancestor of the caller's chain (identified by `known_tip`)
     /// that lies on this view's best chain, or `None` if it cannot be located.
-    async fn find_fork_point(
+    fn find_fork_point(
         &self,
         known_tip: &BlockHash,
-    ) -> Result<Option<ChainBlock>, ChainError>;
+    ) -> impl Future<Output = Result<Option<ChainBlock>, ChainError>> + Send;
 
     /// Returns the final note commitment tree state for each shielded pool as of `height`,
     /// or `None` if `height` is above this view's tip.
-    async fn tree_state_as_of(&self, height: BlockHeight)
-    -> Result<Option<ChainState>, ChainError>;
-
-    /// Returns the block header at `height`, or `None` if above this view's tip.
-    async fn get_block_header(
+    fn tree_state_as_of(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<BlockHeader>, ChainError>;
+    ) -> impl Future<Output = Result<Option<ChainState>, ChainError>> + Send;
+
+    /// Returns the block header at `height`, or `None` if above this view's tip.
+    fn get_block_header(
+        &self,
+        height: BlockHeight,
+    ) -> impl Future<Output = Result<Option<BlockHeader>, ChainError>> + Send;
 
     /// Returns the block at `height`, or `None` if above this view's tip.
-    async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, ChainError>;
+    fn get_block(
+        &self,
+        height: BlockHeight,
+    ) -> impl Future<Output = Result<Option<Block>, ChainError>> + Send;
 
     /// Streams blocks from `start` to this view's tip, inclusive.
     fn stream_blocks_to_tip(&self, start: BlockHeight) -> BoxStream<'_, Result<Block, ChainError>>;
@@ -87,17 +98,28 @@ pub(crate) trait ChainView: Clone + Send + Sync + 'static {
     /// Streams the current mempool. The stream ends when this view's tip changes.
     ///
     /// Returns `None` if the tip has already changed since the view was captured.
-    async fn get_mempool_stream(&self) -> Result<Option<BoxStream<'_, Transaction>>, ChainError>;
+    fn get_mempool_stream(
+        &self,
+    ) -> impl Future<Output = Result<Option<BoxStream<'_, Transaction>>, ChainError>> + Send;
 
     /// Returns the transaction with the given txid, if known.
-    async fn get_transaction(&self, txid: TxId) -> Result<Option<ChainTx>, ChainError>;
+    fn get_transaction(
+        &self,
+        txid: TxId,
+    ) -> impl Future<Output = Result<Option<ChainTx>, ChainError>> + Send;
 
     /// Returns the current status of the given transaction.
-    async fn get_transaction_status(&self, txid: TxId) -> Result<TransactionStatus, ChainError>;
+    fn get_transaction_status(
+        &self,
+        txid: TxId,
+    ) -> impl Future<Output = Result<TransactionStatus, ChainError>> + Send;
 
     /// Returns the height of the given block if it is on this view's main chain.
     #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
-    async fn block_height(&self, hash: &BlockHash) -> Result<Option<BlockHeight>, ChainError>;
+    fn block_height(
+        &self,
+        hash: &BlockHash,
+    ) -> impl Future<Output = Result<Option<BlockHeight>, ChainError>> + Send;
 }
 
 /// A block's height and hash.

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -115,6 +115,10 @@ pub(crate) trait ChainView: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = Result<TransactionStatus, ChainError>> + Send;
 
     /// Returns the height of the given block if it is on this view's main chain.
+    ///
+    /// Gated to the `zcashd-import` migration: its only caller resolves block hashes to
+    /// heights for transactions imported from a `zcashd` wallet, so backends need not
+    /// implement it in builds that cannot perform that import.
     #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
     fn block_height(
         &self,
@@ -169,9 +173,11 @@ mod tests {
 
         async fn find_fork_point(
             &self,
-            _known_tip: &BlockHash,
+            known_tip: &BlockHash,
         ) -> Result<Option<ChainBlock>, ChainError> {
-            Ok(Some(self.tip))
+            // The mock knows only its own tip, so the fork point is locatable only when
+            // the caller's known tip is that block; any other tip cannot be located.
+            Ok((known_tip == &self.tip.hash).then_some(self.tip))
         }
 
         async fn tree_state_as_of(
@@ -237,6 +243,11 @@ mod tests {
         };
         let view = MockChainView { tip };
         assert_eq!(view.tip().await.unwrap(), tip);
+        // The fork point resolves for the view's own tip, and not for an unknown one.
         assert_eq!(view.find_fork_point(&tip.hash).await.unwrap(), Some(tip));
+        assert_eq!(
+            view.find_fork_point(&BlockHash([0u8; 32])).await.unwrap(),
+            None,
+        );
     }
 }

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -38,6 +38,9 @@ use crate::{
 
 use super::TaskHandle;
 
+mod error;
+pub(crate) use error::ChainError;
+
 /// Converts a `zcash_protocol` block height into a Zaino block height.
 fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
     u32::from(height)
@@ -206,15 +209,14 @@ impl ZainoChain {
     /// Returns an error if the transaction failed to be submitted to a single node. No
     /// broadcast guarantees are provided beyond this; transactions should be periodically
     /// rebroadcast while they are unmined and unexpired.
-    pub(crate) async fn broadcast_transaction(&self, tx: &Transaction) -> Result<(), Error> {
+    pub(crate) async fn broadcast_transaction(&self, tx: &Transaction) -> Result<(), ChainError> {
         let mut tx_bytes = vec![];
-        tx.write(&mut tx_bytes)
-            .map_err(|e| ErrorKind::Generic.context(e))?;
+        tx.write(&mut tx_bytes).map_err(ChainError::backend)?;
 
         self.fetcher
             .send_raw_transaction(hex::encode(&tx_bytes))
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?;
+            .map_err(ChainError::backend)?;
 
         Ok(())
     }
@@ -224,12 +226,12 @@ impl ZainoChain {
     /// The data viewable through the returned [`ZainoChainView`] is guaranteed to be available
     /// as long as (any clone of) the returned instance is live, regardless of what new
     /// blocks or reorgs are observed by the underlying chain indexer.
-    pub(crate) async fn snapshot(&self) -> Result<ZainoChainView, Error> {
+    pub(crate) async fn snapshot(&self) -> Result<ZainoChainView, ChainError> {
         let snapshot = self
             .subscriber
             .snapshot_nonfinalized_state()
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?;
+            .map_err(ChainError::backend)?;
 
         Ok(ZainoChainView {
             chain: self.subscriber.clone(),
@@ -240,11 +242,11 @@ impl ZainoChain {
 
     pub(crate) async fn get_sapling_subtree_roots(
         &self,
-    ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, Error> {
+    ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError> {
         self.subscriber
             .get_subtree_roots(ShieldedPool::Sapling, 0, None)
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?
+            .map_err(ChainError::backend)?
             .into_iter()
             .map(|(root_hash, end_height)| {
                 Ok(CommitmentTreeRoot::from_parts(
@@ -253,16 +255,16 @@ impl ZainoChain {
                         .expect("zaino should provide canonical encodings"),
                 ))
             })
-            .collect::<Result<Vec<_>, Error>>()
+            .collect::<Result<Vec<_>, ChainError>>()
     }
 
     pub(crate) async fn get_orchard_subtree_roots(
         &self,
-    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, Error> {
+    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
         self.subscriber
             .get_subtree_roots(ShieldedPool::Orchard, 0, None)
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?
+            .map_err(ChainError::backend)?
             .into_iter()
             .map(|(root_hash, end_height)| {
                 Ok(CommitmentTreeRoot::from_parts(
@@ -271,7 +273,7 @@ impl ZainoChain {
                         .expect("zaino should provide canonical encodings"),
                 ))
             })
-            .collect::<Result<Vec<_>, Error>>()
+            .collect::<Result<Vec<_>, ChainError>>()
     }
 }
 
@@ -289,12 +291,12 @@ pub(crate) struct ZainoChainView {
 
 impl ZainoChainView {
     /// Returns the current chain tip.
-    pub(crate) async fn tip(&self) -> Result<ChainBlock, Error> {
+    pub(crate) async fn tip(&self) -> Result<ChainBlock, ChainError> {
         let best_tip = self
             .chain
             .best_chaintip(&self.snapshot)
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?;
+            .map_err(ChainError::backend)?;
 
         Ok(ChainBlock::from_zaino((best_tip.hash, best_tip.height)))
     }
@@ -305,12 +307,12 @@ impl ZainoChainView {
     pub(crate) async fn block_height(
         &self,
         hash: &BlockHash,
-    ) -> Result<Option<BlockHeight>, Error> {
+    ) -> Result<Option<BlockHeight>, ChainError> {
         Ok(self
             .chain
             .get_block_height(&self.snapshot, zaino_state::BlockHash(hash.0))
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?
+            .map_err(ChainError::backend)?
             .map(|height| BlockHeight::from_u32(height.into())))
     }
 
@@ -320,12 +322,12 @@ impl ZainoChainView {
     pub(crate) async fn find_fork_point(
         &self,
         other: &BlockHash,
-    ) -> Result<Option<ChainBlock>, Error> {
+    ) -> Result<Option<ChainBlock>, ChainError> {
         Ok(self
             .chain
             .find_fork_point(&self.snapshot, &zaino_state::BlockHash(other.0))
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?
+            .map_err(ChainError::backend)?
             .map(ChainBlock::from_zaino))
     }
 
@@ -336,19 +338,19 @@ impl ZainoChainView {
     pub(crate) async fn tree_state_as_of(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<ChainState>, Error> {
+    ) -> Result<Option<ChainState>, ChainError> {
         let block_hash = self
             .chain
             .get_block_hash(&self.snapshot, to_zaino_height(height))
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?;
+            .map_err(ChainError::backend)?;
 
         let chain_state = if let Some(hash) = block_hash {
             let (sapling_treestate, orchard_treestate) = self
                 .chain
                 .get_treestate(&hash)
                 .await
-                .map_err(|e| ErrorKind::Generic.context(e))?;
+                .map_err(ChainError::backend)?;
 
             let final_sapling_tree = match sapling_treestate {
                 None => CommitmentTree::empty(),
@@ -357,7 +359,7 @@ impl ZainoChainView {
                     _,
                     { sapling::NOTE_COMMITMENT_TREE_DEPTH },
                 >(&sapling_tree_bytes[..])
-                .map_err(|e| ErrorKind::Generic.context(e))?,
+                .map_err(ChainError::backend)?,
             }
             .to_frontier();
 
@@ -368,7 +370,7 @@ impl ZainoChainView {
                     _,
                     { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
                 >(&orchard_tree_bytes[..])
-                .map_err(|e| ErrorKind::Generic.context(e))?,
+                .map_err(ChainError::backend)?,
             }
             .to_frontier();
 
@@ -390,21 +392,19 @@ impl ZainoChainView {
     pub(crate) async fn get_block_header(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<BlockHeader>, Error> {
+    ) -> Result<Option<BlockHeader>, ChainError> {
         self.get_block_inner(height, |block_bytes| {
             // Read the header, ignore the transactions.
-            BlockHeader::read(block_bytes.as_slice())
-                .map_err(|e| ErrorKind::Generic.context(e).into())
+            BlockHeader::read(block_bytes.as_slice()).map_err(ChainError::backend)
         })
         .await
     }
 
     /// Returns the block at the given height, or `None` if the height is above this
     /// view's chain tip.
-    pub(crate) async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, Error> {
+    pub(crate) async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, ChainError> {
         self.get_block_inner(height, |block_bytes| {
-            Block::read(block_bytes.as_slice(), &self.params)
-                .map_err(|e| ErrorKind::Generic.context(e).into())
+            Block::read(block_bytes.as_slice(), &self.params).map_err(ChainError::backend)
         })
         .await
     }
@@ -412,8 +412,8 @@ impl ZainoChainView {
     async fn get_block_inner<T>(
         &self,
         height: BlockHeight,
-        f: impl FnOnce(Vec<u8>) -> Result<T, Error>,
-    ) -> Result<Option<T>, Error> {
+        f: impl FnOnce(Vec<u8>) -> Result<T, ChainError>,
+    ) -> Result<Option<T>, ChainError> {
         let height = to_zaino_height(height);
         // TODO: Should return `impl futures::TryStream` if it is to be fallible.
         if let Some(stream) = self
@@ -423,7 +423,7 @@ impl ZainoChainView {
             tokio::pin!(stream);
             let block_bytes = match stream.next().await {
                 None => return Ok(None),
-                Some(ret) => ret.map_err(|e| ErrorKind::Generic.context(e)),
+                Some(ret) => ret.map_err(ChainError::backend),
             }?;
 
             f(block_bytes).map(Some)
@@ -439,7 +439,7 @@ impl ZainoChainView {
     pub(crate) fn stream_blocks_to_tip(
         &self,
         start: BlockHeight,
-    ) -> impl futures::Stream<Item = Result<Block, Error>> {
+    ) -> impl futures::Stream<Item = Result<Block, ChainError>> {
         self.stream_blocks_inner(start, None)
     }
 
@@ -450,7 +450,7 @@ impl ZainoChainView {
     pub(crate) fn stream_blocks(
         &self,
         range: &Range<BlockHeight>,
-    ) -> impl futures::Stream<Item = Result<Block, Error>> {
+    ) -> impl futures::Stream<Item = Result<Block, ChainError>> {
         self.stream_blocks_inner(range.start, Some(range.end - 1))
     }
 
@@ -459,7 +459,7 @@ impl ZainoChainView {
         &self,
         start: BlockHeight,
         end: Option<BlockHeight>,
-    ) -> impl futures::Stream<Item = Result<Block, Error>> {
+    ) -> impl futures::Stream<Item = Result<Block, ChainError>> {
         // TODO: Should return `impl futures::TryStream` if it is to be fallible.
         if let Some(stream) = self.chain.get_block_range(
             &self.snapshot,
@@ -468,11 +468,10 @@ impl ZainoChainView {
         ) {
             stream
                 .map(|res| {
-                    res.map_err(|e| ErrorKind::Generic.context(e).into())
-                        .and_then(|block_bytes| {
-                            Block::read(block_bytes.as_slice(), &self.params)
-                                .map_err(|e| ErrorKind::Sync.context(e).into())
-                        })
+                    res.map_err(ChainError::backend).and_then(|block_bytes| {
+                        Block::read(block_bytes.as_slice(), &self.params)
+                            .map_err(ChainError::invalid_data)
+                    })
                 })
                 .boxed()
         } else {
@@ -488,7 +487,7 @@ impl ZainoChainView {
     /// Returns `None` if the chain tip has changed since this view was captured.
     pub(crate) async fn get_mempool_stream(
         &self,
-    ) -> Result<Option<impl futures::Stream<Item = Transaction>>, Error> {
+    ) -> Result<Option<impl futures::Stream<Item = Transaction>>, ChainError> {
         let mempool_height = self.tip().await?.height + 1;
         let consensus_branch_id = consensus::BranchId::for_height(&self.params, mempool_height);
 
@@ -512,21 +511,20 @@ impl ZainoChainView {
     }
 
     /// Returns the transaction with the given txid, if known.
-    pub(crate) async fn get_transaction(&self, txid: TxId) -> Result<Option<ChainTx>, Error> {
+    pub(crate) async fn get_transaction(&self, txid: TxId) -> Result<Option<ChainTx>, ChainError> {
         let zaino_txid = zaino_state::TransactionHash::from(*txid.as_ref());
 
         let (inner, raw) = match self
             .chain
             .get_raw_transaction(&self.snapshot, &zaino_txid)
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?
+            .map_err(ChainError::backend)?
         {
             None => return Ok(None),
             Some((raw_tx, branch_id)) => {
                 let consensus_branch_id = match branch_id {
                     // If `try_from` fails, it indicates a dependency versioning problem.
-                    Some(id) => consensus::BranchId::try_from(id)
-                        .map_err(|e| ErrorKind::Generic.context(e))?,
+                    Some(id) => consensus::BranchId::try_from(id).map_err(ChainError::backend)?,
                     // Zaino could not determine the consensus branch ID. This happens for
                     // mempool transactions (when the snapshot's mempool height is unknown)
                     // and for pre-Overwinter transactions (which predate consensus branch
@@ -542,7 +540,7 @@ impl ZainoChainView {
                 };
 
                 let tx = Transaction::read(raw_tx.as_slice(), consensus_branch_id)
-                    .map_err(|e| ErrorKind::Generic.context(e))?;
+                    .map_err(ChainError::backend)?;
 
                 (tx, raw_tx)
             }
@@ -552,7 +550,7 @@ impl ZainoChainView {
             .chain
             .get_transaction_status(&self.snapshot, &zaino_txid)
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?
+            .map_err(ChainError::backend)?
         {
             (Some(BestChainLocation::Block(hash, height)), _) => (
                 Some(BlockHash(hash.0)),
@@ -594,14 +592,14 @@ impl ZainoChainView {
     pub(crate) async fn get_transaction_status(
         &self,
         txid: TxId,
-    ) -> Result<TransactionStatus, Error> {
+    ) -> Result<TransactionStatus, ChainError> {
         let zaino_txid = zaino_state::TransactionHash::from(*txid.as_ref());
 
         let status = self
             .chain
             .get_transaction_status(&self.snapshot, &zaino_txid)
             .await
-            .map_err(|e| ErrorKind::Generic.context(e))?;
+            .map_err(ChainError::backend)?;
 
         Ok(match status {
             (Some(BestChainLocation::Block(_, height)), _) => {

--- a/zallet/src/components/chain/error.rs
+++ b/zallet/src/components/chain/error.rs
@@ -1,0 +1,71 @@
+//! Errors surfaced by the chain-data abstraction.
+
+use std::fmt;
+
+/// A boxed, sendable error source.
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// An error returned by a [`Chain`](super::Chain) or [`ChainView`](super::ChainView).
+///
+/// Absence of a requested item is **not** an error; methods return `Ok(None)` for that.
+#[derive(Debug)]
+#[non_exhaustive]
+pub(crate) enum ChainError {
+    /// The chain source is temporarily unable to serve the request; retrying later may
+    /// succeed (transient transport failure, the backend is still syncing, work queue full).
+    ///
+    /// Constructed by alternative backends that can distinguish retryable failures; the
+    /// Zaino backend currently classifies all opaque failures as [`ChainError::Backend`].
+    #[allow(dead_code)]
+    Unavailable(BoxError),
+    /// The chain source returned data that could not be decoded, or that violated an
+    /// invariant the wallet relies on (a non-canonical encoding, an unexpected response
+    /// shape). Not retryable; indicates a bug, corruption, or a version mismatch.
+    InvalidData(BoxError),
+    /// A backend-specific failure with no finer classification.
+    Backend(BoxError),
+}
+
+impl ChainError {
+    /// Wraps an arbitrary error as a [`ChainError::Backend`].
+    pub(crate) fn backend(source: impl Into<BoxError>) -> Self {
+        ChainError::Backend(source.into())
+    }
+
+    /// Wraps an arbitrary error as a [`ChainError::Unavailable`].
+    #[allow(dead_code)]
+    pub(crate) fn unavailable(source: impl Into<BoxError>) -> Self {
+        ChainError::Unavailable(source.into())
+    }
+
+    /// Wraps an arbitrary error as a [`ChainError::InvalidData`].
+    pub(crate) fn invalid_data(source: impl Into<BoxError>) -> Self {
+        ChainError::InvalidData(source.into())
+    }
+}
+
+impl fmt::Display for ChainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChainError::Unavailable(e) => write!(f, "chain source unavailable: {e}"),
+            ChainError::InvalidData(e) => write!(f, "chain source returned invalid data: {e}"),
+            ChainError::Backend(e) => write!(f, "chain backend error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ChainError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ChainError::Unavailable(e) | ChainError::InvalidData(e) | ChainError::Backend(e) => {
+                Some(e.as_ref())
+            }
+        }
+    }
+}
+
+impl From<ChainError> for crate::error::Error {
+    fn from(e: ChainError) -> Self {
+        crate::error::ErrorKind::Chain.context(e).into()
+    }
+}

--- a/zallet/src/components/chain/zaino.rs
+++ b/zallet/src/components/chain/zaino.rs
@@ -1,0 +1,581 @@
+//! The Zaino-backed implementation of [`Chain`] and [`ChainView`].
+
+use std::fmt;
+use std::ops::Range;
+
+use futures::{StreamExt, stream::BoxStream};
+use incrementalmerkletree::frontier::CommitmentTree;
+use jsonrpsee::tracing::{error, info, warn};
+use tokio::net::lookup_host;
+use zaino_common::{CacheConfig, DatabaseConfig, StorageConfig};
+use zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector;
+use zaino_state::{
+    BlockCacheConfig, ChainIndex as _, ChainIndexSnapshot, NodeBackedChainIndex,
+    NodeBackedChainIndexSubscriber, StatusType,
+    chain_index::{
+        ShieldedPool,
+        source::ValidatorConnector,
+        types::{BestChainLocation, NonBestChainLocation},
+    },
+};
+use zcash_client_backend::data_api::{
+    TransactionStatus,
+    chain::{ChainState, CommitmentTreeRoot},
+};
+use zcash_primitives::{
+    block::{Block, BlockHash, BlockHeader},
+    merkle_tree::read_commitment_tree,
+    transaction::Transaction,
+};
+use zcash_protocol::{
+    TxId,
+    consensus::{self, BlockHeight},
+};
+
+use crate::{
+    components::TaskHandle,
+    config::ZalletConfig,
+    error::{Error, ErrorKind},
+    network::Network,
+};
+
+use super::{Chain, ChainBlock, ChainError, ChainTx, ChainView};
+
+/// Converts a `zcash_protocol` block height into a Zaino block height.
+fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
+    u32::from(height)
+        .try_into()
+        .expect("we won't hit max height for a while")
+}
+
+/// The Zaino finalised-state database schema version to target.
+///
+/// `1` selects Zaino's latest v1 finalised-state schema. We run the indexer in ephemeral
+/// mode (see [`BlockCacheConfig::new`] below), so no persistent finalised-state database
+/// is actually opened and this value has no on-disk effect; it is set to the current
+/// schema version for forward-compatibility if ephemeral mode is ever disabled.
+const ZAINO_FINALISED_DB_VERSION: u32 = 1;
+
+#[derive(Clone)]
+pub(crate) struct ZainoChain {
+    subscriber: NodeBackedChainIndexSubscriber,
+    /// Used for submitting transactions to the network (`ChainIndex` is a read-only view
+    /// of the chain).
+    fetcher: JsonRpSeeConnector,
+    params: Network,
+}
+
+impl fmt::Debug for ZainoChain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ZainoChain").finish_non_exhaustive()
+    }
+}
+
+impl ZainoChain {
+    pub(crate) async fn new(config: &ZalletConfig) -> Result<(Self, TaskHandle), Error> {
+        let params = config.consensus.network();
+
+        let resolved_validator_address = match config.indexer.validator_address.as_deref() {
+            Some(addr_str) => match lookup_host(addr_str).await {
+                Ok(mut addrs) => match addrs.next() {
+                    Some(socket_addr) => {
+                        info!(
+                            "Resolved validator_address '{}' to {}",
+                            addr_str, socket_addr
+                        );
+                        Ok(socket_addr)
+                    }
+                    None => {
+                        error!(
+                            "validator_address '{}' resolved to no IP addresses",
+                            addr_str
+                        );
+                        Err(ErrorKind::Init.context(format!(
+                            "validator_address '{addr_str}' resolved to no IP addresses"
+                        )))
+                    }
+                },
+                Err(e) => {
+                    error!("Failed to resolve validator_address '{}': {}", addr_str, e);
+                    Err(ErrorKind::Init.context(format!(
+                        "Failed to resolve validator_address '{addr_str}': {e}"
+                    )))
+                }
+            },
+            None => {
+                // Default to localhost and standard port based on network
+                let default_port = match params {
+                    Network::Consensus(consensus::Network::MainNetwork) => 8232, // Mainnet default RPC port for Zebra/zcashd
+                    _ => 18232, // Testnet/Regtest default RPC port for Zebra/zcashd
+                };
+                let default_addr_str = format!("127.0.0.1:{default_port}");
+                info!(
+                    "validator_address not set, defaulting to {}",
+                    default_addr_str
+                );
+                match default_addr_str.parse::<std::net::SocketAddr>() {
+                    Ok(socket_addr) => Ok(socket_addr),
+                    Err(e) => {
+                        // This should ideally not happen with a hardcoded IP and port
+                        error!(
+                            "Failed to parse default validator_address '{}': {}",
+                            default_addr_str, e
+                        );
+                        Err(ErrorKind::Init.context(format!(
+                            "Failed to parse default validator_address '{default_addr_str}': {e}"
+                        )))
+                    }
+                }
+            }
+        }?;
+
+        let fetcher = JsonRpSeeConnector::new_from_config_parts(
+            &resolved_validator_address.to_string(),
+            config.indexer.validator_user.clone().unwrap_or_default(),
+            config
+                .indexer
+                .validator_password
+                .clone()
+                .unwrap_or_default(),
+            config.indexer.validator_cookie_path.clone(),
+        )
+        .await
+        .map_err(|e| ErrorKind::Init.context(e))?;
+
+        let indexer_config = BlockCacheConfig::new(
+            StorageConfig {
+                cache: CacheConfig::default(),
+                database: DatabaseConfig {
+                    path: config.indexer_db_path().to_path_buf(),
+                    // Unused in ephemeral mode (no persistent finalised-state
+                    // database is opened).
+                    size: zaino_common::DatabaseSize(0),
+                    // Unused in ephemeral mode (the finalised-state bulk-sync
+                    // write path is never exercised); inherit Zaino's default.
+                    ..Default::default()
+                },
+            },
+            ZAINO_FINALISED_DB_VERSION,
+            params.to_zaino(),
+            // Run the finalised state ephemerally: no persistent database, finalised
+            // reads are served from the backing validator.
+            true,
+        );
+
+        info!("Starting Zaino indexer");
+        let indexer =
+            NodeBackedChainIndex::new(ValidatorConnector::Fetch(fetcher.clone()), indexer_config)
+                .await
+                .map_err(|e| ErrorKind::Init.context(e))?;
+        info!("Started Zaino indexer");
+
+        let chain = Self {
+            subscriber: indexer.subscriber(),
+            fetcher,
+            params,
+        };
+
+        // Spawn a task that stops the indexer when appropriate internal signals occur.
+        let task = crate::spawn!("Indexer shutdown", async move {
+            let mut server_interval =
+                tokio::time::interval(tokio::time::Duration::from_millis(100));
+
+            loop {
+                server_interval.tick().await;
+
+                match indexer.status() {
+                    // Check for errors.
+                    StatusType::Offline | StatusType::CriticalError => {
+                        indexer
+                            .shutdown()
+                            .await
+                            .map_err(|e| ErrorKind::Generic.context(e))?;
+                        return Err(ErrorKind::Generic.into());
+                    }
+
+                    // Check for shutdown signals.
+                    StatusType::Closing => return Ok(()),
+
+                    _ => (),
+                }
+            }
+        });
+
+        Ok((chain, task))
+    }
+}
+
+impl Chain for ZainoChain {
+    type View = ZainoChainView;
+
+    async fn broadcast_transaction(&self, tx: &Transaction) -> Result<(), ChainError> {
+        let mut tx_bytes = vec![];
+        tx.write(&mut tx_bytes).map_err(ChainError::backend)?;
+
+        self.fetcher
+            .send_raw_transaction(hex::encode(&tx_bytes))
+            .await
+            .map_err(ChainError::backend)?;
+
+        Ok(())
+    }
+
+    async fn get_sapling_subtree_roots(
+        &self,
+    ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError> {
+        self.subscriber
+            .get_subtree_roots(ShieldedPool::Sapling, 0, None)
+            .await
+            .map_err(ChainError::backend)?
+            .into_iter()
+            .map(|(root_hash, end_height)| {
+                Ok(CommitmentTreeRoot::from_parts(
+                    BlockHeight::from_u32(end_height),
+                    sapling::Node::from_bytes(root_hash)
+                        .expect("zaino should provide canonical encodings"),
+                ))
+            })
+            .collect::<Result<Vec<_>, ChainError>>()
+    }
+
+    async fn get_orchard_subtree_roots(
+        &self,
+    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
+        self.subscriber
+            .get_subtree_roots(ShieldedPool::Orchard, 0, None)
+            .await
+            .map_err(ChainError::backend)?
+            .into_iter()
+            .map(|(root_hash, end_height)| {
+                Ok(CommitmentTreeRoot::from_parts(
+                    BlockHeight::from_u32(end_height),
+                    orchard::tree::MerkleHashOrchard::from_bytes(&root_hash)
+                        .expect("zaino should provide canonical encodings"),
+                ))
+            })
+            .collect::<Result<Vec<_>, ChainError>>()
+    }
+
+    async fn snapshot(&self) -> Result<ZainoChainView, ChainError> {
+        let snapshot = self
+            .subscriber
+            .snapshot_nonfinalized_state()
+            .await
+            .map_err(ChainError::backend)?;
+
+        Ok(ZainoChainView {
+            chain: self.subscriber.clone(),
+            snapshot,
+            params: self.params,
+        })
+    }
+}
+
+/// A stable view of the chain as of a particular chain tip.
+///
+/// The data viewable through an instance of `ZainoChainView` is guaranteed to be available
+/// as long as (any clone of) the instance is live, regardless of what new blocks or
+/// reorgs are observed by the underlying chain indexer.
+#[derive(Clone)]
+pub(crate) struct ZainoChainView {
+    chain: NodeBackedChainIndexSubscriber,
+    snapshot: ChainIndexSnapshot,
+    params: Network,
+}
+
+impl ChainView for ZainoChainView {
+    async fn tip(&self) -> Result<ChainBlock, ChainError> {
+        let best_tip = self
+            .chain
+            .best_chaintip(&self.snapshot)
+            .await
+            .map_err(ChainError::backend)?;
+
+        Ok(ChainBlock::from_zaino((best_tip.hash, best_tip.height)))
+    }
+
+    async fn find_fork_point(
+        &self,
+        known_tip: &BlockHash,
+    ) -> Result<Option<ChainBlock>, ChainError> {
+        Ok(self
+            .chain
+            .find_fork_point(&self.snapshot, &zaino_state::BlockHash(known_tip.0))
+            .await
+            .map_err(ChainError::backend)?
+            .map(ChainBlock::from_zaino))
+    }
+
+    async fn tree_state_as_of(
+        &self,
+        height: BlockHeight,
+    ) -> Result<Option<ChainState>, ChainError> {
+        let block_hash = self
+            .chain
+            .get_block_hash(&self.snapshot, to_zaino_height(height))
+            .await
+            .map_err(ChainError::backend)?;
+
+        let chain_state = if let Some(hash) = block_hash {
+            let (sapling_treestate, orchard_treestate) = self
+                .chain
+                .get_treestate(&hash)
+                .await
+                .map_err(ChainError::backend)?;
+
+            let final_sapling_tree = match sapling_treestate {
+                None => CommitmentTree::empty(),
+                Some(sapling_tree_bytes) => read_commitment_tree::<
+                    sapling::Node,
+                    _,
+                    { sapling::NOTE_COMMITMENT_TREE_DEPTH },
+                >(&sapling_tree_bytes[..])
+                .map_err(ChainError::backend)?,
+            }
+            .to_frontier();
+
+            let final_orchard_tree = match orchard_treestate {
+                None => CommitmentTree::empty(),
+                Some(orchard_tree_bytes) => read_commitment_tree::<
+                    orchard::tree::MerkleHashOrchard,
+                    _,
+                    { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+                >(&orchard_tree_bytes[..])
+                .map_err(ChainError::backend)?,
+            }
+            .to_frontier();
+
+            Some(ChainState::new(
+                height,
+                BlockHash(hash.0),
+                final_sapling_tree,
+                final_orchard_tree,
+            ))
+        } else {
+            None
+        };
+
+        Ok(chain_state)
+    }
+
+    async fn get_block_header(
+        &self,
+        height: BlockHeight,
+    ) -> Result<Option<BlockHeader>, ChainError> {
+        self.get_block_inner(height, |block_bytes| {
+            // Read the header, ignore the transactions.
+            BlockHeader::read(block_bytes.as_slice()).map_err(ChainError::backend)
+        })
+        .await
+    }
+
+    async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, ChainError> {
+        self.get_block_inner(height, |block_bytes| {
+            Block::read(block_bytes.as_slice(), &self.params).map_err(ChainError::backend)
+        })
+        .await
+    }
+
+    fn stream_blocks_to_tip(&self, start: BlockHeight) -> BoxStream<'_, Result<Block, ChainError>> {
+        self.stream_blocks_inner(start, None)
+    }
+
+    fn stream_blocks(
+        &self,
+        range: &Range<BlockHeight>,
+    ) -> BoxStream<'_, Result<Block, ChainError>> {
+        self.stream_blocks_inner(range.start, Some(range.end - 1))
+    }
+
+    async fn get_mempool_stream(&self) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+        let mempool_height = self.tip().await?.height + 1;
+        let consensus_branch_id = consensus::BranchId::for_height(&self.params, mempool_height);
+
+        Ok(self
+            .chain
+            .get_mempool_stream(Some(&self.snapshot))
+            .map(move |stream| {
+                stream
+                    .filter_map(move |result| async move {
+                        result
+                            .inspect_err(|e| warn!("Error receiving transaction: {e}"))
+                            .ok()
+                            .and_then(|raw_tx| {
+                                Transaction::read(raw_tx.as_slice(), consensus_branch_id)
+                                    .inspect_err(|e| {
+                                        warn!("Received invalid transaction from mempool: {e}");
+                                    })
+                                    .ok()
+                            })
+                    })
+                    .boxed()
+            }))
+    }
+
+    async fn get_transaction(&self, txid: TxId) -> Result<Option<ChainTx>, ChainError> {
+        let zaino_txid = zaino_state::TransactionHash::from(*txid.as_ref());
+
+        let (inner, raw) = match self
+            .chain
+            .get_raw_transaction(&self.snapshot, &zaino_txid)
+            .await
+            .map_err(ChainError::backend)?
+        {
+            None => return Ok(None),
+            Some((raw_tx, branch_id)) => {
+                let consensus_branch_id = match branch_id {
+                    // If `try_from` fails, it indicates a dependency versioning problem.
+                    Some(id) => consensus::BranchId::try_from(id).map_err(ChainError::backend)?,
+                    // Zaino could not determine the consensus branch ID. This happens for
+                    // mempool transactions (when the snapshot's mempool height is unknown)
+                    // and for pre-Overwinter transactions (which predate consensus branch
+                    // IDs). A transaction cannot be mined across a network upgrade
+                    // boundary, and an unmined transaction must be minable at the current
+                    // chain tip, so the branch ID at the mempool height (tip + 1) is the
+                    // correct parsing target. This matches the fallback used by
+                    // `get_mempool_stream`.
+                    None => {
+                        let mempool_height = self.tip().await?.height + 1;
+                        consensus::BranchId::for_height(&self.params, mempool_height)
+                    }
+                };
+
+                let tx = Transaction::read(raw_tx.as_slice(), consensus_branch_id)
+                    .map_err(ChainError::backend)?;
+
+                (tx, raw_tx)
+            }
+        };
+
+        let (block_hash, mined_height, in_best_chain) = match self
+            .chain
+            .get_transaction_status(&self.snapshot, &zaino_txid)
+            .await
+            .map_err(ChainError::backend)?
+        {
+            (Some(BestChainLocation::Block(hash, height)), _) => (
+                Some(BlockHash(hash.0)),
+                Some(BlockHeight::from_u32(height.into())),
+                true,
+            ),
+            (Some(BestChainLocation::Mempool(_)), _) => (None, None, false),
+            (None, orphans) => match orphans.into_iter().next() {
+                Some(NonBestChainLocation::Block(hash, height)) => (
+                    Some(BlockHash(hash.0)),
+                    Some(BlockHeight::from_u32(height.into())),
+                    false,
+                ),
+                Some(NonBestChainLocation::Mempool(_)) | None => (None, None, false),
+            },
+        };
+
+        // Only populate the block time for transactions mined into the main chain. The
+        // time of an orphaned block is misleading (the transaction is not in the main
+        // chain) and can differ from the canonical block at the same height.
+        let block_time = match (in_best_chain, mined_height) {
+            (true, Some(height)) => self
+                .get_block_header(height)
+                .await?
+                .map(|header| header.time),
+            _ => None,
+        };
+
+        Ok(Some(ChainTx {
+            inner,
+            raw,
+            block_hash,
+            mined_height,
+            block_time,
+        }))
+    }
+
+    async fn get_transaction_status(&self, txid: TxId) -> Result<TransactionStatus, ChainError> {
+        let zaino_txid = zaino_state::TransactionHash::from(*txid.as_ref());
+
+        let status = self
+            .chain
+            .get_transaction_status(&self.snapshot, &zaino_txid)
+            .await
+            .map_err(ChainError::backend)?;
+
+        Ok(match status {
+            (Some(BestChainLocation::Block(_, height)), _) => {
+                TransactionStatus::Mined(BlockHeight::from_u32(height.into()))
+            }
+            (Some(BestChainLocation::Mempool(_)), _) => TransactionStatus::NotInMainChain,
+            (None, orphans) if orphans.is_empty() => TransactionStatus::TxidNotRecognized,
+            (None, _) => TransactionStatus::NotInMainChain,
+        })
+    }
+
+    /// Returns the height of the given block, if it is in the main chain within this
+    /// chain view.
+    #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+    async fn block_height(&self, hash: &BlockHash) -> Result<Option<BlockHeight>, ChainError> {
+        Ok(self
+            .chain
+            .get_block_height(&self.snapshot, zaino_state::BlockHash(hash.0))
+            .await
+            .map_err(ChainError::backend)?
+            .map(|height| BlockHeight::from_u32(height.into())))
+    }
+}
+
+impl ZainoChainView {
+    async fn get_block_inner<T>(
+        &self,
+        height: BlockHeight,
+        f: impl FnOnce(Vec<u8>) -> Result<T, ChainError>,
+    ) -> Result<Option<T>, ChainError> {
+        let height = to_zaino_height(height);
+        // TODO: Should return `impl futures::TryStream` if it is to be fallible.
+        if let Some(stream) = self
+            .chain
+            .get_block_range(&self.snapshot, height, Some(height))
+        {
+            tokio::pin!(stream);
+            let block_bytes = match stream.next().await {
+                None => return Ok(None),
+                Some(ret) => ret.map_err(ChainError::backend),
+            }?;
+
+            f(block_bytes).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Produces a contiguous stream of blocks from `start` to `end` inclusive.
+    fn stream_blocks_inner(
+        &self,
+        start: BlockHeight,
+        end: Option<BlockHeight>,
+    ) -> BoxStream<'_, Result<Block, ChainError>> {
+        // TODO: Should return `impl futures::TryStream` if it is to be fallible.
+        if let Some(stream) = self.chain.get_block_range(
+            &self.snapshot,
+            to_zaino_height(start),
+            end.map(to_zaino_height),
+        ) {
+            stream
+                .map(|res| {
+                    res.map_err(ChainError::backend).and_then(|block_bytes| {
+                        Block::read(block_bytes.as_slice(), &self.params)
+                            .map_err(ChainError::invalid_data)
+                    })
+                })
+                .boxed()
+        } else {
+            futures::stream::empty().boxed()
+        }
+    }
+}
+
+impl ChainBlock {
+    fn from_zaino((hash, height): (zaino_state::BlockHash, zaino_state::Height)) -> Self {
+        Self {
+            height: BlockHeight::from_u32(height.into()),
+            hash: BlockHash(hash.0),
+        }
+    }
+}

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 
-use super::{TaskHandle, chain::Chain, database::Database};
+use super::{TaskHandle, chain::ZainoChain, database::Database};
 
 #[cfg(zallet_build = "wallet")]
 use super::keystore::KeyStore;
@@ -35,7 +35,7 @@ impl JsonRpc {
         config: &ZalletConfig,
         db: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
-        chain: Chain,
+        chain: ZainoChain,
     ) -> Result<TaskHandle, Error> {
         let rpc = config.rpc.clone();
 

--- a/zallet/src/components/json_rpc.rs
+++ b/zallet/src/components/json_rpc.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 
-use super::{TaskHandle, chain::ZainoChain, database::Database};
+use super::{TaskHandle, chain::Chain, database::Database};
 
 #[cfg(zallet_build = "wallet")]
 use super::keystore::KeyStore;
@@ -31,11 +31,11 @@ pub(crate) mod utils;
 pub(crate) struct JsonRpc {}
 
 impl JsonRpc {
-    pub(crate) async fn spawn(
+    pub(crate) async fn spawn<C: Chain>(
         config: &ZalletConfig,
         db: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
-        chain: ZainoChain,
+        chain: C,
     ) -> Result<TaskHandle, Error> {
         let rpc = config.rpc.clone();
 

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -5,7 +5,7 @@ use jsonrpsee::{
 };
 
 use crate::components::{
-    chain::ZainoChain,
+    chain::Chain,
     database::{Database, DbHandle},
 };
 
@@ -639,19 +639,19 @@ pub(crate) trait WalletRpc {
     ) -> z_shieldcoinbase::Response;
 }
 
-pub(crate) struct RpcImpl {
+pub(crate) struct RpcImpl<C: Chain> {
     wallet: Database,
     #[cfg(zallet_build = "wallet")]
     keystore: KeyStore,
-    chain: ZainoChain,
+    chain: C,
 }
 
-impl RpcImpl {
+impl<C: Chain> RpcImpl<C> {
     /// Creates a new instance of the general RPC handler.
     pub(crate) fn new(
         wallet: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
-        chain: ZainoChain,
+        chain: C,
     ) -> Self {
         Self {
             wallet,
@@ -668,22 +668,22 @@ impl RpcImpl {
             .map_err(|_| jsonrpsee::types::ErrorCode::InternalError.into())
     }
 
-    async fn chain(&self) -> RpcResult<ZainoChain> {
+    async fn chain(&self) -> RpcResult<C> {
         Ok(self.chain.clone())
     }
 }
 
 #[cfg(zallet_build = "wallet")]
-pub(crate) struct WalletRpcImpl {
-    general: RpcImpl,
+pub(crate) struct WalletRpcImpl<C: Chain> {
+    general: RpcImpl<C>,
     keystore: KeyStore,
     async_ops: RwLock<Vec<AsyncOperation>>,
 }
 
 #[cfg(zallet_build = "wallet")]
-impl WalletRpcImpl {
+impl<C: Chain> WalletRpcImpl<C> {
     /// Creates a new instance of the wallet-specific RPC handler.
-    pub(crate) fn new(wallet: Database, keystore: KeyStore, chain_view: ZainoChain) -> Self {
+    pub(crate) fn new(wallet: Database, keystore: KeyStore, chain_view: C) -> Self {
         Self {
             general: RpcImpl::new(wallet, keystore.clone(), chain_view),
             keystore,
@@ -695,7 +695,7 @@ impl WalletRpcImpl {
         self.general.wallet().await
     }
 
-    async fn chain(&self) -> RpcResult<ZainoChain> {
+    async fn chain(&self) -> RpcResult<C> {
         self.general.chain().await
     }
 
@@ -713,7 +713,7 @@ impl WalletRpcImpl {
 }
 
 #[async_trait]
-impl RpcServer for RpcImpl {
+impl<C: Chain> RpcServer for RpcImpl<C> {
     async fn get_wallet_status(&self) -> get_wallet_status::Response {
         get_wallet_status::call(self.wallet().await?.as_ref(), self.chain().await?).await
     }
@@ -830,7 +830,7 @@ impl RpcServer for RpcImpl {
 
 #[cfg(zallet_build = "wallet")]
 #[async_trait]
-impl WalletRpcServer for WalletRpcImpl {
+impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
     fn help(&self, command: Option<&str>) -> help::Response {
         help::call(command)
     }

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -5,7 +5,7 @@ use jsonrpsee::{
 };
 
 use crate::components::{
-    chain::Chain,
+    chain::ZainoChain,
     database::{Database, DbHandle},
 };
 
@@ -643,7 +643,7 @@ pub(crate) struct RpcImpl {
     wallet: Database,
     #[cfg(zallet_build = "wallet")]
     keystore: KeyStore,
-    chain: Chain,
+    chain: ZainoChain,
 }
 
 impl RpcImpl {
@@ -651,7 +651,7 @@ impl RpcImpl {
     pub(crate) fn new(
         wallet: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
-        chain: Chain,
+        chain: ZainoChain,
     ) -> Self {
         Self {
             wallet,
@@ -668,7 +668,7 @@ impl RpcImpl {
             .map_err(|_| jsonrpsee::types::ErrorCode::InternalError.into())
     }
 
-    async fn chain(&self) -> RpcResult<Chain> {
+    async fn chain(&self) -> RpcResult<ZainoChain> {
         Ok(self.chain.clone())
     }
 }
@@ -683,7 +683,7 @@ pub(crate) struct WalletRpcImpl {
 #[cfg(zallet_build = "wallet")]
 impl WalletRpcImpl {
     /// Creates a new instance of the wallet-specific RPC handler.
-    pub(crate) fn new(wallet: Database, keystore: KeyStore, chain_view: Chain) -> Self {
+    pub(crate) fn new(wallet: Database, keystore: KeyStore, chain_view: ZainoChain) -> Self {
         Self {
             general: RpcImpl::new(wallet, keystore.clone(), chain_view),
             keystore,
@@ -695,7 +695,7 @@ impl WalletRpcImpl {
         self.general.wallet().await
     }
 
-    async fn chain(&self) -> RpcResult<Chain> {
+    async fn chain(&self) -> RpcResult<ZainoChain> {
         self.general.chain().await
     }
 

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use zcash_client_backend::data_api::{AccountBirthday, WalletRead, WalletWrite};
 
 use crate::components::{
-    chain::Chain,
+    chain::ZainoChain,
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
@@ -36,7 +36,7 @@ pub(super) const PARAM_SEEDFP_DESC: &str =
 pub(crate) async fn call(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
-    chain: Chain,
+    chain: ZainoChain,
     account_name: &str,
     seedfp: Option<&str>,
 ) -> Response {

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use zcash_client_backend::data_api::{AccountBirthday, WalletRead, WalletWrite};
 
 use crate::components::{
-    chain::ZainoChain,
+    chain::{Chain, ChainView, ZainoChain},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,

--- a/zallet/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet/src/components/json_rpc/methods/get_new_account.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use zcash_client_backend::data_api::{AccountBirthday, WalletRead, WalletWrite};
 
 use crate::components::{
-    chain::{Chain, ChainView, ZainoChain},
+    chain::{Chain, ChainView},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
@@ -33,10 +33,10 @@ pub(super) const PARAM_ACCOUNT_NAME_DESC: &str = "A human-readable name for the 
 pub(super) const PARAM_SEEDFP_DESC: &str =
     "ZIP 32 seed fingerprint for the BIP 39 mnemonic phrase from which to derive the account.";
 
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
-    chain: ZainoChain,
+    chain: C,
     account_name: &str,
     seedfp: Option<&str>,
 ) -> Response {

--- a/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
@@ -13,7 +13,7 @@ use zcash_script::script::{Asm, Code};
 use super::decode_script::{TransparentScript, script_to_json};
 use crate::{
     components::{
-        chain::Chain,
+        chain::ZainoChain,
         database::DbConnection,
         json_rpc::{
             server::LegacyCode,
@@ -470,7 +470,7 @@ pub(super) const PARAM_BLOCKHASH_DESC: &str = "The block in which to look for th
 
 pub(crate) async fn call(
     wallet: &DbConnection,
-    chain: Chain,
+    chain: ZainoChain,
     txid_str: &str,
     verbose: Option<u64>,
     blockhash: Option<String>,

--- a/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
@@ -13,7 +13,7 @@ use zcash_script::script::{Asm, Code};
 use super::decode_script::{TransparentScript, script_to_json};
 use crate::{
     components::{
-        chain::{Chain, ChainView, ZainoChain},
+        chain::{Chain, ChainView},
         database::DbConnection,
         json_rpc::{
             server::LegacyCode,
@@ -468,9 +468,9 @@ pub(super) const PARAM_TXID_DESC: &str = "The ID of the transaction to fetch.";
 pub(super) const PARAM_VERBOSE_DESC: &str = "If 0, return a string of hex-encoded data. If non-zero, return a JSON object with information about `txid`";
 pub(super) const PARAM_BLOCKHASH_DESC: &str = "The block in which to look for the transaction.";
 
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     wallet: &DbConnection,
-    chain: ZainoChain,
+    chain: C,
     txid_str: &str,
     verbose: Option<u64>,
     blockhash: Option<String>,

--- a/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/get_raw_transaction.rs
@@ -13,7 +13,7 @@ use zcash_script::script::{Asm, Code};
 use super::decode_script::{TransparentScript, script_to_json};
 use crate::{
     components::{
-        chain::ZainoChain,
+        chain::{Chain, ChainView, ZainoChain},
         database::DbConnection,
         json_rpc::{
             server::LegacyCode,

--- a/zallet/src/components/json_rpc/methods/get_wallet_status.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_status.rs
@@ -9,7 +9,7 @@ use zcash_client_backend::data_api::{
 use zcash_client_sqlite::{AccountUuid, WalletDb, error::SqliteClientError, util::SystemClock};
 
 use crate::{
-    components::{chain::Chain, database::DbConnection, json_rpc::server::LegacyCode},
+    components::{chain::ZainoChain, database::DbConnection, json_rpc::server::LegacyCode},
     network::Network,
 };
 
@@ -81,7 +81,7 @@ struct Progress {
     denominator: u64,
 }
 
-pub(crate) async fn call(wallet: &DbConnection, chain: Chain) -> Response {
+pub(crate) async fn call(wallet: &DbConnection, chain: ZainoChain) -> Response {
     let node_tip = chain
         .snapshot()
         .await

--- a/zallet/src/components/json_rpc/methods/get_wallet_status.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_status.rs
@@ -10,7 +10,7 @@ use zcash_client_sqlite::{AccountUuid, WalletDb, error::SqliteClientError, util:
 
 use crate::{
     components::{
-        chain::{Chain, ChainView, ZainoChain},
+        chain::{Chain, ChainView},
         database::DbConnection,
         json_rpc::server::LegacyCode,
     },
@@ -85,7 +85,7 @@ struct Progress {
     denominator: u64,
 }
 
-pub(crate) async fn call(wallet: &DbConnection, chain: ZainoChain) -> Response {
+pub(crate) async fn call<C: Chain>(wallet: &DbConnection, chain: C) -> Response {
     let node_tip = chain
         .snapshot()
         .await

--- a/zallet/src/components/json_rpc/methods/get_wallet_status.rs
+++ b/zallet/src/components/json_rpc/methods/get_wallet_status.rs
@@ -9,7 +9,11 @@ use zcash_client_backend::data_api::{
 use zcash_client_sqlite::{AccountUuid, WalletDb, error::SqliteClientError, util::SystemClock};
 
 use crate::{
-    components::{chain::ZainoChain, database::DbConnection, json_rpc::server::LegacyCode},
+    components::{
+        chain::{Chain, ChainView, ZainoChain},
+        database::DbConnection,
+        json_rpc::server::LegacyCode,
+    },
     network::Network,
 };
 

--- a/zallet/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/recover_accounts.rs
@@ -8,7 +8,7 @@ use zcash_client_backend::data_api::{Account as _, AccountBirthday, WalletRead, 
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::components::{
-    chain::ZainoChain,
+    chain::{Chain, ChainView, ZainoChain},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,

--- a/zallet/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/recover_accounts.rs
@@ -8,7 +8,7 @@ use zcash_client_backend::data_api::{Account as _, AccountBirthday, WalletRead, 
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::components::{
-    chain::Chain,
+    chain::ZainoChain,
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
@@ -53,7 +53,7 @@ pub(super) const PARAM_ACCOUNTS_REQUIRED: bool = true;
 pub(crate) async fn call(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
-    chain: Chain,
+    chain: ZainoChain,
     accounts: Vec<AccountParameter<'_>>,
 ) -> Response {
     ensure_wallet_is_unlocked(keystore).await?;

--- a/zallet/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet/src/components/json_rpc/methods/recover_accounts.rs
@@ -8,7 +8,7 @@ use zcash_client_backend::data_api::{Account as _, AccountBirthday, WalletRead, 
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::components::{
-    chain::{Chain, ChainView, ZainoChain},
+    chain::{Chain, ChainView},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
@@ -50,10 +50,10 @@ pub(super) const PARAM_ACCOUNTS_DESC: &str =
     "An array of JSON objects representing the accounts to recover.";
 pub(super) const PARAM_ACCOUNTS_REQUIRED: bool = true;
 
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
-    chain: ZainoChain,
+    chain: C,
     accounts: Vec<AccountParameter<'_>>,
 ) -> Response {
     ensure_wallet_is_unlocked(keystore).await?;

--- a/zallet/src/components/json_rpc/methods/view_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/view_transaction.rs
@@ -23,7 +23,7 @@ use zcash_protocol::{
 };
 
 use crate::components::{
-    chain::{Chain, ChainView},
+    chain::{ZainoChain, ZainoChainView},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
@@ -274,7 +274,7 @@ struct AccountEffect {
 
 pub(super) const PARAM_TXID_DESC: &str = "The ID of the transaction to view.";
 
-pub(crate) async fn call(wallet: &DbConnection, chain: Chain, txid_str: &str) -> Response {
+pub(crate) async fn call(wallet: &DbConnection, chain: ZainoChain, txid_str: &str) -> Response {
     let txid = parse_txid(txid_str)?;
 
     let chain_view = chain
@@ -902,7 +902,7 @@ impl WalletTxInfo {
     /// Logic adapted from `WalletTxToJSON` in `zcashd`, to match the semantics of the `gettransaction` fields.
     async fn fetch(
         wallet: &DbConnection,
-        chain_view: &ChainView,
+        chain_view: &ZainoChainView,
         tx: &zcash_primitives::transaction::Transaction,
         chain_height: BlockHeight,
     ) -> Result<Self, SqliteClientError> {

--- a/zallet/src/components/json_rpc/methods/view_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/view_transaction.rs
@@ -23,7 +23,7 @@ use zcash_protocol::{
 };
 
 use crate::components::{
-    chain::{Chain, ChainView, ZainoChain, ZainoChainView},
+    chain::{Chain, ChainView},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
@@ -274,7 +274,7 @@ struct AccountEffect {
 
 pub(super) const PARAM_TXID_DESC: &str = "The ID of the transaction to view.";
 
-pub(crate) async fn call(wallet: &DbConnection, chain: ZainoChain, txid_str: &str) -> Response {
+pub(crate) async fn call<C: Chain>(wallet: &DbConnection, chain: C, txid_str: &str) -> Response {
     let txid = parse_txid(txid_str)?;
 
     let chain_view = chain
@@ -900,9 +900,9 @@ struct WalletTxInfo {
 
 impl WalletTxInfo {
     /// Logic adapted from `WalletTxToJSON` in `zcashd`, to match the semantics of the `gettransaction` fields.
-    async fn fetch(
+    async fn fetch<V: ChainView>(
         wallet: &DbConnection,
-        chain_view: &ZainoChainView,
+        chain_view: &V,
         tx: &zcash_primitives::transaction::Transaction,
         chain_height: BlockHeight,
     ) -> Result<Self, SqliteClientError> {

--- a/zallet/src/components/json_rpc/methods/view_transaction.rs
+++ b/zallet/src/components/json_rpc/methods/view_transaction.rs
@@ -23,7 +23,7 @@ use zcash_protocol::{
 };
 
 use crate::components::{
-    chain::{ZainoChain, ZainoChainView},
+    chain::{Chain, ChainView, ZainoChain, ZainoChainView},
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,

--- a/zallet/src/components/json_rpc/methods/z_import_address.rs
+++ b/zallet/src/components/json_rpc/methods/z_import_address.rs
@@ -3,11 +3,11 @@ use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use crate::components::{chain::ZainoChain, database::DbConnection, json_rpc::server::LegacyCode};
+use crate::components::{chain::Chain, database::DbConnection, json_rpc::server::LegacyCode};
 
 #[cfg(feature = "transparent-key-import")]
 use {
-    crate::components::chain::{Chain, ChainView},
+    crate::components::chain::ChainView,
     crate::network::Network,
     jsonrpsee::types::ErrorCode as RpcErrorCode,
     secp256k1::PublicKey,
@@ -39,9 +39,9 @@ pub(super) const PARAM_RESCAN_DESC: &str =
     "If true (default), rescan the chain for UTXOs belonging to all wallet transparent addresses.";
 
 #[cfg(feature = "transparent-key-import")]
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
-    chain: ZainoChain,
+    chain: C,
     account: &str,
     hex_data: &str,
     rescan: Option<bool>,
@@ -102,9 +102,9 @@ pub(crate) async fn call(
 }
 
 #[cfg(not(feature = "transparent-key-import"))]
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     _wallet: &mut DbConnection,
-    _chain: ZainoChain,
+    _chain: C,
     _account: &str,
     _hex_data: &str,
     _rescan: Option<bool>,

--- a/zallet/src/components/json_rpc/methods/z_import_address.rs
+++ b/zallet/src/components/json_rpc/methods/z_import_address.rs
@@ -7,6 +7,7 @@ use crate::components::{chain::ZainoChain, database::DbConnection, json_rpc::ser
 
 #[cfg(feature = "transparent-key-import")]
 use {
+    crate::components::chain::{Chain, ChainView},
     crate::network::Network,
     jsonrpsee::types::ErrorCode as RpcErrorCode,
     secp256k1::PublicKey,

--- a/zallet/src/components/json_rpc/methods/z_import_address.rs
+++ b/zallet/src/components/json_rpc/methods/z_import_address.rs
@@ -3,7 +3,7 @@ use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use crate::components::{chain::Chain, database::DbConnection, json_rpc::server::LegacyCode};
+use crate::components::{chain::ZainoChain, database::DbConnection, json_rpc::server::LegacyCode};
 
 #[cfg(feature = "transparent-key-import")]
 use {
@@ -40,7 +40,7 @@ pub(super) const PARAM_RESCAN_DESC: &str =
 #[cfg(feature = "transparent-key-import")]
 pub(crate) async fn call(
     wallet: &mut DbConnection,
-    chain: Chain,
+    chain: ZainoChain,
     account: &str,
     hex_data: &str,
     rescan: Option<bool>,
@@ -103,7 +103,7 @@ pub(crate) async fn call(
 #[cfg(not(feature = "transparent-key-import"))]
 pub(crate) async fn call(
     _wallet: &mut DbConnection,
-    _chain: Chain,
+    _chain: ZainoChain,
     _account: &str,
     _hex_data: &str,
     _rescan: Option<bool>,

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -33,7 +33,7 @@ use zcash_protocol::{
 
 use crate::{
     components::{
-        chain::Chain,
+        chain::ZainoChain,
         database::DbHandle,
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
@@ -86,7 +86,7 @@ pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
 pub(crate) async fn call(
     mut wallet: DbHandle,
     keystore: KeyStore,
-    chain: Chain,
+    chain: ZainoChain,
     fromaddress: String,
     amounts: Vec<AmountParameter>,
     minconf: Option<u32>,
@@ -402,7 +402,7 @@ pub(crate) async fn call(
 ///    could also try to use them.
 async fn run(
     mut wallet: DbHandle,
-    chain: Chain,
+    chain: ZainoChain,
     proposal: Proposal<StandardFeeRule, ReceivedNoteId>,
     spending_keys: SpendingKeys,
 ) -> RpcResult<SendResult> {

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -33,7 +33,7 @@ use zcash_protocol::{
 
 use crate::{
     components::{
-        chain::ZainoChain,
+        chain::Chain,
         database::DbHandle,
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
@@ -83,10 +83,10 @@ pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
     "Policy for what information leakage is acceptable.";
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     mut wallet: DbHandle,
     keystore: KeyStore,
-    chain: ZainoChain,
+    chain: C,
     fromaddress: String,
     amounts: Vec<AmountParameter>,
     minconf: Option<u32>,
@@ -400,9 +400,9 @@ pub(crate) async fn call(
 /// 2. #1360 Note selection is not optimal.
 /// 3. #1277 Spendable notes are not locked, so an operation running in parallel
 ///    could also try to use them.
-async fn run(
+async fn run<C: Chain>(
     mut wallet: DbHandle,
-    chain: ZainoChain,
+    chain: C,
     proposal: Proposal<StandardFeeRule, ReceivedNoteId>,
     spending_keys: SpendingKeys,
 ) -> RpcResult<SendResult> {

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -31,7 +31,7 @@ use zcash_protocol::value::Zatoshis;
 use crate::components::json_rpc::payments::enforce_privacy_policy;
 use crate::{
     components::{
-        chain::ZainoChain,
+        chain::Chain,
         database::{DbConnection, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
@@ -141,10 +141,10 @@ pub(super) const PARAM_PRIVACY_POLICY_DESC: &str = "Policy for what information 
 pub(super) const COINBASE_INPUTS_WARN_THRESHOLD: u64 = 400;
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     mut wallet: DbHandle,
     keystore: KeyStore,
-    chain: ZainoChain,
+    chain: C,
     fromaddress: String,
     toaddress: String,
     fee: Option<JsonValue>,
@@ -499,9 +499,9 @@ fn enumerate_eligible(
 }
 
 /// Construct and broadcast the shielding transaction.
-async fn run(
+async fn run<C: Chain>(
     mut wallet: DbHandle,
-    chain: ZainoChain,
+    chain: C,
     proposal: Proposal<StandardFeeRule, Infallible>,
     spending_keys: SpendingKeys,
 ) -> RpcResult<SendResult> {

--- a/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -31,7 +31,7 @@ use zcash_protocol::value::Zatoshis;
 use crate::components::json_rpc::payments::enforce_privacy_policy;
 use crate::{
     components::{
-        chain::Chain,
+        chain::ZainoChain,
         database::{DbConnection, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
@@ -144,7 +144,7 @@ pub(super) const COINBASE_INPUTS_WARN_THRESHOLD: u64 = 400;
 pub(crate) async fn call(
     mut wallet: DbHandle,
     keystore: KeyStore,
-    chain: Chain,
+    chain: ZainoChain,
     fromaddress: String,
     toaddress: String,
     fee: Option<JsonValue>,
@@ -501,7 +501,7 @@ fn enumerate_eligible(
 /// Construct and broadcast the shielding transaction.
 async fn run(
     mut wallet: DbHandle,
-    chain: Chain,
+    chain: ZainoChain,
     proposal: Proposal<StandardFeeRule, Infallible>,
     spending_keys: SpendingKeys,
 ) -> RpcResult<SendResult> {

--- a/zallet/src/components/json_rpc/payments.rs
+++ b/zallet/src/components/json_rpc/payments.rs
@@ -9,7 +9,7 @@ use zcash_keys::address::Address;
 use zcash_protocol::{PoolType, ShieldedProtocol, TxId, memo::MemoBytes};
 
 use crate::{
-    components::{chain::Chain, database::DbConnection},
+    components::{chain::ZainoChain, database::DbConnection},
     fl,
     prelude::APP,
 };
@@ -457,7 +457,7 @@ pub(super) fn get_account_for_address(
 /// Broadcasts the specified transactions to the network, if configured to do so.
 pub(super) async fn broadcast_transactions(
     wallet: &DbConnection,
-    chain: Chain,
+    chain: ZainoChain,
     txids: Vec<TxId>,
 ) -> RpcResult<SendResult> {
     if APP.config().external.broadcast() {

--- a/zallet/src/components/json_rpc/payments.rs
+++ b/zallet/src/components/json_rpc/payments.rs
@@ -9,10 +9,7 @@ use zcash_keys::address::Address;
 use zcash_protocol::{PoolType, ShieldedProtocol, TxId, memo::MemoBytes};
 
 use crate::{
-    components::{
-        chain::{Chain, ZainoChain},
-        database::DbConnection,
-    },
+    components::{chain::Chain, database::DbConnection},
     fl,
     prelude::APP,
 };
@@ -458,9 +455,9 @@ pub(super) fn get_account_for_address(
 }
 
 /// Broadcasts the specified transactions to the network, if configured to do so.
-pub(super) async fn broadcast_transactions(
+pub(super) async fn broadcast_transactions<C: Chain>(
     wallet: &DbConnection,
-    chain: ZainoChain,
+    chain: C,
     txids: Vec<TxId>,
 ) -> RpcResult<SendResult> {
     if APP.config().external.broadcast() {

--- a/zallet/src/components/json_rpc/payments.rs
+++ b/zallet/src/components/json_rpc/payments.rs
@@ -9,7 +9,10 @@ use zcash_keys::address::Address;
 use zcash_protocol::{PoolType, ShieldedProtocol, TxId, memo::MemoBytes};
 
 use crate::{
-    components::{chain::ZainoChain, database::DbConnection},
+    components::{
+        chain::{Chain, ZainoChain},
+        database::DbConnection,
+    },
     fl,
     prelude::APP,
 };

--- a/zallet/src/components/json_rpc/server.rs
+++ b/zallet/src/components/json_rpc/server.rs
@@ -7,7 +7,7 @@ use jsonrpsee::{
 use tokio::task::JoinHandle;
 
 use crate::{
-    components::{chain::ZainoChain, database::Database},
+    components::{chain::Chain, database::Database},
     config::RpcSection,
     error::{Error, ErrorKind},
     fl,
@@ -30,11 +30,11 @@ mod rpc_call_compatibility;
 
 type ServerTask = JoinHandle<Result<(), Error>>;
 
-pub(crate) async fn spawn(
+pub(crate) async fn spawn<C: Chain>(
     config: RpcSection,
     wallet: Database,
     #[cfg(zallet_build = "wallet")] keystore: KeyStore,
-    chain: ZainoChain,
+    chain: C,
 ) -> Result<ServerTask, Error> {
     // Caller should make sure `bind` only contains a single address (for now).
     assert_eq!(config.bind.len(), 1);

--- a/zallet/src/components/json_rpc/server.rs
+++ b/zallet/src/components/json_rpc/server.rs
@@ -7,7 +7,7 @@ use jsonrpsee::{
 use tokio::task::JoinHandle;
 
 use crate::{
-    components::{chain::Chain, database::Database},
+    components::{chain::ZainoChain, database::Database},
     config::RpcSection,
     error::{Error, ErrorKind},
     fl,
@@ -34,7 +34,7 @@ pub(crate) async fn spawn(
     config: RpcSection,
     wallet: Database,
     #[cfg(zallet_build = "wallet")] keystore: KeyStore,
-    chain: Chain,
+    chain: ZainoChain,
 ) -> Result<ServerTask, Error> {
     // Caller should make sure `bind` only contains a single address (for now).
     assert_eq!(config.bind.len(), 1);

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -54,7 +54,7 @@ use zip32::Scope;
 
 use super::{
     TaskHandle,
-    chain::{ChainBlock, ChainError, ZainoChain},
+    chain::{Chain, ChainBlock, ChainError, ChainView, ZainoChain},
     database::{Database, DbConnection},
 };
 use crate::{config::ZalletConfig, error::Error, network::Network};

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -28,7 +28,7 @@
 //! TODO: Integrate or remove these other notes:
 //!
 //! - Zebra discards the non-finalized chain tip on restart, so Zallet needs to tolerate
-//!   the `ChainView` being up to 100 blocks behind the wallet's view of the chain tip at
+//!   the `ZainoChainView` being up to 100 blocks behind the wallet's view of the chain tip at
 //!   process start.
 
 use std::sync::{
@@ -54,7 +54,7 @@ use zip32::Scope;
 
 use super::{
     TaskHandle,
-    chain::{Chain, ChainBlock},
+    chain::{ChainBlock, ZainoChain},
     database::{Database, DbConnection},
 };
 use crate::{
@@ -79,7 +79,7 @@ impl WalletSync {
     pub(crate) async fn spawn(
         config: &ZalletConfig,
         db: Database,
-        chain: Chain,
+        chain: ZainoChain,
     ) -> Result<(TaskHandle, TaskHandle, TaskHandle, TaskHandle), Error> {
         let params = config.consensus.network();
 
@@ -179,7 +179,7 @@ fn update_boundary(current_boundary: BlockHeight, tip_height: BlockHeight) -> Bl
 /// Returns the boundary block between [`steady_state`] and [`recover_history`] syncing.
 #[tracing::instrument(skip_all)]
 async fn initialize(
-    chain: &Chain,
+    chain: &ZainoChain,
     params: &Network,
     db_data: &mut DbConnection,
     decryptor: decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
@@ -239,7 +239,7 @@ async fn initialize(
 /// Keeps the wallet state up-to-date with the chain tip, and handles the mempool.
 #[tracing::instrument(skip_all)]
 async fn steady_state(
-    chain: Chain,
+    chain: ZainoChain,
     params: &Network,
     db_data: &mut DbConnection,
     mut prev_tip: ChainBlock,
@@ -363,7 +363,7 @@ async fn steady_state(
 /// This function only operates on finalized chain state, and does not handle reorgs.
 #[tracing::instrument(skip_all)]
 async fn recover_history(
-    chain: Chain,
+    chain: ZainoChain,
     params: &Network,
     db_data: &mut DbConnection,
     upper_boundary: Arc<AtomicU32>,
@@ -432,7 +432,7 @@ async fn recover_history(
 /// history.
 #[tracing::instrument(skip_all)]
 async fn data_requests(
-    chain: Chain,
+    chain: ZainoChain,
     params: &Network,
     db_data: &mut DbConnection,
     tip_change_signal: Arc<Notify>,

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -54,7 +54,7 @@ use zip32::Scope;
 
 use super::{
     TaskHandle,
-    chain::{Chain, ChainBlock, ChainError, ChainView, ZainoChain},
+    chain::{Chain, ChainBlock, ChainError, ChainView},
     database::{Database, DbConnection},
 };
 use crate::{config::ZalletConfig, error::Error, network::Network};
@@ -72,10 +72,10 @@ const RECOVER_BATCH_SIZE: u32 = 1000;
 pub(crate) struct WalletSync {}
 
 impl WalletSync {
-    pub(crate) async fn spawn(
+    pub(crate) async fn spawn<C: Chain>(
         config: &ZalletConfig,
         db: Database,
-        chain: ZainoChain,
+        chain: C,
     ) -> Result<(TaskHandle, TaskHandle, TaskHandle, TaskHandle), Error> {
         let params = config.consensus.network();
 
@@ -174,8 +174,8 @@ fn update_boundary(current_boundary: BlockHeight, tip_height: BlockHeight) -> Bl
 ///
 /// Returns the boundary block between [`steady_state`] and [`recover_history`] syncing.
 #[tracing::instrument(skip_all)]
-async fn initialize(
-    chain: &ZainoChain,
+async fn initialize<C: Chain>(
+    chain: &C,
     params: &Network,
     db_data: &mut DbConnection,
     decryptor: decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
@@ -234,8 +234,8 @@ async fn initialize(
 
 /// Keeps the wallet state up-to-date with the chain tip, and handles the mempool.
 #[tracing::instrument(skip_all)]
-async fn steady_state(
-    chain: ZainoChain,
+async fn steady_state<C: Chain>(
+    chain: C,
     params: &Network,
     db_data: &mut DbConnection,
     mut prev_tip: ChainBlock,
@@ -354,8 +354,8 @@ async fn steady_state(
 ///
 /// This function only operates on finalized chain state, and does not handle reorgs.
 #[tracing::instrument(skip_all)]
-async fn recover_history(
-    chain: ZainoChain,
+async fn recover_history<C: Chain>(
+    chain: C,
     params: &Network,
     db_data: &mut DbConnection,
     upper_boundary: Arc<AtomicU32>,
@@ -423,8 +423,8 @@ async fn recover_history(
 /// Fetches information that the wallet requests to complete its view of transaction
 /// history.
 #[tracing::instrument(skip_all)]
-async fn data_requests(
-    chain: ZainoChain,
+async fn data_requests<C: Chain>(
+    chain: C,
     params: &Network,
     db_data: &mut DbConnection,
     tip_change_signal: Arc<Notify>,

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -54,14 +54,10 @@ use zip32::Scope;
 
 use super::{
     TaskHandle,
-    chain::{ChainBlock, ZainoChain},
+    chain::{ChainBlock, ChainError, ZainoChain},
     database::{Database, DbConnection},
 };
-use crate::{
-    config::ZalletConfig,
-    error::{Error, ErrorKind},
-    network::Network,
-};
+use crate::{config::ZalletConfig, error::Error, network::Network};
 
 mod error;
 pub(crate) use error::SyncError;
@@ -279,15 +275,11 @@ async fn steady_state(
                 .await
                 .map_err(SyncError::Chain)?
                 .ok_or_else(|| {
-                    SyncError::Chain(
-                        ErrorKind::Sync
-                            .context(format!(
-                                "Could not determine the reorg point: the wallet's previous \
-                                 chain tip {} (height {}) is not known to the chain indexer",
-                                prev_tip.hash, prev_tip.height,
-                            ))
-                            .into(),
-                    )
+                    SyncError::Chain(ChainError::backend(format!(
+                        "Could not determine the reorg point: the wallet's previous \
+                         chain tip {} (height {}) is not known to the chain indexer",
+                        prev_tip.hash, prev_tip.height,
+                    )))
                 })?;
             assert!(fork_point.height <= current_tip.height);
 

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -28,7 +28,7 @@
 //! TODO: Integrate or remove these other notes:
 //!
 //! - Zebra discards the non-finalized chain tip on restart, so Zallet needs to tolerate
-//!   the `ZainoChainView` being up to 100 blocks behind the wallet's view of the chain tip at
+//!   the `ChainView` being up to 100 blocks behind the wallet's view of the chain tip at
 //!   process start.
 
 use std::sync::{

--- a/zallet/src/components/sync/error.rs
+++ b/zallet/src/components/sync/error.rs
@@ -4,12 +4,12 @@ use shardtree::error::ShardTreeError;
 use zcash_client_backend::scanning::ScanError;
 use zcash_client_sqlite::error::SqliteClientError;
 
-use crate::error::Error;
+use crate::components::chain::ChainError;
 
 #[derive(Debug)]
 pub(crate) enum SyncError {
     BatchDecryptorUnavailable,
-    Chain(Error),
+    Chain(ChainError),
     Scan(ScanError),
     Tree(Box<ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>>),
     Other(Box<SqliteClientError>),

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -19,7 +19,7 @@ use zip32::Scope;
 
 use crate::{
     components::{
-        chain::{Chain, ChainView},
+        chain::{ZainoChain, ZainoChainView},
         database::DbConnection,
     },
     error::ErrorKind,
@@ -29,7 +29,7 @@ use crate::{
 use super::{SyncError, decryptor};
 
 pub(super) async fn update_subtree_roots(
-    chain: &Chain,
+    chain: &ZainoChain,
     db_data: &mut DbConnection,
 ) -> Result<(), SyncError> {
     // TODO: Query and insert only the subtree roots added since our last query (via the
@@ -83,7 +83,7 @@ fn scan_block_error(e: ScanBlockError<Infallible>) -> SyncError {
 
 /// Scans a contiguous sequence of blocks in the main chain.
 pub(super) async fn scan_blocks(
-    chain_view: ChainView,
+    chain_view: ZainoChainView,
     db_data: &mut DbConnection,
     params: &Network,
     scan_range: &ScanRange,
@@ -161,7 +161,7 @@ pub(super) async fn scan_blocks(
 
 /// Scans a block in the main chain.
 pub(super) async fn scan_block(
-    chain_view: &ChainView,
+    chain_view: &ZainoChainView,
     db_data: &mut DbConnection,
     params: &Network,
     block: Block,

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -19,7 +19,7 @@ use zip32::Scope;
 
 use crate::{
     components::{
-        chain::{ChainError, ZainoChain, ZainoChainView},
+        chain::{Chain, ChainError, ChainView, ZainoChain, ZainoChainView},
         database::DbConnection,
     },
     network::Network,

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -19,7 +19,7 @@ use zip32::Scope;
 
 use crate::{
     components::{
-        chain::{Chain, ChainError, ChainView, ZainoChain, ZainoChainView},
+        chain::{Chain, ChainError, ChainView},
         database::DbConnection,
     },
     network::Network,
@@ -27,8 +27,8 @@ use crate::{
 
 use super::{SyncError, decryptor};
 
-pub(super) async fn update_subtree_roots(
-    chain: &ZainoChain,
+pub(super) async fn update_subtree_roots<C: Chain>(
+    chain: &C,
     db_data: &mut DbConnection,
 ) -> Result<(), SyncError> {
     // TODO: Query and insert only the subtree roots added since our last query (via the
@@ -81,8 +81,8 @@ fn scan_block_error(e: ScanBlockError<Infallible>) -> SyncError {
 }
 
 /// Scans a contiguous sequence of blocks in the main chain.
-pub(super) async fn scan_blocks(
-    chain_view: ZainoChainView,
+pub(super) async fn scan_blocks<V: ChainView>(
+    chain_view: V,
     db_data: &mut DbConnection,
     params: &Network,
     scan_range: &ScanRange,
@@ -159,8 +159,8 @@ pub(super) async fn scan_blocks(
 }
 
 /// Scans a block in the main chain.
-pub(super) async fn scan_block(
-    chain_view: &ZainoChainView,
+pub(super) async fn scan_block<V: ChainView>(
+    chain_view: &V,
     db_data: &mut DbConnection,
     params: &Network,
     block: Block,

--- a/zallet/src/components/sync/steps.rs
+++ b/zallet/src/components/sync/steps.rs
@@ -19,10 +19,9 @@ use zip32::Scope;
 
 use crate::{
     components::{
-        chain::{ZainoChain, ZainoChainView},
+        chain::{ChainError, ZainoChain, ZainoChainView},
         database::DbConnection,
     },
-    error::ErrorKind,
     network::Network,
 };
 
@@ -77,7 +76,7 @@ fn scan_block_error(e: ScanBlockError<Infallible>) -> SyncError {
         ScanBlockError::Scan(e) => SyncError::Scan(e),
         // The address lookup is infallible, and `ScanBlockError` is non-exhaustive, so
         // map any future variants to a generic error rather than panicking.
-        other => SyncError::Chain(ErrorKind::Sync.context(other.to_string()).into()),
+        other => SyncError::Chain(ChainError::backend(other.to_string())),
     }
 }
 
@@ -174,11 +173,9 @@ pub(super) async fn scan_block(
         .await
         .map_err(SyncError::Chain)?
         .ok_or_else(|| {
-            SyncError::Chain(
-                ErrorKind::Sync
-                    .context("Programming error: tried to scan block ahead of the chain view's tip")
-                    .into(),
-            )
+            SyncError::Chain(ChainError::backend(
+                "Programming error: tried to scan block ahead of the chain view's tip",
+            ))
         })?;
 
     info!("Scanning block {} ({})", height, block.header().hash());

--- a/zallet/src/error.rs
+++ b/zallet/src/error.rs
@@ -33,6 +33,7 @@ macro_rules! wlnfl {
 pub(crate) enum ErrorKind {
     Generic,
     Init,
+    Chain,
     #[cfg(feature = "rpc-cli")]
     RpcCli(RpcCliError),
     Sync,
@@ -43,6 +44,7 @@ impl fmt::Display for ErrorKind {
         match self {
             ErrorKind::Generic => wfl!(f, "err-kind-generic"),
             ErrorKind::Init => wfl!(f, "err-kind-init"),
+            ErrorKind::Chain => wfl!(f, "err-kind-chain"),
             #[cfg(feature = "rpc-cli")]
             ErrorKind::RpcCli(e) => e.fmt(f),
             ErrorKind::Sync => wfl!(f, "err-kind-sync"),


### PR DESCRIPTION
## Summary

Introduces a backend-neutral trait boundary for chain-data access, as groundwork for feature-flagging the Zaino dependency and adding an alternative `zebra-state` + Zebra-RPC backend.

- `components/chain.rs` is now the **interface**: the `Chain` and `ChainView` traits plus a semantic `ChainError` ADT (`Unavailable` / `InvalidData` / `Backend`). It has zero `zaino_*` imports.
- The existing Zaino implementation moves into `components/chain/zaino.rs` as `ZainoChain` / `ZainoChainView`, implementing the traits.
- The sync engine and the **entire JSON-RPC layer** are now generic over `<C: Chain>`; the concrete `ZainoChain` is named only at the two construction sites (`start`, `migrate-zcashd-wallet`).

No public API changes — the chain types were already `pub(crate)`.

## Commits

1. `chain:` rename concrete `Chain`/`ChainView` → `ZainoChain`/`ZainoChainView`
2. `chain:` introduce `ChainError` and use it across the chain layer (+ `ErrorKind::Chain`)
3. `chain:` extract `Chain`/`ChainView` traits; move Zaino impl to `chain/zaino.rs`
4. `sync:` make the sync engine generic over `Chain`/`ChainView`
5. `rpc:` make the JSON-RPC layer generic over `Chain`

## Design notes

- Trait methods are declared `fn … -> impl Future<…> + Send` (rather than `async fn`) so the generic sync futures are `Send` and spawnable on the tokio runtime.
- Stream methods return `BoxStream<'_, …>` rather than associated stream types, because the block/mempool streams borrow the pinned view and so cannot be `'static`.
- `find_fork_point` keeps a single-hash signature. Zebra's non-finalized state retains all forks back to the finalized tip, so a small upstream `ReadRequest` can satisfy it for the future `zebra-state` backend (no locator threading needed in the wallet).
- A `MockChainView` unit test locks the `ChainView` contract and proves the trait is implementable by a non-Zaino backend.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default features)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
