### PR TITLE
chain: Give Zaino finalised-state DB a non-zero LMDB map size

### DIFF
--- a/zallet/src/components/chain/zaino.rs
+++ b/zallet/src/components/chain/zaino.rs
@@ -50,10 +50,9 @@ fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
 
 /// The Zaino finalised-state database schema version to target.
 ///
-/// `1` selects Zaino's latest v1 finalised-state schema. We run the indexer in ephemeral
-/// mode (see [`BlockCacheConfig::new`] below), so no persistent finalised-state database
-/// is actually opened and this value has no on-disk effect; it is set to the current
-/// schema version for forward-compatibility if ephemeral mode is ever disabled.
+/// `1` selects Zaino's latest v1 finalised-state schema. The pinned Zaino always opens the
+/// persistent v1 finalised-state DB (the no-sync flag passed to [`BlockCacheConfig::new`]
+/// below is currently ignored), so this selects the on-disk schema version that is created.
 const ZAINO_FINALISED_DB_VERSION: u32 = 1;
 
 #[derive(Clone)]
@@ -147,18 +146,19 @@ impl ZainoChain {
                 cache: CacheConfig::default(),
                 database: DatabaseConfig {
                     path: config.indexer_db_path().to_path_buf(),
-                    // Unused in ephemeral mode (no persistent finalised-state
-                    // database is opened).
-                    size: zaino_common::DatabaseSize(0),
-                    // Unused in ephemeral mode (the finalised-state bulk-sync
-                    // write path is never exercised); inherit Zaino's default.
+                    // The pinned Zaino ignores the no-sync flag below and always opens the
+                    // persistent v1 finalised-state DB, sizing its LMDB map from this value.
+                    // A size of 0 makes LMDB fall back to its ~10 MiB default, which fills
+                    // after a few hundred blocks and dies with `MapFull`. Inherit Zaino's
+                    // default map size (a sparse virtual reservation) so the map never fills.
                     ..Default::default()
                 },
             },
             ZAINO_FINALISED_DB_VERSION,
             params.to_zaino(),
-            // Run the finalised state ephemerally: no persistent database, finalised
-            // reads are served from the backing validator.
+            // No-sync flag. The pinned Zaino discards this argument, so the persistent v1
+            // finalised-state DB is opened and synced regardless; it is sized by the
+            // `database.size` above.
             true,
         );
 


### PR DESCRIPTION
## What

One line: stop sizing the in-process Zaino finalised-state DB at `0`. Inherit Zaino's default map size instead.

```diff
  database: DatabaseConfig {
      path: config.indexer_db_path().to_path_buf(),
-     size: zaino_common::DatabaseSize(0),
      ..Default::default()
  },
```

## Why

Zallet built from `main` crashes deterministically a few hundred regtest blocks into a sync:

```
…finalised_state::db::v1::write_core: syncing finalised blocks …
…chain_index: Sync loop iteration failed … ErrorFromSource(LmdbError(MapFull))
Sync loop failed 10 consecutive times, giving up
Exiting Zallet because an ongoing task exited
```

The chain-indexer task exits, Zallet exits, and the wallet RPC disappears.

**Root cause.** We configured the indexer assuming it runs ephemerally — `DatabaseSize(0)`, plus `true` for the no-sync flag, on the premise that no persistent DB is opened. The pinned Zaino (`zingolabs/zaino@1f068945`) does not honour that premise:

- `BlockCacheConfig::new(storage, db_version, network, _no_sync)` **discards** `_no_sync`, so the persistent v1 finalised-state LMDB DB is always opened.
- Its map size comes from `database.size`, and `DatabaseSize(0).to_byte_count() == 0`.
- LMDB treats a `0` map size as its ~10 MiB default — which fills after a few hundred blocks → `MapFull`.

Inheriting the default map size (a sparse virtual reservation, the same default `zainod` uses) means the map never fills. Comments in the file are updated to describe what the pinned Zaino actually does — the previous "ephemeral / no persistent DB" wording was inaccurate against this pin.

## Verification

Ran `wallet_z_shieldcoinbase.py` (zcash/integration-tests #140) locally on regtest — same machine, same Zaino pin, same binary build — toggling only this one line:

| Build | Result |
| --- | --- |
| `main` as-is (`size = 0`) | wallet RPC dies mid-test, `wait_for_mature_coinbase_count` times out after 300s → **Failed** |
| with this fix | **All z_shieldcoinbase tests passed!** — no `MapFull` |

## Follow-up (not this PR)

The underlying defect is upstream: Zaino's `BlockCacheConfig::new` takes a no-sync argument it silently ignores. Worth a `zingolabs/zaino` fix to either honour the flag or clamp a `0` map size to a sane minimum, so the next caller can't hit this.