### PR TITLE
sync: fix ChainError conversion in initialize tip scan

### DIFF
--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -245,15 +245,11 @@ async fn initialize<C: Chain>(
                             .await
                             .map_err(SyncError::Chain)?
                             .ok_or_else(|| {
-                                SyncError::Chain(
-                                    ErrorKind::Sync
-                                        .context(format!(
-                                            "chain view did not return its own tip \
-                                             block at height {}",
-                                            current_tip.height
-                                        ))
-                                        .into(),
-                                )
+                                SyncError::Chain(ChainError::backend(format!(
+                                    "chain view did not return its own tip \
+                                     block at height {}",
+                                    current_tip.height
+                                )))
                             })?;
                         steps::scan_block(&chain_view, db_data, params, tip_block, &decryptor).await
                     };


### PR DESCRIPTION
`ErrorKind::Sync.context(...).into()` cannot convert to `ChainError` since that trait bound is not implemented. Use `ChainError::backend` instead, consistent with the existing pattern in the same function.

solves DVRL-61