### PR TITLE
migrate: use the db_dump vendored by zewif-zcashd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7340,7 +7340,6 @@ dependencies = [
  "tracing-subscriber",
  "trycmd",
  "uuid",
- "which 8.0.0",
  "xdg 2.5.2",
  "zaino-common",
  "zaino-fetch",

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -141,7 +141,6 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 transparent.workspace = true
 uuid.workspace = true
-which = { workspace = true, optional = true }
 xdg.workspace = true
 zaino-common.workspace = true
 zaino-fetch.workspace = true
@@ -220,7 +219,6 @@ transparent-key-import = [
 ## Allows `zallet` to import zcashd wallets.
 zcashd-import = [
   "transparent-key-import",
-  "dep:which",
   "dep:zewif",
   "dep:zewif-zcashd",
   "zcash_client_backend/zcashd-compat",

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -106,52 +106,48 @@ impl MigrateZcashdWalletCmd {
             self.path.to_path_buf()
         };
 
-        let db_dump_path = match &self.zcashd_install_dir {
+        // Resolve the `db_dump` utility. An explicit `--zcashd-install-dir` uses that
+        // installation's binary; otherwise prefer the BDB 6.2 `db_dump` vendored by
+        // `zewif-zcashd` (via `BDBDump::from_file`), which falls back to one on the `PATH`.
+        let db_dump = match &self.zcashd_install_dir {
             Some(path) => {
                 let db_dump_path = path.join("zcutil").join("bin").join("db_dump");
-                db_dump_path
-                    .is_file()
-                    .then_some(db_dump_path)
-                    .ok_or(which::Error::CannotFindBinaryPath)
-            }
-            None => which::which("db_dump"),
-        };
-
-        if let Ok(db_dump_path) = db_dump_path {
-            let db_dump =
+                if !db_dump_path.is_file() {
+                    return Err(MigrateError::Wrapped(
+                        ErrorKind::Generic
+                            .context(fl!("err-migrate-wallet-db-dump-not-found"))
+                            .into(),
+                    ));
+                }
                 BDBDump::from_file_with_path(db_dump_path.as_path(), wallet_path.as_path())
-                    .map_err(|e| MigrateError::Zewif {
-                        error_type: ZewifError::BdbDump,
-                        wallet_path: wallet_path.to_path_buf(),
-                        error: e,
-                    })?;
-
-            let zcashd_dump =
-                ZcashdDump::from_bdb_dump(&db_dump, self.allow_warnings).map_err(|e| {
-                    MigrateError::Zewif {
-                        error_type: ZewifError::ZcashdDump,
-                        wallet_path: wallet_path.clone(),
-                        error: e,
-                    }
-                })?;
-
-            let (zcashd_wallet, _unparsed_keys) =
-                ZcashdParser::parse_dump(&zcashd_dump, !self.allow_warnings).map_err(|e| {
-                    MigrateError::Zewif {
-                        error_type: ZewifError::ZcashdDump,
-                        wallet_path,
-                        error: e,
-                    }
-                })?;
-
-            Ok(zcashd_wallet)
-        } else {
-            Err(MigrateError::Wrapped(
-                ErrorKind::Generic
-                    .context(fl!("err-migrate-wallet-db-dump-not-found"))
-                    .into(),
-            ))
+            }
+            None => BDBDump::from_file(wallet_path.as_path()),
         }
+        .map_err(|e| MigrateError::Zewif {
+            error_type: ZewifError::BdbDump,
+            wallet_path: wallet_path.to_path_buf(),
+            error: e,
+        })?;
+
+        let zcashd_dump =
+            ZcashdDump::from_bdb_dump(&db_dump, self.allow_warnings).map_err(|e| {
+                MigrateError::Zewif {
+                    error_type: ZewifError::ZcashdDump,
+                    wallet_path: wallet_path.clone(),
+                    error: e,
+                }
+            })?;
+
+        let (zcashd_wallet, _unparsed_keys) =
+            ZcashdParser::parse_dump(&zcashd_dump, !self.allow_warnings).map_err(|e| {
+                MigrateError::Zewif {
+                    error_type: ZewifError::ZcashdDump,
+                    wallet_path,
+                    error: e,
+                }
+            })?;
+
+        Ok(zcashd_wallet)
     }
 
     fn check_network(


### PR DESCRIPTION
The migrate-zcashd-wallet command resolved db_dump itself (zcashd's zcutil/bin/db_dump, or `which db_dump` on PATH) and called BDBDump::from_file_with_path, so it never used the BDB 6.2 db_dump that zewif-zcashd's build.rs vendors. Without an external db_dump — e.g. a zcashd checkout that hasn't built it, or only the BDB 5.3 db_dump on PATH — the command failed.

Use BDBDump::from_file for the default path, which prefers the vendored db_dump (via option_env!("DB_DUMP_PATH")) and falls back to one on PATH; keep --zcashd-install-dir as an explicit override. The `which` dependency is no longer used and is dropped.