### PR TITLE
tui: Add an interactive terminal UI behind a `tui` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ be considered breaking changes.
   is generated on startup and written to `{datadir}/.cookie`, enabling
   `zallet rpc` to authenticate automatically without manual password setup.
   Cookie auth coexists with configured `[[rpc.auth]]` users.
+- An interactive terminal UI, available as `zallet tui` when built with the
+  `tui` feature. It connects to a Zallet JSON-RPC interface: either an
+  in-process server it spawns itself (the default, on the configured loopback
+  `rpc.bind` address, authenticating via the RPC cookie), or a remote `zallet
+  start` instance via `--rpc-url`. It provides dashboard, accounts, balances,
+  receive (with QR codes and a per-account selector), transactions, send, and
+  logs views, with a persistent wallet-wide sync indicator.
 - RPC methods:
   - `decoderawtransaction`
   - `decodescript`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,6 +844,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1036,20 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "console"
@@ -1252,6 +1281,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1344,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1358,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -1591,7 +1646,7 @@ dependencies = [
  "optfield",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.27.2",
  "syn 2.0.108",
 ]
 
@@ -2311,6 +2366,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2871,12 +2928,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2951,6 +3030,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3312,6 +3400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3426,6 +3523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -4288,6 +4386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quickcheck"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4503,6 +4607,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -5406,6 +5531,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5659,11 +5805,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -6448,6 +6616,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6804,6 +6995,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6811,6 +7018,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -7285,6 +7498,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "console-subscriber",
+ "crossterm",
  "deadpool",
  "deadpool-sqlite",
  "deadpool-sync",
@@ -7308,8 +7522,10 @@ dependencies = [
  "once_cell",
  "orchard",
  "phf 0.12.1",
+ "qrcode",
  "quote",
  "rand 0.8.5",
+ "ratatui",
  "regex",
  "rpassword",
  "rusqlite",
@@ -7698,7 +7914,7 @@ dependencies = [
  "sha2 0.10.9",
  "sinsemilla",
  "static_assertions",
- "strum",
+ "strum 0.27.2",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -7845,8 +8061,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,11 @@ rust_decimal = { version = "1.37", default-features = false, features = [
 schemars = "1"
 tower = "0.4"
 
+# Terminal UI
+crossterm = "0.28"
+qrcode = { version = "0.14", default-features = false }
+ratatui = "0.29"
+
 # Testing
 once_cell = "1.2"
 regex = "1.4"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -260,6 +260,14 @@ criteria = "safe-to-deploy"
 version = "0.1.9"
 criteria = "safe-to-deploy"
 
+[[exemptions.cassowary]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.castaway]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.cbc]]
 version = "0.1.2"
 criteria = "safe-to-deploy"
@@ -314,6 +322,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.colorchoice]]
 version = "1.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.compact_str]]
+version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.console]]
@@ -396,6 +408,14 @@ criteria = "safe-to-deploy"
 version = "0.8.20"
 criteria = "safe-to-deploy"
 
+[[exemptions.crossterm]]
+version = "0.28.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossterm_winapi]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.crypto-bigint]]
 version = "0.5.5"
 criteria = "safe-to-deploy"
@@ -421,15 +441,15 @@ version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling]]
-version = "0.20.11"
+version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_core]]
-version = "0.20.11"
+version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_macro]]
-version = "0.20.11"
+version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.dashmap]]
@@ -550,14 +570,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
 version = "0.6.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-iterator]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-streaming-iterator]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.ff]]
@@ -792,6 +804,14 @@ criteria = "safe-to-deploy"
 version = "1.9.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.indoc]]
+version = "2.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.instability]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
 [[exemptions.interprocess]]
 version = "2.2.3"
 criteria = "safe-to-deploy"
@@ -822,6 +842,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
 version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
@@ -926,6 +950,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.lock_api]]
 version = "0.4.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.lru]]
+version = "0.12.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.lz4-sys]]
@@ -1220,6 +1248,10 @@ criteria = "safe-to-deploy"
 version = "21.1.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.qrcode]]
+version = "0.14.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.quickcheck]]
 version = "0.9.2"
 criteria = "safe-to-deploy"
@@ -1266,6 +1298,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand_xoshiro]]
 version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ratatui]]
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.recvmsg]]
@@ -1506,6 +1542,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.shadow-rs]]
 version = "1.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.signal-hook]]
+version = "0.3.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.signal-hook-mio]]
+version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.signal-hook-registry]]
@@ -1772,6 +1816,10 @@ criteria = "safe-to-deploy"
 version = "2.9.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.unicode-truncate]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.untrusted]]
 version = "0.9.0"
 criteria = "safe-to-deploy"
@@ -1864,8 +1912,20 @@ criteria = "safe-to-deploy"
 version = "1.2.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.winapi-util]]
 version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.winnow]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -64,6 +64,20 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
+[[publisher.unicode-width]]
+version = "0.1.14"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.2.0"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
 [[publisher.unicode-xid]]
 version = "0.2.6"
 when = "2024-09-19"
@@ -469,6 +483,16 @@ notes = "Just a dependency version bump and a bug fix for redox"
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.9 -> 0.3.10"
+
+[[audits.bytecode-alliance.audits.fallible-iterator]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+notes = """
+This major version update has a few minor breaking changes but everything
+this crate has to do with iterators and `Result` and such. No `unsafe` or
+anything like that, all looks good.
+"""
 
 [[audits.bytecode-alliance.audits.fastrand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2265,6 +2289,15 @@ end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.wildcard-audits.unicode-width]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-12-05"
+end = "2026-02-01"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.wildcard-audits.unicode-xid]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2492,6 +2525,78 @@ criteria = "safe-to-deploy"
 delta = "0.1.3 -> 0.1.6"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.darling]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.13.4 -> 0.14.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.2 -> 0.14.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.3 -> 0.20.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.20.1 -> 0.20.10"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.13.4 -> 0.14.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.2 -> 0.14.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.3 -> 0.20.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_core]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.20.1 -> 0.20.10"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_macro]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.13.4 -> 0.14.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_macro]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.2 -> 0.14.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_macro]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.3 -> 0.20.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.darling_macro]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.20.1 -> 0.20.10"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.deranged]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -2532,6 +2637,18 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-streaming-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.9"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fastrand]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -174,6 +174,11 @@ anyhow.workspace = true
 console-subscriber = { workspace = true, optional = true }
 jsonrpsee-http-client = { workspace = true, optional = true }
 
+# Terminal UI (feature = "tui")
+crossterm = { workspace = true, optional = true, features = ["event-stream"] }
+qrcode = { workspace = true, optional = true }
+ratatui = { workspace = true, optional = true }
+
 [build-dependencies]
 clap = { workspace = true, features = ["string", "unstable-styles"] }
 clap_complete.workspace = true
@@ -198,6 +203,18 @@ trycmd.workspace = true
 [features]
 ## `zallet rpc` CLI support
 rpc-cli = ["jsonrpsee/async-client", "dep:jsonrpsee-http-client"]
+
+## Terminal UI (`zallet tui`)
+##
+## Provides an interactive terminal frontend for the wallet. It connects to a
+## Zallet JSON-RPC interface: either an in-process server it spawns itself
+## (the default), or a remote `zallet start` instance (via `--rpc-url`).
+tui = [
+  "rpc-cli",
+  "dep:crossterm",
+  "dep:qrcode",
+  "dep:ratatui",
+]
 
 ## `tokio-console` support
 ##

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -307,3 +307,224 @@ man-zallet-about = A {-zcash} wallet.
 
 man-zallet-description =
     {-zallet} is a {-zcash} wallet.
+
+## Interactive terminal UI (`zallet tui`)
+
+# Terms (not to be localized)
+-tui-rpc-url = --rpc-url
+
+# View / tab titles
+tui-view-dashboard = Dashboard
+tui-view-accounts = Accounts
+tui-view-balances = Balances
+tui-view-receive = Receive
+tui-view-transactions = Transactions
+tui-view-send = Send
+tui-view-logs = Logs
+
+# Sync status labels
+tui-sync-synced = Synced
+tui-sync-syncing = Syncing…
+tui-sync-percent = Sync {$percent}%
+tui-sync-heights = ({$synced} / {$node})
+tui-sync-tip = (tip {$node})
+tui-sync-blocks-left = · {$remaining} blocks left
+
+# Generic units / values
+tui-amount-zec = {$amount} ZEC
+tui-value-unknown = (unknown)
+tui-value-unnamed = (unnamed)
+
+# Lock state (title bar)
+tui-lock-unencrypted = unencrypted
+tui-lock-locked = LOCKED
+tui-lock-unlocked = unlocked
+
+# Toasts: refresh and generic
+tui-toast-refreshed = Refreshed
+
+# Toasts: RPC call failures (method is a protocol identifier)
+tui-err-rpc-call = {$method}: {$error}
+
+# Toasts and prompts: lock / unlock
+tui-unlock-not-encrypted-prompt = This wallet is not encrypted; there is no passphrase to enter.
+tui-unlock-not-encrypted = This wallet is not encrypted; nothing to unlock.
+tui-prompt-unlock-title = Unlock wallet (passphrase)
+tui-prompt-new-account-title = New account name
+tui-toast-unlocked = Wallet unlocked for 5 minutes
+tui-err-incorrect-passphrase = Incorrect passphrase.
+tui-err-unlock-failed = Unlock failed: {$error}
+tui-toast-locked = Wallet locked
+tui-lock-not-encrypted = This wallet is not encrypted; there is nothing to lock.
+
+# Toasts: wallet locked, action needs unlock
+tui-err-locked-press-u-lower = Wallet is locked. Press 'u' to unlock first.
+tui-err-locked-press-u-upper = Wallet is locked. Press 'U' to unlock first.
+
+# Toasts: accounts
+tui-err-account-name-empty = Account name cannot be empty
+tui-toast-account-created = Created account '{$name}'
+
+# Toasts: send operations
+tui-toast-send-completed = Send completed
+tui-toast-send-cancelled = Send cancelled
+tui-err-send-failed = Send failed: {$error}
+tui-err-unknown = unknown error
+
+# Logs view (toasts / placeholders)
+tui-logs-remote-toast = Logs are written by the remote node in {-tui-rpc-url} mode.
+tui-err-read-log = Could not read log file: {$error}
+
+# Client errors (Display impls)
+tui-err-build-client = failed to build RPC client: {$error}
+tui-err-request = RPC request failed: {$error}
+tui-err-rpc-with-code = {$message} (code {$code})
+
+# Prompt modal
+tui-prompt-hint = Enter to confirm · Esc to cancel
+
+# Locked screen
+tui-locked-title = Wallet locked
+tui-locked-line1 = This wallet is encrypted and locked.
+tui-locked-line2 = You must unlock it before you can view balances, addresses,
+tui-locked-line3 = transactions, or send funds.
+tui-locked-hint = Press 'u' or Enter to unlock · 'q' to quit
+
+# Header / footer
+tui-header-title = {-zallet} · {$lock}
+tui-footer-gated = [u]nlock  [q]uit
+tui-footer-unlock = [U]nlock{" "}
+tui-footer-lock = [L]ock{" "}
+tui-footer-nav-tabs = [h/l]tab [Enter]open
+tui-footer-nav-view = [Esc]tabs [Tab]switch
+tui-footer-hint = [?]help [q]uit [r]efresh {$nav} {$lock}
+
+# Help overlay
+tui-help-nav-header = Navigation
+tui-help-nav-esc = Esc               Move focus to the tab row
+tui-help-nav-switch-tabs = h/l or ←/→        Switch tabs (when on tab row)
+tui-help-nav-enter = Enter or j        Enter the focused view
+tui-help-nav-switch-view = Tab / Shift-Tab   Switch view directly
+tui-help-nav-jump = 1..7              Jump to a view
+tui-help-nav-select = j/k or ↑/↓        Move selection within a view
+tui-help-global-header = Global
+tui-help-global-refresh = r                 Refresh data
+tui-help-global-unlock = U                 Unlock wallet (encrypted)
+tui-help-global-lock = L                 Lock wallet (encrypted)
+tui-help-global-help = ?                 Toggle this help
+tui-help-global-quit = q / Ctrl-C        Quit
+tui-help-accounts = Accounts: n = new   ·   Receive: ←/→ account, a = derive address
+tui-help-transactions = Transactions: [ / ] = page   ·   Send: Enter or i edits a field
+tui-help-logs = Logs: j/k scroll, g/G top/bottom, R reload
+tui-help-close = Press any key to close
+tui-help-title = Help
+
+# Dashboard view
+tui-dash-status-title = Status
+tui-dash-node-tip = Node tip
+tui-dash-node-hash = Node hash
+tui-dash-wallet-tip = Wallet tip
+tui-dash-not-syncing = (not yet syncing)
+tui-dash-fully-synced-to = Fully synced to
+tui-dash-loading-status = Loading wallet status…
+tui-dash-accounts = Accounts
+tui-dash-sync-title = Sync
+tui-dash-sync-progress = {$percent}%  ({$blocks} blocks remaining)
+tui-dash-fully-synced = Fully synced
+tui-dash-balance-title = Balance
+tui-dash-balances-syncing = Balances are not available yet — the wallet is still syncing.
+tui-dash-total = Total
+tui-dash-shielded = Shielded (private)
+tui-dash-transparent = Transparent
+tui-dash-total-unavailable = Total balance unavailable (watch-only, or not yet synced).
+tui-dash-minconf = minconf = {$minconf}
+
+# Accounts view
+tui-accounts-title = Accounts
+tui-accounts-empty = No accounts yet. Press 'n' to create one (wallet must be unlocked).
+tui-accounts-title-list = Accounts  ([n]ew)
+tui-accounts-balance-transparent = t:{$amount}
+tui-accounts-balance-sapling = s:{$amount}
+tui-accounts-balance-orchard = o:{$amount}
+
+# Addresses (Receive) view
+tui-addr-no-account-selected = No account selected.
+tui-addr-derived = Derived a new address
+tui-addr-kind-unified = unified
+tui-addr-kind-sapling = sapling
+tui-addr-kind-transparent = transparent
+tui-addr-no-accounts = (no accounts)
+tui-addr-account-label = {" "}Account:{" "}
+tui-addr-account-hint = (←/→ account · j/k address · a new)
+tui-addr-empty = No addresses for this account yet. Press 'a' to derive one.
+tui-addr-title = Addresses
+tui-addr-receive-title = Receive
+tui-addr-select = Select an address to view it.
+tui-addr-qr-enlarge = (enlarge the window to show the QR code)
+tui-addr-qr-too-long = (address too long to render as QR)
+
+# Balances view
+tui-bal-header-account = Account
+tui-bal-header-transparent = Transparent
+tui-bal-header-sapling = Sapling
+tui-bal-header-orchard = Orchard
+tui-bal-title = Balances  (minconf = {$minconf}  [+/-] to change)
+tui-bal-syncing = Balances are not available yet — the wallet is still syncing.
+tui-bal-empty = No balances to display.
+
+# Transactions view
+tui-tx-title = Transactions  (page {$page}, [ / ] to page · experimental)
+tui-tx-empty = No transactions to display.
+tui-tx-unmined = unmined
+tui-tx-detail-title = Detail
+tui-tx-field-txid = txid
+tui-tx-field-height = height
+tui-tx-field-delta = delta
+tui-tx-field-fee = fee
+tui-tx-field-block-time = block time
+tui-tx-field-account = account
+tui-tx-expired = expired (unmined)
+tui-tx-select = Select a transaction.
+
+# Send view
+tui-send-cancelled = Send cancelled
+tui-send-err-no-accounts = No accounts available to send from
+tui-send-err-no-source = Select a source account
+tui-send-err-no-spendable = Selected account has no spendable address
+tui-send-err-recipient-required = Recipient address is required
+tui-send-err-amount-required = Amount is required
+tui-send-err-amount-nan = Amount must be a number
+tui-send-err-no-source-selected = No source account selected
+tui-send-submitted = Submitted (op {$opid})
+tui-send-from = From
+tui-send-to = To
+tui-send-amount = Amount (ZEC)
+tui-send-memo = Memo
+tui-send-privacy-policy = Privacy policy
+tui-send-review = [ Review & send ]
+tui-send-no-spendable-suffix = (no spendable address)
+tui-send-fees-note = Fees are computed automatically (ZIP-317).
+tui-send-privacy-warning = ⚠ This policy reduces privacy. Only proceed if you understand the implications.
+tui-send-hint-editing = EDITING — type to enter text · Enter/Esc to finish
+tui-send-hint-text = ↑↓ move · Enter to edit this field · Esc to tabs
+tui-send-hint-submit = ↑↓ move · Enter to review & send · Esc to tabs
+tui-send-hint-select = ↑↓ move · ←/→ change selection · Esc to tabs
+tui-send-title = Send
+tui-send-operation-title = Operation
+tui-send-confirm = Confirm send?
+tui-send-confirm-summary = {$amount} ZEC from {$from} → {$to}
+tui-send-confirm-hint = [y] yes   [n] no
+tui-send-queued = queued
+tui-send-operation = Operation {$opid}
+tui-send-status = Status: {$status}…
+tui-send-succeeded = Send succeeded
+tui-send-txid = txid: {$txid}
+tui-send-failed = Last send did not succeed (see footer).
+tui-send-placeholder = Fill in the form and press Enter to review.
+
+# Logs view
+tui-logs-file-label = {" "}Log file:{" "}
+tui-logs-remote = Logs are written by the remote node when using {-tui-rpc-url}.
+tui-logs-title = Logs  ({$state}  ·  j/k scroll · g/G top/bottom · R reload)
+tui-logs-following = following
+tui-logs-scrolled = scrolled

--- a/zallet/src/application.rs
+++ b/zallet/src/application.rs
@@ -12,7 +12,12 @@ use abscissa_core::{
 use abscissa_tokio::TokioComponent;
 use i18n_embed::unic_langid::LanguageIdentifier;
 
-use crate::{cli::EntryPoint, components::tracing::Tracing, config::ZalletConfig, i18n};
+use crate::{
+    cli::EntryPoint,
+    components::tracing::{LogTarget, Tracing},
+    config::ZalletConfig,
+    i18n,
+};
 
 /// Application state
 pub static APP: AppCell<ZalletApp> = AppCell::new();
@@ -69,8 +74,17 @@ impl Application for ZalletApp {
 
     fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
         let mut components = self.framework_components(command)?;
+
+        // A command may divert log output to a file instead of the terminal (e.g. when it
+        // takes over the terminal, or when file logging is otherwise requested). Otherwise
+        // logs are written to standard error.
+        let log_file_path = command.log_file_path();
+        let log_target = match &log_file_path {
+            Some(path) => LogTarget::File(path),
+            None => LogTarget::Stderr,
+        };
         components.push(Box::new(
-            Tracing::new(self.term_colors(command))
+            Tracing::new(self.term_colors(command), log_target)
                 .expect("tracing subsystem failed to initialize"),
         ));
         components.push(Box::new(

--- a/zallet/src/cli.rs
+++ b/zallet/src/cli.rs
@@ -88,6 +88,10 @@ pub(crate) enum ZalletCmd {
     #[cfg(feature = "rpc-cli")]
     Rpc(RpcCliCmd),
 
+    /// Run the interactive terminal UI for the wallet.
+    #[cfg(all(feature = "tui", zallet_build = "wallet"))]
+    Tui(TuiCmd),
+
     /// Commands for repairing broken wallet states.
     #[command(subcommand)]
     Repair(RepairCmd),
@@ -292,6 +296,32 @@ pub(crate) struct RpcCliCmd {
 
     /// Any parameters for the command.
     pub(crate) params: Vec<String>,
+}
+
+/// `tui` subcommand
+#[cfg(all(feature = "tui", zallet_build = "wallet"))]
+#[derive(Debug, Parser)]
+#[cfg_attr(outside_buildscript, derive(Command))]
+pub(crate) struct TuiCmd {
+    /// Connect to an already-running Zallet JSON-RPC server at this URL instead of
+    /// starting one.
+    ///
+    /// The value is the URL of the remote server (e.g. `http://127.0.0.1:28232`); a bare
+    /// `host:port` is also accepted and assumed to be `http`. Authentication is taken from
+    /// the `[[rpc.auth]]` entries in the configuration file, unless credentials are
+    /// embedded in the URL.
+    ///
+    /// When omitted, the TUI starts its own wallet backend and JSON-RPC server in-process
+    /// (bound to an ephemeral loopback port with an in-memory credential), and holds the
+    /// data directory lock for the duration of the session.
+    #[arg(long, value_name = "URL")]
+    pub(crate) rpc_url: Option<String>,
+
+    /// Client timeout in seconds during HTTP requests, or 0 for no timeout.
+    ///
+    /// Default is 900 seconds.
+    #[arg(long)]
+    pub(crate) timeout: Option<u64>,
 }
 
 #[derive(Debug, Parser)]

--- a/zallet/src/commands.rs
+++ b/zallet/src/commands.rs
@@ -124,6 +124,16 @@ impl EntryPoint {
                 .map(|base| base.join(".zallet"))
         }
     }
+
+    /// Returns the path to which `tracing` output should be written as a file, or `None`
+    /// to log to standard error (the default).
+    ///
+    /// File-based logging is used by commands that take over the terminal (and so must not
+    /// interleave log output with their display), and may in future be opted into by other
+    /// commands as an alternative to logging to standard error.
+    pub(crate) fn log_file_path(&self) -> Option<PathBuf> {
+        None
+    }
 }
 
 impl Runnable for EntryPoint {

--- a/zallet/src/commands.rs
+++ b/zallet/src/commands.rs
@@ -44,6 +44,9 @@ mod migrate_zcashd_wallet;
 #[cfg(feature = "rpc-cli")]
 pub(crate) mod rpc_cli;
 
+#[cfg(all(feature = "tui", zallet_build = "wallet"))]
+mod tui;
+
 /// Zallet Configuration Filename
 pub const CONFIG_FILE: &str = "zallet.toml";
 
@@ -129,9 +132,14 @@ impl EntryPoint {
     /// to log to standard error (the default).
     ///
     /// File-based logging is used by commands that take over the terminal (and so must not
-    /// interleave log output with their display), and may in future be opted into by other
-    /// commands as an alternative to logging to standard error.
+    /// interleave log output with their display). The interactive terminal UI (`zallet
+    /// tui`) writes its logs to `<datadir>/tui.log` instead of the terminal.
     pub(crate) fn log_file_path(&self) -> Option<PathBuf> {
+        #[cfg(all(feature = "tui", zallet_build = "wallet"))]
+        if matches!(self.cmd, ZalletCmd::Tui(_)) {
+            let datadir = self.datadir().ok()?;
+            return Some(resolve_datadir_path(&datadir, Path::new("tui.log")));
+        }
         None
     }
 }

--- a/zallet/src/commands/tui.rs
+++ b/zallet/src/commands/tui.rs
@@ -1,0 +1,225 @@
+//! `tui` subcommand: an interactive terminal frontend for the wallet.
+//!
+//! The TUI is fundamentally a JSON-RPC client. It supports two modes:
+//!
+//! - **Self-hosted (default):** boots the full wallet backend in-process (database,
+//!   keystore, chain, and sync tasks), spawns the JSON-RPC server on the configured
+//!   loopback `rpc.bind` address, and then connects to that server as an HTTP client. The
+//!   server generates an RPC cookie in the data directory on startup (see the `cookie`
+//!   module), which the TUI reads to authenticate; no credentials need to be configured.
+//!   This holds the data directory lock for the duration of the session.
+//!
+//! - **Remote (`--rpc-url`):** connects to an already-running `zallet start` instance over
+//!   HTTP, using the `[[rpc.auth]]` credentials from the configuration. No backend is
+//!   booted and the data directory lock is not taken.
+//!
+//! In both modes the UI drives the wallet exclusively through the JSON-RPC interface, so
+//! there is a single tested code path regardless of where the server lives.
+
+use std::time::Duration;
+
+use abscissa_core::Runnable;
+use secrecy::SecretString;
+use tokio::{pin, select};
+
+use crate::{
+    cli::TuiCmd,
+    commands::AsyncRunnable,
+    components::{
+        chain::ZainoChain, database::Database, json_rpc::server::cookie, keystore::KeyStore,
+        sync::WalletSync,
+    },
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+
+mod app;
+mod client;
+mod event;
+mod qr;
+mod terminal;
+mod ui;
+mod views;
+
+const DEFAULT_HTTP_CLIENT_TIMEOUT: u64 = 900;
+
+impl AsyncRunnable for TuiCmd {
+    async fn run(&self) -> Result<(), Error> {
+        let timeout = Duration::from_secs(match self.timeout {
+            Some(0) => u64::MAX,
+            Some(timeout) => timeout,
+            None => DEFAULT_HTTP_CLIENT_TIMEOUT,
+        });
+
+        if let Some(rpc_url) = &self.rpc_url {
+            self.run_remote(rpc_url, timeout).await
+        } else {
+            self.run_self_hosted(timeout).await
+        }
+    }
+}
+
+impl TuiCmd {
+    /// Connects to a remote `zallet start` instance and runs the UI.
+    async fn run_remote(&self, rpc_url: &str, timeout: Duration) -> Result<(), Error> {
+        let config = APP.config();
+
+        let client = client::WalletClient::connect_remote(rpc_url, &config.rpc.auth, timeout)
+            .map_err(|e| ErrorKind::Generic.context(e))?;
+
+        // In remote mode logs are written by the remote `zallet start`, not locally.
+        run_ui(client, None).await
+    }
+
+    /// Boots the wallet backend in-process and runs the UI against a self-hosted JSON-RPC
+    /// server.
+    async fn run_self_hosted(&self, timeout: Duration) -> Result<(), Error> {
+        let config = APP.config();
+        let _lock = config.lock_datadir()?;
+
+        // The self-hosted server binds to the configured `rpc.bind` address (a single
+        // loopback address) and authenticates the TUI via the RPC cookie it generates. A
+        // bind address is required; the data directory cookie is what makes this secure
+        // without configured credentials.
+        let rpc_addr = match config.rpc.bind.as_slice() {
+            [addr] => *addr,
+            [] => {
+                return Err(ErrorKind::Init
+                    .context(
+                        "`zallet tui` requires a single loopback `rpc.bind` address to be \
+                         configured (it hosts a local JSON-RPC server). Set `rpc.bind` in your \
+                         configuration, or use `--rpc-url` to connect to a running `zallet start`.",
+                    )
+                    .into());
+            }
+            _ => {
+                return Err(ErrorKind::Init
+                    .context("`zallet tui` supports only a single `rpc.bind` address")
+                    .into());
+            }
+        };
+
+        let datadir = config.datadir().to_path_buf();
+
+        let db = Database::open(&config).await?;
+        let keystore = KeyStore::new(&config, db.clone())?;
+
+        // Start monitoring the chain.
+        let (chain, chain_indexer_task_handle) = ZainoChain::new(&config).await?;
+
+        // Launch the JSON-RPC server (which generates the RPC cookie in the data directory).
+        let rpc_task_handle = crate::components::json_rpc::server::spawn(
+            config.rpc.clone(),
+            datadir.clone(),
+            db.clone(),
+            keystore,
+            chain.clone(),
+        )
+        .await?;
+
+        // Read the cookie the server just generated, and use it to authenticate.
+        let cookie = SecretString::new(
+            cookie::read_cookie(&datadir).map_err(|e| ErrorKind::Generic.context(e))?,
+        );
+
+        // Start the wallet sync process so balances and history stay live.
+        let (
+            wallet_sync_steady_state_task_handle,
+            wallet_sync_recover_history_task_handle,
+            wallet_sync_batch_decryptor_task_handle,
+            wallet_sync_data_requests_task_handle,
+        ) = WalletSync::spawn(&config, db, chain).await?;
+
+        info!("Spawned Zallet TUI backend tasks");
+
+        // Connect the UI client to our own server using the cookie credential.
+        let client = client::WalletClient::connect_local(rpc_addr, &cookie, timeout)
+            .map_err(|e| ErrorKind::Generic.context(e))?;
+
+        // The self-hosted backend writes its logs to `<datadir>/tui.log` (see
+        // `EntryPoint::log_file_path`); surface that path to the Logs view.
+        let log_path =
+            crate::commands::resolve_datadir_path(&datadir, std::path::Path::new("tui.log"));
+
+        pin!(chain_indexer_task_handle);
+        pin!(rpc_task_handle);
+        pin!(wallet_sync_steady_state_task_handle);
+        pin!(wallet_sync_recover_history_task_handle);
+        pin!(wallet_sync_batch_decryptor_task_handle);
+        pin!(wallet_sync_data_requests_task_handle);
+
+        // Run the UI, racing it against the backend tasks. If any backend task exits
+        // (which should only happen on failure), tear down the UI and surface the result.
+        let res = select! {
+            ui_result = run_ui(client, Some(log_path)) => ui_result,
+
+            join = &mut chain_indexer_task_handle => {
+                let r = join.expect("unexpected panic in the chain indexer task");
+                info!(?r, "Chain indexer task exited");
+                r
+            }
+            join = &mut rpc_task_handle => {
+                let r = join.expect("unexpected panic in the RPC task");
+                info!(?r, "RPC task exited");
+                r
+            }
+            join = &mut wallet_sync_steady_state_task_handle => {
+                let r = join.expect("unexpected panic in the wallet steady-state sync task");
+                info!(?r, "Wallet steady-state sync task exited");
+                r
+            }
+            join = &mut wallet_sync_recover_history_task_handle => {
+                let r = join.expect("unexpected panic in the wallet recover-history sync task");
+                info!(?r, "Wallet recover-history sync task exited");
+                r
+            }
+            join = &mut wallet_sync_batch_decryptor_task_handle => {
+                let r = join.expect("unexpected panic in the wallet batch decryptor task");
+                info!(?r, "Wallet batch decryptor task exited");
+                r
+            }
+            join = &mut wallet_sync_data_requests_task_handle => {
+                let r = join.expect("unexpected panic in the wallet data-requests sync task");
+                info!(?r, "Wallet data-requests sync task exited");
+                r
+            }
+        };
+
+        info!("Shutting down Zallet TUI backend tasks");
+
+        chain_indexer_task_handle.abort();
+        rpc_task_handle.abort();
+        wallet_sync_steady_state_task_handle.abort();
+        wallet_sync_recover_history_task_handle.abort();
+        wallet_sync_batch_decryptor_task_handle.abort();
+        wallet_sync_data_requests_task_handle.abort();
+
+        res
+    }
+}
+
+/// Runs the terminal UI event loop against the given wallet client.
+///
+/// The terminal is placed into raw mode and the alternate screen on entry, and restored on
+/// exit (including on panic, via [`terminal::TerminalGuard`]).
+async fn run_ui(
+    client: client::WalletClient,
+    log_path: Option<std::path::PathBuf>,
+) -> Result<(), Error> {
+    let mut guard = terminal::TerminalGuard::enter().map_err(|e| ErrorKind::Generic.context(e))?;
+
+    let mut app = app::App::new(client, log_path);
+    let result = app.run(guard.terminal_mut()).await;
+
+    // Restore the terminal before returning, so any error is printed cleanly.
+    guard.restore();
+
+    result
+}
+
+impl Runnable for TuiCmd {
+    fn run(&self) {
+        self.run_on_runtime();
+        info!("Exited Zallet TUI");
+    }
+}

--- a/zallet/src/commands/tui/app.rs
+++ b/zallet/src/commands/tui/app.rs
@@ -1,0 +1,812 @@
+//! TUI application state and event loop.
+
+use std::time::Duration;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::error::Error;
+
+use super::client::{
+    Account, Balances, LockState, OperationStatus, TotalBalance, WalletClient, WalletStatus,
+    WalletTx,
+};
+use super::event::{Event, EventSource};
+use super::terminal::Tui;
+use super::{ui, views};
+
+/// How often the UI refreshes wallet data and re-renders.
+const TICK_RATE: Duration = Duration::from_secs(3);
+
+/// The number of transactions fetched per page in the transactions view.
+pub(super) const TX_PAGE_SIZE: u32 = 50;
+
+/// The primary views of the TUI.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum View {
+    Dashboard,
+    Accounts,
+    Balances,
+    Addresses,
+    Transactions,
+    Send,
+    Logs,
+}
+
+impl View {
+    /// All views, in tab order.
+    pub(super) const ALL: [View; 7] = [
+        View::Dashboard,
+        View::Accounts,
+        View::Balances,
+        View::Addresses,
+        View::Transactions,
+        View::Send,
+        View::Logs,
+    ];
+
+    pub(super) fn title(self) -> String {
+        match self {
+            View::Dashboard => crate::fl!("tui-view-dashboard"),
+            View::Accounts => crate::fl!("tui-view-accounts"),
+            View::Balances => crate::fl!("tui-view-balances"),
+            View::Addresses => crate::fl!("tui-view-receive"),
+            View::Transactions => crate::fl!("tui-view-transactions"),
+            View::Send => crate::fl!("tui-view-send"),
+            View::Logs => crate::fl!("tui-view-logs"),
+        }
+    }
+
+    fn index(self) -> usize {
+        View::ALL.iter().position(|&v| v == self).unwrap_or(0)
+    }
+}
+
+/// A compact summary of wallet sync progress, derived from `getwalletstatus`.
+pub(super) struct SyncSummary {
+    /// Fraction in `[0.0, 1.0]`, or `None` if indeterminate.
+    pub(super) fraction: Option<f64>,
+    /// Whether the wallet is fully synced.
+    pub(super) synced: bool,
+    /// The height the wallet is fully synced to, if known.
+    pub(super) synced_height: Option<u32>,
+    /// The node's chain tip height.
+    pub(super) node_height: Option<u32>,
+    /// Blocks still to scan, if known.
+    pub(super) unscanned_blocks: Option<u32>,
+}
+
+impl SyncSummary {
+    /// A short one-line label, e.g. `Sync 87%` or `Synced`.
+    pub(super) fn short_label(&self) -> String {
+        if self.synced {
+            crate::fl!("tui-sync-synced")
+        } else if let Some(f) = self.fraction {
+            crate::fl!("tui-sync-percent", percent = format!("{:.0}", f * 100.0))
+        } else {
+            crate::fl!("tui-sync-syncing")
+        }
+    }
+}
+
+/// Where keyboard focus currently sits.
+///
+/// `Tabs` focus means navigation keys move between views (the header row is highlighted);
+/// `View` focus means keys are handled by the active view's body. `Esc` moves focus from
+/// the body up to the tabs; selecting/entering a view moves focus back down into it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum Focus {
+    Tabs,
+    View,
+}
+
+/// A transient status message shown in the footer.
+#[derive(Clone)]
+pub(super) struct Toast {
+    pub(super) text: String,
+    pub(super) is_error: bool,
+}
+
+/// Cached wallet data, refreshed on each tick and after actions.
+#[derive(Default)]
+pub(super) struct WalletData {
+    pub(super) status: Option<WalletStatus>,
+    pub(super) total_balance: Option<TotalBalance>,
+    pub(super) balances: Option<Balances>,
+    pub(super) accounts: Vec<Account>,
+    pub(super) transactions: Vec<WalletTx>,
+    /// The minimum number of confirmations used when querying balances.
+    pub(super) minconf: u32,
+    /// Whether the wallet summary is ready yet (balances unavailable while syncing).
+    pub(super) balances_syncing: bool,
+}
+
+/// The interactive send form.
+#[derive(Default)]
+pub(super) struct SendForm {
+    /// The source account, as an index into [`WalletData::accounts`].
+    pub(super) from_account: usize,
+    pub(super) to: String,
+    pub(super) amount: String,
+    pub(super) memo: String,
+    /// Index into [`PRIVACY_POLICIES`].
+    pub(super) privacy_policy: usize,
+    /// Which field currently has focus.
+    pub(super) field: SendField,
+    /// Whether the focused text field is currently being edited.
+    ///
+    /// Text fields only capture keystrokes while editing; otherwise navigation keys
+    /// (`j`/`k`) move between fields. Editing is entered with `Enter` and left with `Esc`.
+    pub(super) editing: bool,
+    /// A submitted operation that is being polled, if any.
+    pub(super) pending_opid: Option<String>,
+    /// The latest known status of the pending operation.
+    pub(super) pending_status: Option<OperationStatus>,
+    /// Whether the confirmation prompt is showing.
+    pub(super) confirming: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum SendField {
+    #[default]
+    From,
+    To,
+    Amount,
+    Memo,
+    PrivacyPolicy,
+    /// The "Review & send" action row.
+    Submit,
+}
+
+impl SendField {
+    /// Whether this field accepts free-text input (vs. a selector or action).
+    pub(super) fn is_text(self) -> bool {
+        matches!(self, SendField::To | SendField::Amount | SendField::Memo)
+    }
+}
+
+/// The privacy policies offered in the send form, weakest-last.
+pub(super) const PRIVACY_POLICIES: [&str; 7] = [
+    "FullPrivacy",
+    "AllowRevealedAmounts",
+    "AllowRevealedRecipients",
+    "AllowRevealedSenders",
+    "AllowLinkingAccountAddresses",
+    "AllowFullyTransparent",
+    "NoPrivacy",
+];
+
+/// State for the Logs view.
+#[derive(Default)]
+pub(super) struct LogsState {
+    /// The path to the log file, if known (self-hosted mode only).
+    pub(super) path: Option<std::path::PathBuf>,
+    /// The most recently loaded tail of the log file.
+    pub(super) lines: Vec<String>,
+    /// Scroll offset from the bottom, in lines (0 = following the tail).
+    pub(super) scroll_from_bottom: usize,
+    /// An error encountered while reading the log file, if any.
+    pub(super) read_error: Option<String>,
+}
+
+/// A modal prompt for textual input (e.g. unlock passphrase, new account name).
+pub(super) struct Prompt {
+    pub(super) title: String,
+    pub(super) value: String,
+    pub(super) masked: bool,
+    pub(super) kind: PromptKind,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum PromptKind {
+    Unlock,
+    NewAccount,
+}
+
+/// The top-level application state.
+pub(super) struct App {
+    client: WalletClient,
+    pub(super) view: View,
+    pub(super) focus: Focus,
+    pub(super) data: WalletData,
+    pub(super) send: SendForm,
+    pub(super) logs: LogsState,
+    pub(super) toast: Option<Toast>,
+    pub(super) prompt: Option<Prompt>,
+    pub(super) show_help: bool,
+    /// The wallet's encryption/lock state, as last observed.
+    pub(super) lock_state: LockState,
+    /// Selection index for list-based views.
+    pub(super) accounts_selected: usize,
+    /// The account selected in the Receive view, as an index into the accounts list.
+    pub(super) receive_account: usize,
+    pub(super) addresses_selected: usize,
+    pub(super) tx_selected: usize,
+    pub(super) tx_offset: u32,
+    should_quit: bool,
+}
+
+impl App {
+    pub(super) fn new(client: WalletClient, log_path: Option<std::path::PathBuf>) -> Self {
+        Self {
+            client,
+            view: View::Dashboard,
+            focus: Focus::View,
+            data: WalletData {
+                minconf: 1,
+                ..Default::default()
+            },
+            send: SendForm::default(),
+            logs: LogsState {
+                path: log_path,
+                ..Default::default()
+            },
+            toast: None,
+            prompt: None,
+            show_help: false,
+            // Assume locked until we learn otherwise, so the UI never appears usable
+            // before we have confirmed the wallet is accessible.
+            lock_state: LockState::Locked,
+            accounts_selected: 0,
+            receive_account: 0,
+            addresses_selected: 0,
+            tx_selected: 0,
+            tx_offset: 0,
+            should_quit: false,
+        }
+    }
+
+    /// Whether the wallet is currently inaccessible and must be unlocked before use.
+    pub(super) fn is_gated(&self) -> bool {
+        self.lock_state == LockState::Locked
+    }
+
+    /// Whether a text field is currently capturing keystrokes, in which case global
+    /// keyboard shortcuts must be suppressed so the characters can be typed.
+    fn is_text_input_active(&self) -> bool {
+        self.view == View::Send && self.send.editing
+    }
+
+    /// Computes a summary of wallet sync progress from the latest `getwalletstatus`.
+    ///
+    /// Progress is wallet-wide (the backend does not expose per-account progress).
+    pub(super) fn sync_summary(&self) -> SyncSummary {
+        let Some(status) = &self.data.status else {
+            return SyncSummary {
+                fraction: None,
+                synced: false,
+                synced_height: None,
+                node_height: None,
+                unscanned_blocks: None,
+            };
+        };
+
+        match &status.sync_work_remaining {
+            // No work remaining means fully synced.
+            None => SyncSummary {
+                fraction: Some(1.0),
+                synced: true,
+                synced_height: status.fully_synced_height,
+                node_height: Some(status.node_tip.height),
+                unscanned_blocks: Some(0),
+            },
+            Some(work) => {
+                let p = &work.progress;
+                // The denominator can be zero when a range contains no shielded notes.
+                let fraction = (p.denominator != 0)
+                    .then(|| (p.numerator as f64 / p.denominator as f64).clamp(0.0, 1.0));
+                SyncSummary {
+                    fraction,
+                    synced: false,
+                    synced_height: status.fully_synced_height,
+                    node_height: Some(status.node_tip.height),
+                    unscanned_blocks: Some(work.unscanned_blocks),
+                }
+            }
+        }
+    }
+
+    /// Runs the event loop until the user quits.
+    pub(super) async fn run(&mut self, terminal: &mut Tui) -> Result<(), Error> {
+        let mut events = EventSource::new(TICK_RATE);
+
+        // Determine the wallet's lock state before doing anything else, so the UI never
+        // appears usable when the wallet is locked.
+        self.refresh_lock_state().await;
+        if !self.is_gated() {
+            self.refresh().await;
+        }
+
+        loop {
+            terminal
+                .draw(|frame| ui::render(self, frame))
+                .map_err(|e| crate::error::ErrorKind::Generic.context(e))?;
+
+            match events.next().await {
+                Event::Key(key) => self.on_key(key).await,
+                Event::Tick => self.on_tick().await,
+                Event::Resize => {}
+            }
+
+            if self.should_quit {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Refreshes the wallet's encryption/lock state from `getwalletinfo`.
+    pub(super) async fn refresh_lock_state(&mut self) {
+        match self.client.get_wallet_info().await {
+            Ok(Ok(info)) => self.lock_state = info.lock_state(),
+            // If we can't determine the state, remain conservative: stay locked.
+            Ok(Err(e)) => self.error(crate::fl!(
+                "tui-err-rpc-call",
+                method = "getwalletinfo",
+                error = e.to_string()
+            )),
+            Err(e) => self.error(e.to_string()),
+        }
+    }
+
+    /// Returns a reference to the wallet client.
+    pub(super) fn client(&self) -> &WalletClient {
+        &self.client
+    }
+
+    /// Shows a transient informational message.
+    pub(super) fn info(&mut self, text: impl Into<String>) {
+        self.toast = Some(Toast {
+            text: text.into(),
+            is_error: false,
+        });
+    }
+
+    /// Shows a transient error message.
+    pub(super) fn error(&mut self, text: impl Into<String>) {
+        self.toast = Some(Toast {
+            text: text.into(),
+            is_error: true,
+        });
+    }
+
+    async fn on_tick(&mut self) {
+        // The Logs view is available regardless of lock state, and follows the log tail.
+        if self.view == View::Logs && self.logs.scroll_from_bottom == 0 {
+            self.load_logs();
+        }
+
+        // Keep the lock state current (it can change when the unlock timeout elapses).
+        self.refresh_lock_state().await;
+        if self.is_gated() {
+            // While locked, do not fetch or display any wallet data.
+            return;
+        }
+        self.refresh().await;
+        // Poll a pending send operation if there is one.
+        if self.send.pending_opid.is_some() {
+            self.poll_send().await;
+        }
+    }
+
+    /// Refreshes cached wallet data from the backend.
+    pub(super) async fn refresh(&mut self) {
+        let minconf = self.data.minconf;
+
+        match self.client.get_wallet_status().await {
+            Ok(Ok(status)) => self.data.status = Some(status),
+            Ok(Err(e)) => self.error(crate::fl!(
+                "tui-err-rpc-call",
+                method = "getwalletstatus",
+                error = e.to_string()
+            )),
+            Err(e) => self.error(e.to_string()),
+        }
+
+        match self.client.get_total_balance(minconf).await {
+            Ok(Ok(tb)) => self.data.total_balance = Some(tb),
+            Ok(Err(_)) => {} // tolerated; total balance has stricter requirements
+            Err(e) => self.error(e.to_string()),
+        }
+
+        match self.client.get_balances(minconf).await {
+            Ok(Ok(b)) => {
+                self.data.balances = Some(b);
+                self.data.balances_syncing = false;
+            }
+            // `-28` (InWarmup) means the wallet summary isn't ready yet because the wallet
+            // is still syncing/scanning. This is expected, not an error: surface it as a
+            // "syncing" state rather than a scary toast.
+            Ok(Err(e)) if e.code == -28 => {
+                self.data.balances = None;
+                self.data.balances_syncing = true;
+            }
+            Ok(Err(e)) => self.error(crate::fl!(
+                "tui-err-rpc-call",
+                method = "z_getbalances",
+                error = e.to_string()
+            )),
+            Err(e) => self.error(e.to_string()),
+        }
+
+        match self.client.list_accounts().await {
+            Ok(Ok(accounts)) => {
+                self.data.accounts = accounts;
+                self.clamp_selection();
+            }
+            Ok(Err(e)) => self.error(crate::fl!(
+                "tui-err-rpc-call",
+                method = "z_listaccounts",
+                error = e.to_string()
+            )),
+            Err(e) => self.error(e.to_string()),
+        }
+
+        self.refresh_transactions().await;
+    }
+
+    pub(super) async fn refresh_transactions(&mut self) {
+        match self
+            .client
+            .list_transactions(self.tx_offset, TX_PAGE_SIZE)
+            .await
+        {
+            Ok(Ok(txs)) => {
+                self.data.transactions = txs;
+                if self.tx_selected >= self.data.transactions.len() {
+                    self.tx_selected = self.data.transactions.len().saturating_sub(1);
+                }
+            }
+            // z_listtransactions is experimental; don't spam errors on empty wallets.
+            Ok(Err(_)) => self.data.transactions.clear(),
+            Err(e) => self.error(e.to_string()),
+        }
+    }
+
+    fn clamp_selection(&mut self) {
+        if self.accounts_selected >= self.data.accounts.len() {
+            self.accounts_selected = self.data.accounts.len().saturating_sub(1);
+        }
+    }
+
+    async fn on_key(&mut self, key: KeyEvent) {
+        // Global: Ctrl-C always quits.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.should_quit = true;
+            return;
+        }
+
+        // A modal prompt takes precedence over everything else.
+        if self.prompt.is_some() {
+            self.on_key_prompt(key).await;
+            return;
+        }
+
+        // The help overlay swallows input; any key dismisses it.
+        if self.show_help {
+            self.show_help = false;
+            return;
+        }
+
+        // While the wallet is locked, the only permitted actions are unlocking, quitting,
+        // viewing help, and viewing the (non-sensitive) logs. The wallet's data must not
+        // appear usable.
+        if self.is_gated() {
+            match key.code {
+                KeyCode::Char('q') => self.should_quit = true,
+                KeyCode::Char('?') => self.show_help = true,
+                KeyCode::Char('u') => self.open_unlock_prompt(),
+                // Allow toggling to/from the Logs view while locked.
+                KeyCode::Char('7') => self.set_view(View::Logs),
+                KeyCode::Char('1') => self.set_view(View::Dashboard),
+                // Enter unlocks unless we're on the Logs view (where it's not an action).
+                KeyCode::Enter if self.view != View::Logs => self.open_unlock_prompt(),
+                // Let the Logs view handle scrolling keys while locked.
+                _ if self.view == View::Logs => views::logs::on_key(self, key),
+                _ => {}
+            }
+            return;
+        }
+
+        // When a text field is actively being edited, all keystrokes must go to the field
+        // (so e.g. '?', 'q', and digits are typed rather than triggering shortcuts).
+        if self.is_text_input_active() {
+            self.on_key_view(key).await;
+            return;
+        }
+
+        // Keys handled regardless of focus.
+        match key.code {
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+                return;
+            }
+            KeyCode::Char('?') => {
+                self.show_help = true;
+                return;
+            }
+            KeyCode::Char('r') => {
+                self.refresh().await;
+                self.info(crate::fl!("tui-toast-refreshed"));
+                return;
+            }
+            // Direct view jumps work from anywhere and focus the view body.
+            KeyCode::Char(c @ '1'..='7') => {
+                let idx = (c as u8 - b'1') as usize;
+                if let Some(&v) = View::ALL.get(idx) {
+                    self.set_view(v);
+                    self.focus = Focus::View;
+                }
+                return;
+            }
+            // Lock/unlock shortcuts (only meaningful for encrypted wallets).
+            KeyCode::Char('L') => {
+                self.lock_wallet().await;
+                return;
+            }
+            KeyCode::Char('U') => {
+                self.open_unlock_prompt();
+                return;
+            }
+            _ => {}
+        }
+
+        match self.focus {
+            Focus::Tabs => self.on_key_tabs(key),
+            Focus::View => self.on_key_view(key).await,
+        }
+    }
+
+    /// Key handling when focus is on the header/tab row.
+    fn on_key_tabs(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Left | KeyCode::Char('h') | KeyCode::BackTab => self.prev_view(),
+            KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => self.next_view(),
+            // Descend into the focused view's body.
+            KeyCode::Enter | KeyCode::Down | KeyCode::Char('j') => self.focus = Focus::View,
+            _ => {}
+        }
+    }
+
+    /// Switches to the given view, performing any per-view entry work.
+    fn set_view(&mut self, view: View) {
+        self.view = view;
+        // Load the log tail immediately on entering the Logs view.
+        if view == View::Logs {
+            self.load_logs();
+        }
+    }
+
+    fn next_view(&mut self) {
+        let idx = (self.view.index() + 1) % View::ALL.len();
+        self.set_view(View::ALL[idx]);
+    }
+
+    fn prev_view(&mut self) {
+        let idx = (self.view.index() + View::ALL.len() - 1) % View::ALL.len();
+        self.set_view(View::ALL[idx]);
+    }
+
+    /// Dispatches keys to the active view when focus is on the body.
+    ///
+    /// `Esc` normally moves focus back up to the tab row so the user can switch views;
+    /// `Tab`/`BackTab` move between views directly. The exception is when the Send view is
+    /// actively editing a text field: in that case all keys (including `Esc`/`Tab`) are
+    /// routed to the Send handler so they don't navigate away mid-edit.
+    async fn on_key_view(&mut self, key: KeyEvent) {
+        let send_editing = self.view == View::Send && self.send.editing;
+
+        if !send_editing {
+            match key.code {
+                KeyCode::Esc => {
+                    self.focus = Focus::Tabs;
+                    return;
+                }
+                KeyCode::Tab => {
+                    self.next_view();
+                    return;
+                }
+                KeyCode::BackTab => {
+                    self.prev_view();
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        match self.view {
+            View::Accounts => views::accounts::on_key(self, key).await,
+            View::Addresses => views::addresses::on_key(self, key).await,
+            View::Transactions => views::transactions::on_key(self, key).await,
+            View::Balances => views::balances::on_key(self, key),
+            View::Send => views::send::on_key(self, key).await,
+            View::Logs => views::logs::on_key(self, key),
+            View::Dashboard => {}
+        }
+    }
+
+    /// Reads the tail of the log file into [`LogsState`].
+    ///
+    /// At most the last `MAX_LOG_LINES` lines are kept, to bound memory and rendering
+    /// cost for a large log file.
+    pub(super) fn load_logs(&mut self) {
+        const MAX_LOG_LINES: usize = 2000;
+
+        let Some(path) = self.logs.path.clone() else {
+            self.logs.read_error = Some(crate::fl!("tui-logs-remote-toast"));
+            return;
+        };
+
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                let mut lines: Vec<String> = contents.lines().map(|l| l.to_string()).collect();
+                if lines.len() > MAX_LOG_LINES {
+                    lines.drain(0..lines.len() - MAX_LOG_LINES);
+                }
+                self.logs.lines = lines;
+                self.logs.read_error = None;
+            }
+            Err(e) => {
+                self.logs.lines.clear();
+                self.logs.read_error = Some(crate::fl!("tui-err-read-log", error = e.to_string()));
+            }
+        }
+    }
+
+    // --- Prompts ----------------------------------------------------------------------
+
+    fn open_unlock_prompt(&mut self) {
+        if self.lock_state == LockState::Unencrypted {
+            self.info(crate::fl!("tui-unlock-not-encrypted-prompt"));
+            return;
+        }
+        self.prompt = Some(Prompt {
+            title: crate::fl!("tui-prompt-unlock-title"),
+            value: String::new(),
+            masked: true,
+            kind: PromptKind::Unlock,
+        });
+    }
+
+    pub(super) fn open_new_account_prompt(&mut self) {
+        self.prompt = Some(Prompt {
+            title: crate::fl!("tui-prompt-new-account-title"),
+            value: String::new(),
+            masked: false,
+            kind: PromptKind::NewAccount,
+        });
+    }
+
+    async fn on_key_prompt(&mut self, key: KeyEvent) {
+        let Some(prompt) = self.prompt.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => self.prompt = None,
+            KeyCode::Enter => {
+                let prompt = self.prompt.take().expect("prompt is present");
+                self.submit_prompt(prompt).await;
+            }
+            KeyCode::Backspace => {
+                prompt.value.pop();
+            }
+            KeyCode::Char(c) => prompt.value.push(c),
+            _ => {}
+        }
+    }
+
+    async fn submit_prompt(&mut self, prompt: Prompt) {
+        match prompt.kind {
+            PromptKind::Unlock => {
+                // Unlock for 5 minutes.
+                match self.client.unlock(&prompt.value, 300).await {
+                    Ok(Ok(())) => {
+                        self.info(crate::fl!("tui-toast-unlocked"));
+                        // Re-check state and load data now that we have access.
+                        self.refresh_lock_state().await;
+                        if !self.is_gated() {
+                            self.focus = Focus::View;
+                            self.refresh().await;
+                        }
+                    }
+                    // Wrong passphrase.
+                    Ok(Err(e)) if e.code == -14 => {
+                        self.error(crate::fl!("tui-err-incorrect-passphrase"));
+                    }
+                    // Wallet is not encrypted (should not happen: we guard the prompt).
+                    Ok(Err(e)) if e.code == -15 => {
+                        self.error(crate::fl!("tui-unlock-not-encrypted"));
+                    }
+                    Ok(Err(e)) => {
+                        self.error(crate::fl!("tui-err-unlock-failed", error = e.to_string()))
+                    }
+                    Err(e) => self.error(e.to_string()),
+                }
+            }
+            PromptKind::NewAccount => {
+                if prompt.value.trim().is_empty() {
+                    self.error(crate::fl!("tui-err-account-name-empty"));
+                    return;
+                }
+                match self.client.new_account(prompt.value.trim()).await {
+                    Ok(Ok(_)) => {
+                        self.info(crate::fl!(
+                            "tui-toast-account-created",
+                            name = prompt.value.trim()
+                        ));
+                        self.refresh().await;
+                    }
+                    Ok(Err(e)) if e.is_unlock_needed() => {
+                        self.error(crate::fl!("tui-err-locked-press-u-lower"));
+                    }
+                    Ok(Err(e)) => self.error(crate::fl!(
+                        "tui-err-rpc-call",
+                        method = "z_getnewaccount",
+                        error = e.to_string()
+                    )),
+                    Err(e) => self.error(e.to_string()),
+                }
+            }
+        }
+    }
+
+    // --- Lock/unlock ------------------------------------------------------------------
+
+    async fn lock_wallet(&mut self) {
+        if self.lock_state == LockState::Unencrypted {
+            self.info(crate::fl!("tui-lock-not-encrypted"));
+            return;
+        }
+        match self.client.lock().await {
+            Ok(Ok(())) => {
+                self.info(crate::fl!("tui-toast-locked"));
+                self.refresh_lock_state().await;
+            }
+            Ok(Err(e)) => self.error(crate::fl!(
+                "tui-err-rpc-call",
+                method = "walletlock",
+                error = e.to_string()
+            )),
+            Err(e) => self.error(e.to_string()),
+        }
+    }
+
+    // --- Send polling -----------------------------------------------------------------
+
+    /// Polls the pending send operation and updates its status.
+    pub(super) async fn poll_send(&mut self) {
+        let Some(opid) = self.send.pending_opid.clone() else {
+            return;
+        };
+        match self.client.operation_status(&opid).await {
+            Ok(Ok(mut statuses)) => {
+                if let Some(status) = statuses.pop() {
+                    let finished =
+                        matches!(status.status.as_str(), "success" | "failed" | "cancelled");
+                    if finished {
+                        self.send.pending_opid = None;
+                        match status.status.as_str() {
+                            "success" => self.info(crate::fl!("tui-toast-send-completed")),
+                            "failed" => {
+                                let msg = status
+                                    .error
+                                    .as_ref()
+                                    .and_then(|e| e.message.clone())
+                                    .unwrap_or_else(|| crate::fl!("tui-err-unknown"));
+                                self.error(crate::fl!("tui-err-send-failed", error = msg));
+                            }
+                            _ => self.info(crate::fl!("tui-toast-send-cancelled")),
+                        }
+                    }
+                    self.send.pending_status = Some(status);
+                }
+            }
+            Ok(Err(e)) => self.error(crate::fl!(
+                "tui-err-rpc-call",
+                method = "z_getoperationstatus",
+                error = e.to_string()
+            )),
+            Err(e) => self.error(e.to_string()),
+        }
+    }
+}

--- a/zallet/src/commands/tui/client.rs
+++ b/zallet/src/commands/tui/client.rs
@@ -1,0 +1,491 @@
+//! Typed JSON-RPC client for the TUI.
+//!
+//! This wraps a [`jsonrpsee`] HTTP client with one method per wallet RPC the TUI uses,
+//! deserializing responses into purpose-built structs. The same client type is used for
+//! both self-hosted (loopback) and remote connections.
+
+use std::fmt;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use base64ct::{Base64, Encoding};
+use hyper::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use jsonrpsee::core::{client::ClientT, params::ArrayParams};
+use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::config::RpcAuthSection;
+
+/// Errors that can arise when building or using the TUI's RPC client.
+#[derive(Debug)]
+pub(super) enum ClientError {
+    Build(String),
+    Request(String),
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ClientError::Build(e) => {
+                write!(f, "{}", crate::fl!("tui-err-build-client", error = e))
+            }
+            ClientError::Request(e) => {
+                write!(f, "{}", crate::fl!("tui-err-request", error = e))
+            }
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+/// A JSON-RPC error returned by the wallet, including its numeric code.
+///
+/// The code matches the `zcashd`-compatible `LegacyCode` values (e.g. `-13` for
+/// "wallet needs unlocking").
+#[derive(Clone, Debug)]
+pub(super) struct RpcError {
+    pub(super) code: i32,
+    pub(super) message: String,
+}
+
+impl RpcError {
+    /// Whether this error indicates the wallet must be unlocked before the operation can
+    /// proceed (`LegacyCode::WalletUnlockNeeded`).
+    pub(super) fn is_unlock_needed(&self) -> bool {
+        self.code == -13
+    }
+}
+
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            crate::fl!(
+                "tui-err-rpc-with-code",
+                message = self.message.clone(),
+                code = self.code
+            )
+        )
+    }
+}
+
+/// The result of a wallet RPC call: either a typed value, or a structured wallet error.
+pub(super) type CallResult<T> = Result<Result<T, RpcError>, ClientError>;
+
+/// A typed JSON-RPC client for the wallet.
+#[derive(Clone)]
+pub(super) struct WalletClient {
+    inner: HttpClient,
+}
+
+impl WalletClient {
+    /// Connects to the self-hosted server at the given loopback address, authenticating
+    /// with the RPC cookie credential (`user:password`) that the server generated on
+    /// startup.
+    ///
+    /// The credential is sent via an HTTP `Authorization: Basic` header rather than being
+    /// embedded in the URL, since the cookie password is Base64 and may contain characters
+    /// that are not URL-safe.
+    pub(super) fn connect_local(
+        addr: SocketAddr,
+        cookie: &SecretString,
+        timeout: Duration,
+    ) -> Result<Self, ClientError> {
+        let encoded = Base64::encode_string(cookie.expose_secret().as_bytes());
+        let mut value = HeaderValue::from_str(&format!("Basic {encoded}"))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        value.set_sensitive(true);
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, value);
+
+        let inner = HttpClientBuilder::default()
+            .request_timeout(timeout)
+            .set_headers(headers)
+            .build(format!("http://{addr}"))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Connects to a remote `zallet start` server at the given RPC URL.
+    ///
+    /// The URL may include a scheme (`http://` or `https://`); if it doesn't, `http://` is
+    /// assumed (so a bare `host:port` works). If the URL does not already embed
+    /// credentials, authentication is taken from the configured `[[rpc.auth]]` entries
+    /// (the first entry with a cleartext password).
+    pub(super) fn connect_remote(
+        rpc_url: &str,
+        auth: &[RpcAuthSection],
+        timeout: Duration,
+    ) -> Result<Self, ClientError> {
+        // Split off an explicit scheme, defaulting to http.
+        let (scheme, rest) = match rpc_url.split_once("://") {
+            Some((scheme, rest)) => (scheme, rest),
+            None => ("http", rpc_url),
+        };
+
+        // If the user already embedded credentials (`user:pass@host`), keep them as-is;
+        // otherwise inject the configured auth.
+        let url = if rest.contains('@') {
+            SecretString::new(format!("{scheme}://{rest}"))
+        } else {
+            let auth_prefix = auth
+                .iter()
+                .find_map(|a| {
+                    a.password
+                        .as_ref()
+                        .map(|pw| SecretString::new(format!("{}:{}@", a.user, pw.expose_secret())))
+                })
+                .unwrap_or_else(|| SecretString::new(String::new()));
+            SecretString::new(format!("{scheme}://{}{rest}", auth_prefix.expose_secret()))
+        };
+
+        Self::build(url.expose_secret(), timeout)
+    }
+
+    fn build(url: &str, timeout: Duration) -> Result<Self, ClientError> {
+        let inner = HttpClientBuilder::default()
+            .request_timeout(timeout)
+            .build(url)
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Performs a raw request, mapping a jsonrpsee error into either a structured
+    /// [`RpcError`] (for wallet-level call errors) or a transport [`ClientError`].
+    async fn request<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: &str,
+        params: ArrayParams,
+    ) -> CallResult<T> {
+        match self.inner.request::<T, _>(method, params).await {
+            Ok(value) => Ok(Ok(value)),
+            Err(jsonrpsee::core::client::Error::Call(err)) => Ok(Err(RpcError {
+                code: err.code(),
+                message: err.message().to_string(),
+            })),
+            Err(other) => Err(ClientError::Request(other.to_string())),
+        }
+    }
+
+    // --- Status & balances ------------------------------------------------------------
+
+    pub(super) async fn get_wallet_status(&self) -> CallResult<WalletStatus> {
+        self.request("getwalletstatus", ArrayParams::new()).await
+    }
+
+    pub(super) async fn get_wallet_info(&self) -> CallResult<WalletInfo> {
+        self.request("getwalletinfo", ArrayParams::new()).await
+    }
+
+    pub(super) async fn get_balances(&self, minconf: u32) -> CallResult<Balances> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(minconf))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_getbalances", params).await
+    }
+
+    pub(super) async fn get_total_balance(&self, minconf: u32) -> CallResult<TotalBalance> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(minconf))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        // `z_gettotalbalance` currently requires `include_watchonly = true`.
+        params
+            .insert(json!(true))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_gettotalbalance", params).await
+    }
+
+    // --- Accounts ---------------------------------------------------------------------
+
+    pub(super) async fn list_accounts(&self) -> CallResult<Vec<Account>> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(true))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_listaccounts", params).await
+    }
+
+    pub(super) async fn new_account(&self, name: &str) -> CallResult<serde_json::Value> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(name))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_getnewaccount", params).await
+    }
+
+    pub(super) async fn new_address_for_account(
+        &self,
+        account_uuid: &str,
+    ) -> CallResult<serde_json::Value> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(account_uuid))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_getaddressforaccount", params).await
+    }
+
+    // --- Transactions -----------------------------------------------------------------
+
+    pub(super) async fn list_transactions(
+        &self,
+        offset: u32,
+        limit: u32,
+    ) -> CallResult<Vec<WalletTx>> {
+        let mut params = ArrayParams::new();
+        // account_uuid, start_height, end_height: null (all)
+        params
+            .insert(serde_json::Value::Null)
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(serde_json::Value::Null)
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(serde_json::Value::Null)
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(json!(offset))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(json!(limit))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_listtransactions", params).await
+    }
+
+    // --- Wallet lock ------------------------------------------------------------------
+
+    pub(super) async fn unlock(&self, passphrase: &str, timeout: u64) -> CallResult<()> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(passphrase))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(json!(timeout))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        // `walletpassphrase` returns null on success.
+        self.request("walletpassphrase", params).await
+    }
+
+    pub(super) async fn lock(&self) -> CallResult<()> {
+        self.request("walletlock", ArrayParams::new()).await
+    }
+
+    // --- Sending ----------------------------------------------------------------------
+
+    /// Submits a `z_sendmany`, returning the async operation id.
+    pub(super) async fn send_many(
+        &self,
+        from: &str,
+        to: &str,
+        amount: &str,
+        memo: Option<&str>,
+        privacy_policy: &str,
+    ) -> CallResult<String> {
+        let mut recipient = serde_json::Map::new();
+        recipient.insert("address".into(), json!(to));
+        recipient.insert("amount".into(), json!(amount));
+        if let Some(memo) = memo {
+            recipient.insert("memo".into(), json!(memo));
+        }
+
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!(from))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(json!([serde_json::Value::Object(recipient)]))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(json!(1)) // minconf
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(serde_json::Value::Null) // fee: ZIP-317 automatic
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        params
+            .insert(json!(privacy_policy))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_sendmany", params).await
+    }
+
+    /// Polls the status of one async operation.
+    pub(super) async fn operation_status(&self, opid: &str) -> CallResult<Vec<OperationStatus>> {
+        let mut params = ArrayParams::new();
+        params
+            .insert(json!([opid]))
+            .map_err(|e| ClientError::Build(e.to_string()))?;
+        self.request("z_getoperationstatus", params).await
+    }
+}
+
+// --- Response types -------------------------------------------------------------------
+//
+// These mirror the JSON shapes produced by the wallet RPC. They are intentionally
+// tolerant: unknown fields are ignored, and optional fields are modelled as `Option`.
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct WalletStatus {
+    pub(super) node_tip: ChainTip,
+    #[serde(default)]
+    pub(super) wallet_tip: Option<ChainTip>,
+    #[serde(default)]
+    pub(super) fully_synced_height: Option<u32>,
+    #[serde(default)]
+    pub(super) sync_work_remaining: Option<SyncWorkRemaining>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct ChainTip {
+    pub(super) blockhash: String,
+    pub(super) height: u32,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct SyncWorkRemaining {
+    pub(super) unscanned_blocks: u32,
+    pub(super) progress: Progress,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct Progress {
+    pub(super) numerator: u64,
+    pub(super) denominator: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct TotalBalance {
+    pub(super) transparent: String,
+    pub(super) private: String,
+    pub(super) total: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct Balances {
+    #[serde(default)]
+    pub(super) accounts: Vec<AccountBalance>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct AccountBalance {
+    pub(super) account_uuid: String,
+    #[serde(default)]
+    pub(super) transparent: Option<String>,
+    #[serde(default)]
+    pub(super) sapling: Option<String>,
+    #[serde(default)]
+    pub(super) orchard: Option<String>,
+}
+
+/// The wallet's encryption and lock state, derived from `getwalletinfo`.
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct WalletInfo {
+    /// The timestamp (seconds since epoch) until which the wallet is unlocked, or `0` if
+    /// the wallet is encrypted but currently locked.
+    ///
+    /// This field is absent entirely when the wallet is unencrypted.
+    #[serde(default)]
+    pub(super) unlocked_until: Option<u64>,
+}
+
+impl WalletInfo {
+    /// The wallet's encryption/lock state.
+    pub(super) fn lock_state(&self) -> LockState {
+        match self.unlocked_until {
+            None => LockState::Unencrypted,
+            Some(0) => LockState::Locked,
+            Some(_) => LockState::Unlocked,
+        }
+    }
+}
+
+/// The encryption/lock state of the wallet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum LockState {
+    /// The wallet is not encrypted; there is no passphrase and nothing to unlock.
+    Unencrypted,
+    /// The wallet is encrypted and currently locked. Spending requires unlocking.
+    Locked,
+    /// The wallet is encrypted and currently unlocked.
+    Unlocked,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct Account {
+    pub(super) account_uuid: String,
+    #[serde(default)]
+    pub(super) name: Option<String>,
+    #[serde(default)]
+    pub(super) addresses: Vec<AccountAddress>,
+}
+
+impl Account {
+    /// A human-readable label for this account: its name, or a short UUID prefix.
+    pub(super) fn label(&self) -> String {
+        match &self.name {
+            Some(name) if !name.is_empty() => name.clone(),
+            _ => {
+                let short = if self.account_uuid.len() > 8 {
+                    &self.account_uuid[..8]
+                } else {
+                    &self.account_uuid
+                };
+                format!("({short})")
+            }
+        }
+    }
+
+    /// Returns a unified address owned by this account, suitable for use as a `z_sendmany`
+    /// source (`fromaddress`). `z_sendmany` does not accept account UUIDs, so the selected
+    /// account must be resolved to one of its addresses.
+    pub(super) fn spend_source_address(&self) -> Option<&str> {
+        self.addresses
+            .iter()
+            .find_map(|a| a.ua.as_deref())
+            .or_else(|| self.addresses.iter().find_map(|a| a.sapling.as_deref()))
+            .or_else(|| self.addresses.iter().find_map(|a| a.transparent.as_deref()))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct AccountAddress {
+    #[serde(default)]
+    pub(super) ua: Option<String>,
+    #[serde(default)]
+    pub(super) sapling: Option<String>,
+    #[serde(default)]
+    pub(super) transparent: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct WalletTx {
+    #[serde(default)]
+    pub(super) account_uuid: Option<String>,
+    #[serde(default)]
+    pub(super) mined_height: Option<u32>,
+    pub(super) txid: String,
+    pub(super) account_balance_delta: i64,
+    #[serde(default)]
+    pub(super) fee_paid: Option<i64>,
+    #[serde(default)]
+    pub(super) block_time: Option<i64>,
+    #[serde(default)]
+    pub(super) expired_unmined: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct OperationStatus {
+    pub(super) status: String,
+    #[serde(default)]
+    pub(super) error: Option<OperationError>,
+    #[serde(default)]
+    pub(super) result: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct OperationError {
+    #[serde(default)]
+    pub(super) message: Option<String>,
+}

--- a/zallet/src/commands/tui/event.rs
+++ b/zallet/src/commands/tui/event.rs
@@ -1,0 +1,60 @@
+//! Input and tick event handling for the TUI.
+
+use std::time::Duration;
+
+use crossterm::event::{Event as CtEvent, EventStream, KeyEvent};
+use futures::{FutureExt, StreamExt};
+use tokio::time::{Interval, MissedTickBehavior, interval};
+
+/// An event delivered to the TUI event loop.
+pub(super) enum Event {
+    /// A key was pressed.
+    Key(KeyEvent),
+    /// A periodic tick fired; the UI should refresh time-sensitive data.
+    Tick,
+    /// The terminal was resized.
+    Resize,
+}
+
+/// A combined stream of terminal input events and periodic ticks.
+pub(super) struct EventSource {
+    reader: EventStream,
+    ticker: Interval,
+}
+
+impl EventSource {
+    /// Creates an event source that ticks every `tick_rate`.
+    pub(super) fn new(tick_rate: Duration) -> Self {
+        let mut ticker = interval(tick_rate);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        Self {
+            reader: EventStream::new(),
+            ticker,
+        }
+    }
+
+    /// Waits for the next event (a key press, a resize, or a tick).
+    ///
+    /// Non-key terminal events other than resize are skipped transparently.
+    pub(super) async fn next(&mut self) -> Event {
+        loop {
+            tokio::select! {
+                _ = self.ticker.tick() => return Event::Tick,
+                maybe = self.reader.next().fuse() => {
+                    match maybe {
+                        Some(Ok(CtEvent::Key(key))) => return Event::Key(key),
+                        Some(Ok(CtEvent::Resize(_, _))) => return Event::Resize,
+                        // Mouse / focus / paste events: ignore and keep waiting.
+                        Some(Ok(_)) => continue,
+                        // Read error or end of stream: fall back to ticking so the UI
+                        // stays responsive rather than spinning.
+                        Some(Err(_)) | None => {
+                            self.ticker.tick().await;
+                            return Event::Tick;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/zallet/src/commands/tui/qr.rs
+++ b/zallet/src/commands/tui/qr.rs
@@ -1,0 +1,90 @@
+//! Rendering of strings (addresses) as terminal QR codes.
+
+use qrcode::{EcLevel, QrCode};
+use ratatui::{
+    style::{Color, Style},
+    text::{Line, Span},
+};
+
+/// A rendered QR code, with the terminal dimensions it occupies.
+pub(super) struct RenderedQr {
+    pub(super) lines: Vec<Line<'static>>,
+    /// Width in terminal columns.
+    pub(super) width: u16,
+    /// Height in terminal rows.
+    pub(super) height: u16,
+}
+
+/// Renders the given data as a QR code, returning one [`Line`] per two rows of QR modules.
+///
+/// Two vertical modules are packed into each character cell using the unicode half-block
+/// characters, so the resulting QR code is roughly square in a typical terminal. Returns
+/// `None` if the data cannot be encoded as a QR code (e.g. it is too long).
+pub(super) fn render(data: &str) -> Option<RenderedQr> {
+    let code = QrCode::with_error_correction_level(data.as_bytes(), EcLevel::M).ok()?;
+    let width = code.width();
+    let modules = code.to_colors();
+
+    // `dark(x, y)` is true when the module is dark (should be drawn).
+    let dark = |x: usize, y: usize| -> bool {
+        if x >= width || y >= width {
+            // Treat out-of-bounds (the odd row of an odd-height code) as light.
+            false
+        } else {
+            modules[y * width + x] == qrcode::Color::Dark
+        }
+    };
+
+    // One character of horizontal quiet zone on each side.
+    const QUIET: usize = 1;
+
+    let mut lines = Vec::with_capacity(width / 2 + 1 + QUIET * 2);
+
+    // Explicitly pin dark modules to black and light modules to white, rather than relying
+    // on the terminal's default colors. The half-block glyphs encode the top module in the
+    // cell's foreground and the bottom module in its background, so with `fg = black` and
+    // `bg = white` every module renders dark-on-light regardless of the terminal's theme
+    // (a light-on-dark terminal would otherwise produce an inverted code that some scanners
+    // reject).
+    let style = Style::default().fg(Color::Black).bg(Color::White);
+
+    // Top quiet zone (one blank line covers two module rows).
+    let total_width = width + QUIET * 2;
+    let blank: String = " ".repeat(total_width);
+    lines.push(Line::from(Span::styled(blank.clone(), style)));
+
+    let mut y = 0;
+    while y < width {
+        let mut s = String::with_capacity(total_width);
+        // Left quiet zone.
+        for _ in 0..QUIET {
+            s.push(' ');
+        }
+        for x in 0..width {
+            let top = dark(x, y);
+            let bottom = dark(x, y + 1);
+            // Foreground = dark module. Use half blocks so two rows fit one cell.
+            s.push(match (top, bottom) {
+                (true, true) => '\u{2588}',  // full block
+                (true, false) => '\u{2580}', // upper half block
+                (false, true) => '\u{2584}', // lower half block
+                (false, false) => ' ',
+            });
+        }
+        for _ in 0..QUIET {
+            s.push(' ');
+        }
+        lines.push(Line::from(Span::styled(s, style)));
+        y += 2;
+    }
+
+    // Bottom quiet zone.
+    lines.push(Line::from(Span::styled(blank, style)));
+
+    let height = lines.len() as u16;
+    Some(RenderedQr {
+        lines,
+        width: total_width as u16,
+        height,
+    })
+}

--- a/zallet/src/commands/tui/terminal.rs
+++ b/zallet/src/commands/tui/terminal.rs
@@ -1,0 +1,84 @@
+//! Terminal setup and teardown for the TUI.
+
+use std::io::{self, Stdout};
+
+use crossterm::{
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+
+/// Alias for the concrete terminal type used by the TUI.
+pub(super) type Tui = Terminal<CrosstermBackend<Stdout>>;
+
+/// An RAII guard that places the terminal into raw mode and the alternate screen on
+/// construction, and restores it on drop.
+///
+/// Restoring on drop ensures the user's terminal is not left in a broken state if the UI
+/// panics. [`TerminalGuard::restore`] can be called explicitly to restore early (e.g. so
+/// that an error message is printed to a normal terminal); it is idempotent.
+pub(super) struct TerminalGuard {
+    terminal: Option<Tui>,
+    restored: bool,
+}
+
+impl TerminalGuard {
+    /// Enters raw mode and the alternate screen, returning a guard that owns the terminal.
+    ///
+    /// If setup fails partway through (e.g. entering the alternate screen or constructing
+    /// the terminal fails after raw mode was enabled), any state already changed is rolled
+    /// back before returning the error, so the user's terminal is not left in raw mode.
+    pub(super) fn enter() -> io::Result<Self> {
+        enable_raw_mode()?;
+
+        // From here on, undo raw mode (and the alternate screen) if anything fails, since
+        // no `Drop` guard exists yet to restore it.
+        let setup = (|| {
+            let mut stdout = io::stdout();
+            execute!(stdout, EnterAlternateScreen)?;
+            let backend = CrosstermBackend::new(stdout);
+            Terminal::new(backend)
+        })();
+
+        match setup {
+            Ok(terminal) => Ok(Self {
+                terminal: Some(terminal),
+                restored: false,
+            }),
+            Err(e) => {
+                // Best-effort rollback; preserve and return the original error.
+                let _ = disable_raw_mode();
+                let _ = execute!(io::stdout(), LeaveAlternateScreen);
+                Err(e)
+            }
+        }
+    }
+
+    /// Returns a mutable reference to the underlying terminal.
+    pub(super) fn terminal_mut(&mut self) -> &mut Tui {
+        self.terminal
+            .as_mut()
+            .expect("terminal is present until the guard is dropped")
+    }
+
+    /// Restores the terminal to its original state. Idempotent.
+    pub(super) fn restore(&mut self) {
+        if self.restored {
+            return;
+        }
+        self.restored = true;
+
+        // Best-effort restoration; nothing useful can be done if these fail.
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        if let Some(terminal) = self.terminal.as_mut() {
+            let _ = terminal.show_cursor();
+        }
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}

--- a/zallet/src/commands/tui/ui.rs
+++ b/zallet/src/commands/tui/ui.rs
@@ -1,0 +1,326 @@
+//! Top-level rendering: tab bar, status bar, modals, and view dispatch.
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Tabs, Wrap},
+};
+
+use super::app::{App, Focus, View};
+use super::client::LockState;
+use super::views;
+
+/// Renders the entire UI for one frame.
+pub(super) fn render(app: &App, frame: &mut Frame<'_>) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // tab bar
+            Constraint::Length(1), // sync bar (visible on every screen)
+            Constraint::Min(0),    // body
+            Constraint::Length(1), // status/footer
+        ])
+        .split(frame.area());
+
+    render_tabs(app, frame, chunks[0]);
+    render_sync_bar(app, frame, chunks[1]);
+
+    // When the wallet is locked, the body is replaced by a mandatory unlock screen so the
+    // wallet never appears usable. The Logs view is exempt: it shows no wallet data and is
+    // useful for diagnosing why the wallet may be locked or failing to start.
+    if app.is_gated() && app.view != View::Logs {
+        render_locked(app, frame, chunks[2]);
+    } else {
+        render_body(app, frame, chunks[2]);
+    }
+    render_footer(app, frame, chunks[3]);
+
+    if app.show_help {
+        render_help(frame);
+    }
+    if let Some(prompt) = &app.prompt {
+        render_prompt(prompt, frame);
+    }
+}
+
+/// Renders a compact, always-visible wallet-wide sync progress bar.
+fn render_sync_bar(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    use ratatui::widgets::LineGauge;
+
+    let summary = app.sync_summary();
+
+    // Build a descriptive label shown alongside the bar.
+    let mut label = summary.short_label();
+    if let (Some(synced), Some(node)) = (summary.synced_height, summary.node_height) {
+        label.push_str("  ");
+        label.push_str(&crate::fl!(
+            "tui-sync-heights",
+            synced = synced,
+            node = node
+        ));
+    } else if let Some(node) = summary.node_height {
+        label.push_str("  ");
+        label.push_str(&crate::fl!("tui-sync-tip", node = node));
+    }
+    if let Some(remaining) = summary.unscanned_blocks {
+        if remaining > 0 {
+            label.push_str("  ");
+            label.push_str(&crate::fl!("tui-sync-blocks-left", remaining = remaining));
+        }
+    }
+
+    let ratio = summary.fraction.unwrap_or(0.0);
+    let color = if summary.synced {
+        Color::Green
+    } else {
+        Color::Cyan
+    };
+
+    let gauge = LineGauge::default()
+        .filled_style(Style::default().fg(color).add_modifier(Modifier::BOLD))
+        .unfilled_style(Style::default().fg(Color::DarkGray))
+        .label(format!(" {label} "))
+        .ratio(ratio);
+    frame.render_widget(gauge, area);
+}
+
+fn render_tabs(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let titles: Vec<Line<'_>> = View::ALL
+        .iter()
+        .enumerate()
+        .map(|(i, v)| Line::from(format!(" {}:{} ", i + 1, v.title())))
+        .collect();
+
+    let selected = View::ALL.iter().position(|&v| v == app.view).unwrap_or(0);
+
+    // The header is highlighted (cyan border) when focus is on the tab row.
+    let border_style = match app.focus {
+        Focus::Tabs => Style::default().fg(Color::Cyan),
+        Focus::View => Style::default().fg(Color::DarkGray),
+    };
+    let highlight_style = match app.focus {
+        Focus::Tabs => Style::default()
+            .fg(Color::Black)
+            .bg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+        Focus::View => Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    };
+
+    let title = format!(
+        " {} ",
+        crate::fl!("tui-header-title", lock = lock_label(app.lock_state))
+    );
+    let tabs = Tabs::new(titles)
+        .select(selected)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(title)
+                .title_alignment(Alignment::Left),
+        )
+        .highlight_style(highlight_style);
+    frame.render_widget(tabs, area);
+}
+
+fn lock_label(state: LockState) -> String {
+    match state {
+        LockState::Unencrypted => crate::fl!("tui-lock-unencrypted"),
+        LockState::Locked => crate::fl!("tui-lock-locked"),
+        LockState::Unlocked => crate::fl!("tui-lock-unlocked"),
+    }
+}
+
+fn render_locked(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-locked-title")))
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  {}", crate::fl!("tui-locked-line1")),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(format!("  {}", crate::fl!("tui-locked-line2"))),
+        Line::from(format!("  {}", crate::fl!("tui-locked-line3"))),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  {}", crate::fl!("tui-locked-hint")),
+            Style::default().fg(Color::Cyan),
+        )),
+    ];
+
+    if app.prompt.is_none() {
+        if let Some(toast) = &app.toast {
+            if toast.is_error {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", toast.text),
+                    Style::default().fg(Color::Red),
+                )));
+            }
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_body(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    match app.view {
+        View::Dashboard => views::dashboard::render(app, frame, area),
+        View::Accounts => views::accounts::render(app, frame, area),
+        View::Balances => views::balances::render(app, frame, area),
+        View::Addresses => views::addresses::render(app, frame, area),
+        View::Transactions => views::transactions::render(app, frame, area),
+        View::Send => views::send::render(app, frame, area),
+        View::Logs => views::logs::render(app, frame, area),
+    }
+}
+
+fn render_footer(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let hint = if app.is_gated() {
+        crate::fl!("tui-footer-gated")
+    } else {
+        let lock_hint = match app.lock_state {
+            LockState::Unencrypted => String::new(),
+            LockState::Locked => crate::fl!("tui-footer-unlock"),
+            LockState::Unlocked => crate::fl!("tui-footer-lock"),
+        };
+        let nav = match app.focus {
+            Focus::Tabs => crate::fl!("tui-footer-nav-tabs"),
+            Focus::View => crate::fl!("tui-footer-nav-view"),
+        };
+        crate::fl!("tui-footer-hint", nav = nav, lock = lock_hint)
+    };
+
+    let mut spans = vec![Span::styled(
+        format!(" {hint} "),
+        Style::default().fg(Color::DarkGray),
+    )];
+
+    if let Some(toast) = &app.toast {
+        let style = if toast.is_error {
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Green)
+        };
+        spans.push(Span::styled(format!("— {}", toast.text), style));
+    }
+
+    let footer = Paragraph::new(Line::from(spans));
+    frame.render_widget(footer, area);
+}
+
+fn render_help(frame: &mut Frame<'_>) {
+    let area = centered_rect(60, 70, frame.area());
+    frame.render_widget(Clear, area);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            crate::fl!("tui-help-nav-header"),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(format!("  {}", crate::fl!("tui-help-nav-esc"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-nav-switch-tabs"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-nav-enter"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-nav-switch-view"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-nav-jump"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-nav-select"))),
+        Line::from(""),
+        Line::from(Span::styled(
+            crate::fl!("tui-help-global-header"),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(format!("  {}", crate::fl!("tui-help-global-refresh"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-global-unlock"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-global-lock"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-global-help"))),
+        Line::from(format!("  {}", crate::fl!("tui-help-global-quit"))),
+        Line::from(""),
+        Line::from(Span::styled(
+            crate::fl!("tui-help-accounts"),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            crate::fl!("tui-help-transactions"),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            crate::fl!("tui-help-logs"),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            crate::fl!("tui-help-close"),
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-help-title")))
+        .border_style(Style::default().fg(Color::Cyan));
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_prompt(prompt: &super::app::Prompt, frame: &mut Frame<'_>) {
+    let area = centered_rect(50, 20, frame.area());
+    frame.render_widget(Clear, area);
+
+    let display = if prompt.masked {
+        "*".repeat(prompt.value.chars().count())
+    } else {
+        prompt.value.clone()
+    };
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::raw(format!("  {display}_"))),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  {}", crate::fl!("tui-prompt-hint")),
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", prompt.title))
+        .border_style(Style::default().fg(Color::Yellow));
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+/// Returns a `Rect` centered in `area`, sized to a percentage of it.
+pub(super) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}

--- a/zallet/src/commands/tui/views.rs
+++ b/zallet/src/commands/tui/views.rs
@@ -1,0 +1,9 @@
+//! The individual views (screens) of the TUI.
+
+pub(super) mod accounts;
+pub(super) mod addresses;
+pub(super) mod balances;
+pub(super) mod dashboard;
+pub(super) mod logs;
+pub(super) mod send;
+pub(super) mod transactions;

--- a/zallet/src/commands/tui/views/accounts.rs
+++ b/zallet/src/commands/tui/views/accounts.rs
@@ -1,0 +1,135 @@
+//! Accounts view.
+
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState},
+};
+
+use crate::commands::tui::app::App;
+use crate::commands::tui::client::AccountBalance;
+
+pub(crate) async fn on_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.accounts_selected + 1 < app.data.accounts.len() {
+                app.accounts_selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.accounts_selected = app.accounts_selected.saturating_sub(1);
+        }
+        KeyCode::Char('n') => app.open_new_account_prompt(),
+        _ => {}
+    }
+}
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    if app.data.accounts.is_empty() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} ", crate::fl!("tui-accounts-title")));
+        let p = ratatui::widgets::Paragraph::new(crate::fl!("tui-accounts-empty"))
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(p, area);
+        return;
+    }
+
+    // Build a per-account balance lookup once, keyed by account UUID, so rendering each row
+    // is O(1) rather than scanning the full balance list per account.
+    let balances: HashMap<&str, &AccountBalance> = app
+        .data
+        .balances
+        .as_ref()
+        .map(|b| {
+            b.accounts
+                .iter()
+                .map(|a| (a.account_uuid.as_str(), a))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let items: Vec<ListItem<'_>> = app
+        .data
+        .accounts
+        .iter()
+        .map(|acct| {
+            let name = acct
+                .name
+                .clone()
+                .unwrap_or_else(|| crate::fl!("tui-value-unnamed"));
+            let balance = account_balance(&balances, &acct.account_uuid);
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("{name:<24}"),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{}  ", short_uuid(&acct.account_uuid)),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(balance, Style::default().fg(Color::Green)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" {} ", crate::fl!("tui-accounts-title-list"))),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut state = ListState::default();
+    state.select(Some(app.accounts_selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+/// Sums the per-pool balances for an account into a display string.
+fn account_balance(balances: &HashMap<&str, &AccountBalance>, uuid: &str) -> String {
+    let Some(acct) = balances.get(uuid) else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    if let Some(t) = &acct.transparent {
+        parts.push(crate::fl!(
+            "tui-accounts-balance-transparent",
+            amount = t.clone()
+        ));
+    }
+    if let Some(s) = &acct.sapling {
+        parts.push(crate::fl!(
+            "tui-accounts-balance-sapling",
+            amount = s.clone()
+        ));
+    }
+    if let Some(o) = &acct.orchard {
+        parts.push(crate::fl!(
+            "tui-accounts-balance-orchard",
+            amount = o.clone()
+        ));
+    }
+    parts.join("  ")
+}
+
+fn short_uuid(uuid: &str) -> String {
+    if uuid.len() > 8 {
+        uuid[..8].to_string()
+    } else {
+        uuid.to_string()
+    }
+}

--- a/zallet/src/commands/tui/views/addresses.rs
+++ b/zallet/src/commands/tui/views/addresses.rs
@@ -1,0 +1,296 @@
+//! Addresses / receive view: per-account address list with QR rendering.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::commands::tui::{app::App, qr};
+
+pub(crate) async fn on_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        // Account selector.
+        KeyCode::Left | KeyCode::Char('h') => {
+            select_prev_account(app);
+            app.addresses_selected = 0;
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            select_next_account(app);
+            app.addresses_selected = 0;
+        }
+        // Address selector within the account.
+        KeyCode::Down | KeyCode::Char('j') => {
+            let n = account_addresses(app).len();
+            if app.addresses_selected + 1 < n {
+                app.addresses_selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.addresses_selected = app.addresses_selected.saturating_sub(1);
+        }
+        KeyCode::Char('a') => derive_new_address(app).await,
+        _ => {}
+    }
+}
+
+fn select_next_account(app: &mut App) {
+    if !app.data.accounts.is_empty() {
+        app.receive_account = (app.receive_account + 1) % app.data.accounts.len();
+    }
+}
+
+fn select_prev_account(app: &mut App) {
+    if !app.data.accounts.is_empty() {
+        let n = app.data.accounts.len();
+        app.receive_account = (app.receive_account + n - 1) % n;
+    }
+}
+
+async fn derive_new_address(app: &mut App) {
+    let Some(account) = app.data.accounts.get(app.receive_account) else {
+        app.error(crate::fl!("tui-addr-no-account-selected"));
+        return;
+    };
+    let uuid = account.account_uuid.clone();
+    match app.client().new_address_for_account(&uuid).await {
+        Ok(Ok(_)) => {
+            app.info(crate::fl!("tui-addr-derived"));
+            app.refresh().await;
+        }
+        Ok(Err(e)) if e.is_unlock_needed() => {
+            app.error(crate::fl!("tui-err-locked-press-u-upper"));
+        }
+        Ok(Err(e)) => app.error(crate::fl!(
+            "tui-err-rpc-call",
+            method = "z_getaddressforaccount",
+            error = e.to_string()
+        )),
+        Err(e) => app.error(e.to_string()),
+    }
+}
+
+/// A single receiving address with a label for its kind.
+struct AddressEntry {
+    kind: String,
+    address: String,
+}
+
+/// Collects the receiving addresses for the currently-selected account.
+fn account_addresses(app: &App) -> Vec<AddressEntry> {
+    let Some(account) = app.data.accounts.get(app.receive_account) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for addr in &account.addresses {
+        if let Some(ua) = &addr.ua {
+            out.push(AddressEntry {
+                kind: crate::fl!("tui-addr-kind-unified"),
+                address: ua.clone(),
+            });
+        }
+        if let Some(sapling) = &addr.sapling {
+            out.push(AddressEntry {
+                kind: crate::fl!("tui-addr-kind-sapling"),
+                address: sapling.clone(),
+            });
+        }
+        if let Some(t) = &addr.transparent {
+            out.push(AddressEntry {
+                kind: crate::fl!("tui-addr-kind-transparent"),
+                address: t.clone(),
+            });
+        }
+    }
+    out
+}
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let addresses = account_addresses(app);
+
+    // Reserve a one-line account selector at the top, then split the rest between the
+    // address list and the detail/QR pane. The split direction adapts to the terminal
+    // size: side-by-side when wide, stacked when narrow.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(area);
+
+    render_account_selector(app, frame, chunks[0]);
+
+    let body = chunks[1];
+    // A QR plus borders needs a fair amount of width; only go side-by-side when there is
+    // comfortably enough room for both a readable list and the detail pane.
+    let side_by_side = body.width >= 72;
+
+    let panes = if side_by_side {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(28), Constraint::Min(0)])
+            .split(body)
+    } else {
+        // Stacked: a compact list on top, detail (with QR if it fits) below.
+        let list_height = (addresses.len() as u16 + 2).min(body.height / 2).max(3);
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(list_height), Constraint::Min(0)])
+            .split(body)
+    };
+
+    render_list(app, &addresses, frame, panes[0]);
+    render_detail(app, &addresses, frame, panes[1]);
+}
+
+fn render_account_selector(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let label = match app.data.accounts.get(app.receive_account) {
+        Some(account) => format!("◀ {} ▶", account.label()),
+        None => crate::fl!("tui-addr-no-accounts"),
+    };
+    // Keep the hint short, and drop it entirely on very narrow terminals.
+    let mut spans = vec![
+        Span::styled(
+            crate::fl!("tui-addr-account-label"),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            label,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
+    if area.width >= 56 {
+        spans.push(Span::styled(
+            format!("   {}", crate::fl!("tui-addr-account-hint")),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn render_list(app: &App, addresses: &[AddressEntry], frame: &mut Frame<'_>, area: Rect) {
+    if addresses.is_empty() {
+        let p = Paragraph::new(crate::fl!("tui-addr-empty"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!(" {} ", crate::fl!("tui-addr-title"))),
+            )
+            .style(Style::default().fg(Color::DarkGray))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(p, area);
+        return;
+    }
+
+    // The address text is truncated to whatever width is left after the kind column and
+    // the list chrome, so the list never overflows a narrow pane.
+    let avail = area.width.saturating_sub(2 + 2 + 13) as usize; // borders, marker, kind col
+    let items: Vec<ListItem<'_>> = addresses
+        .iter()
+        .map(|entry| {
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{:<12}", entry.kind),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::raw(truncate(&entry.address, avail.max(8))),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" {} ", crate::fl!("tui-addr-title"))),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut state = ListState::default();
+    state.select(Some(app.addresses_selected.min(addresses.len() - 1)));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+/// Renders the detail pane for the selected address: its kind, the full address (wrapped
+/// to the pane width), and a QR code if there is room to draw one.
+fn render_detail(app: &App, addresses: &[AddressEntry], frame: &mut Frame<'_>, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-addr-receive-title")));
+
+    let Some(entry) = addresses.get(
+        app.addresses_selected
+            .min(addresses.len().saturating_sub(1)),
+    ) else {
+        let p = Paragraph::new(crate::fl!("tui-addr-select"))
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(p, area);
+        return;
+    };
+
+    // Interior dimensions (inside the border).
+    let inner_w = area.width.saturating_sub(2);
+    let inner_h = area.height.saturating_sub(2);
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    // The address kind and full address text always shown (wrapped by the Paragraph).
+    lines.push(Line::from(Span::styled(
+        entry.kind.clone(),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(Span::styled(
+        entry.address.clone(),
+        Style::default().fg(Color::Gray),
+    )));
+    lines.push(Line::from(""));
+
+    // Render the QR only if it fits within the remaining interior space; otherwise show a
+    // short hint so the pane stays usable on small terminals.
+    let address_rows = ((entry.address.len() as u16) / inner_w.max(1)) + 1;
+    let rows_left = inner_h.saturating_sub(2 + address_rows + 1);
+    match qr::render(&entry.address) {
+        Some(rendered) if rendered.width <= inner_w && rendered.height <= rows_left => {
+            lines.extend(rendered.lines);
+        }
+        Some(_) => {
+            lines.push(Line::from(Span::styled(
+                crate::fl!("tui-addr-qr-enlarge"),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+        None => {
+            lines.push(Line::from(Span::styled(
+                crate::fl!("tui-addr-qr-too-long"),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+
+    let p = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(p, area);
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let head: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{head}…")
+    } else {
+        s.to_string()
+    }
+}

--- a/zallet/src/commands/tui/views/balances.rs
+++ b/zallet/src/commands/tui/views/balances.rs
@@ -1,0 +1,103 @@
+//! Per-account balances view, with a `minconf` control.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+};
+
+use crate::commands::tui::app::App;
+
+pub(crate) fn on_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        // Adjust minconf with +/- (and the unshifted '=' for convenience).
+        KeyCode::Char('+') | KeyCode::Char('=') => {
+            app.data.minconf = app.data.minconf.saturating_add(1);
+        }
+        KeyCode::Char('-') => {
+            app.data.minconf = app.data.minconf.saturating_sub(1);
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from(crate::fl!("tui-bal-header-account")),
+        Cell::from(crate::fl!("tui-bal-header-transparent")),
+        Cell::from(crate::fl!("tui-bal-header-sapling")),
+        Cell::from(crate::fl!("tui-bal-header-orchard")),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row<'_>> = match &app.data.balances {
+        Some(balances) => balances
+            .accounts
+            .iter()
+            .map(|acct| {
+                let name = app
+                    .data
+                    .accounts
+                    .iter()
+                    .find(|a| a.account_uuid == acct.account_uuid)
+                    .and_then(|a| a.name.clone())
+                    .unwrap_or_else(|| short_uuid(&acct.account_uuid));
+                Row::new(vec![
+                    Cell::from(name),
+                    Cell::from(acct.transparent.clone().unwrap_or_else(|| "0".into())),
+                    Cell::from(acct.sapling.clone().unwrap_or_else(|| "0".into())),
+                    Cell::from(acct.orchard.clone().unwrap_or_else(|| "0".into())),
+                ])
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+
+    let title = format!(
+        " {} ",
+        crate::fl!("tui-bal-title", minconf = app.data.minconf)
+    );
+
+    if app.data.balances_syncing {
+        let p = Paragraph::new(crate::fl!("tui-bal-syncing"))
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .style(Style::default().fg(Color::Yellow));
+        frame.render_widget(p, area);
+        return;
+    }
+
+    if rows.is_empty() {
+        let p = Paragraph::new(crate::fl!("tui-bal-empty"))
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(p, area);
+        return;
+    }
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(34),
+            Constraint::Percentage(22),
+            Constraint::Percentage(22),
+            Constraint::Percentage(22),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(title));
+    frame.render_widget(table, area);
+}
+
+fn short_uuid(uuid: &str) -> String {
+    if uuid.len() > 8 {
+        uuid[..8].to_string()
+    } else {
+        uuid.to_string()
+    }
+}

--- a/zallet/src/commands/tui/views/dashboard.rs
+++ b/zallet/src/commands/tui/views/dashboard.rs
@@ -1,0 +1,191 @@
+//! Dashboard / status view.
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Gauge, Paragraph},
+};
+
+use crate::commands::tui::app::App;
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(8), // status
+            Constraint::Length(3), // sync gauge
+            Constraint::Min(0),    // balances
+        ])
+        .split(area);
+
+    render_status(app, frame, chunks[0]);
+    render_sync(app, frame, chunks[1]);
+    render_balances(app, frame, chunks[2]);
+}
+
+fn render_status(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let mut lines = Vec::new();
+
+    match &app.data.status {
+        Some(status) => {
+            lines.push(field(
+                &crate::fl!("tui-dash-node-tip"),
+                status.node_tip.height.to_string(),
+            ));
+            lines.push(field(
+                &crate::fl!("tui-dash-node-hash"),
+                shorten(&status.node_tip.blockhash),
+            ));
+            match &status.wallet_tip {
+                Some(tip) => lines.push(field(
+                    &crate::fl!("tui-dash-wallet-tip"),
+                    tip.height.to_string(),
+                )),
+                None => lines.push(field(
+                    &crate::fl!("tui-dash-wallet-tip"),
+                    crate::fl!("tui-dash-not-syncing"),
+                )),
+            }
+            match status.fully_synced_height {
+                Some(h) => lines.push(field(
+                    &crate::fl!("tui-dash-fully-synced-to"),
+                    h.to_string(),
+                )),
+                None => lines.push(field(
+                    &crate::fl!("tui-dash-fully-synced-to"),
+                    "—".to_string(),
+                )),
+            }
+        }
+        None => lines.push(Line::from(Span::styled(
+            crate::fl!("tui-dash-loading-status"),
+            Style::default().fg(Color::DarkGray),
+        ))),
+    }
+
+    lines.push(field(
+        &crate::fl!("tui-dash-accounts"),
+        app.data.accounts.len().to_string(),
+    ));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-dash-status-title")));
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_sync(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let (ratio, label) = match app
+        .data
+        .status
+        .as_ref()
+        .and_then(|s| s.sync_work_remaining.as_ref())
+    {
+        Some(work) => {
+            let p = &work.progress;
+            let ratio = if p.denominator == 0 {
+                1.0
+            } else {
+                (p.numerator as f64 / p.denominator as f64).clamp(0.0, 1.0)
+            };
+            (
+                ratio,
+                crate::fl!(
+                    "tui-dash-sync-progress",
+                    percent = format!("{:.1}", ratio * 100.0),
+                    blocks = work.unscanned_blocks
+                ),
+            )
+        }
+        // No work remaining means fully synced (or no data yet).
+        None => (1.0, crate::fl!("tui-dash-fully-synced")),
+    };
+
+    let gauge = Gauge::default()
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" {} ", crate::fl!("tui-dash-sync-title"))),
+        )
+        .gauge_style(Style::default().fg(Color::Cyan))
+        .ratio(ratio)
+        .label(label);
+    frame.render_widget(gauge, area);
+}
+
+fn render_balances(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let mut lines = Vec::new();
+
+    if app.data.balances_syncing {
+        lines.push(Line::from(Span::styled(
+            crate::fl!("tui-dash-balances-syncing"),
+            Style::default().fg(Color::Yellow),
+        )));
+    } else {
+        match &app.data.total_balance {
+            Some(tb) => {
+                lines.push(big_field(
+                    &crate::fl!("tui-dash-total"),
+                    &tb.total,
+                    Color::Green,
+                ));
+                lines.push(field(
+                    &crate::fl!("tui-dash-shielded"),
+                    crate::fl!("tui-amount-zec", amount = tb.private.clone()),
+                ));
+                lines.push(field(
+                    &crate::fl!("tui-dash-transparent"),
+                    crate::fl!("tui-amount-zec", amount = tb.transparent.clone()),
+                ));
+            }
+            None => lines.push(Line::from(Span::styled(
+                crate::fl!("tui-dash-total-unavailable"),
+                Style::default().fg(Color::DarkGray),
+            ))),
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        crate::fl!("tui-dash-minconf", minconf = app.data.minconf),
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-dash-balance-title")));
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn field(label: &str, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:>18}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw(value),
+    ])
+}
+
+fn big_field(label: &str, value: &str, color: Color) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:>18}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            crate::fl!("tui-amount-zec", amount = value),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+fn shorten(hash: &str) -> String {
+    if hash.len() > 20 {
+        format!("{}…{}", &hash[..10], &hash[hash.len() - 8..])
+    } else {
+        hash.to_string()
+    }
+}

--- a/zallet/src/commands/tui/views/logs.rs
+++ b/zallet/src/commands/tui/views/logs.rs
@@ -1,0 +1,109 @@
+//! Logs view: shows the tail of the TUI's log file and its path.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use crate::commands::tui::app::App;
+
+pub(crate) fn on_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        // Scroll up into history (increases offset from the bottom).
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.logs.scroll_from_bottom = app.logs.scroll_from_bottom.saturating_add(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.logs.scroll_from_bottom = app.logs.scroll_from_bottom.saturating_sub(1);
+        }
+        KeyCode::PageUp => {
+            app.logs.scroll_from_bottom = app.logs.scroll_from_bottom.saturating_add(20);
+        }
+        KeyCode::PageDown => {
+            app.logs.scroll_from_bottom = app.logs.scroll_from_bottom.saturating_sub(20);
+        }
+        // `G` jumps to the bottom (follow the tail); `g` jumps to the top.
+        KeyCode::Char('G') => app.logs.scroll_from_bottom = 0,
+        KeyCode::Char('g') => {
+            app.logs.scroll_from_bottom = app.logs.lines.len();
+        }
+        // Reload the file now.
+        KeyCode::Char('R') => app.load_logs(),
+        _ => {}
+    }
+}
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(area);
+
+    render_path(app, frame, chunks[0]);
+    render_body(app, frame, chunks[1]);
+}
+
+fn render_path(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let line = match &app.logs.path {
+        Some(path) => Line::from(vec![
+            Span::styled(
+                crate::fl!("tui-logs-file-label"),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(
+                path.display().to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        None => Line::from(Span::styled(
+            format!(" {}", crate::fl!("tui-logs-remote")),
+            Style::default().fg(Color::DarkGray),
+        )),
+    };
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+fn render_body(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let following = app.logs.scroll_from_bottom == 0;
+    let state = if following {
+        crate::fl!("tui-logs-following")
+    } else {
+        crate::fl!("tui-logs-scrolled")
+    };
+    let title = format!(" {} ", crate::fl!("tui-logs-title", state = state));
+    let block = Block::default().borders(Borders::ALL).title(title);
+
+    if let Some(err) = &app.logs.read_error {
+        let p = Paragraph::new(err.clone())
+            .block(block)
+            .style(Style::default().fg(Color::Red))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(p, area);
+        return;
+    }
+
+    // The visible window is the last `height` lines, offset upward by `scroll_from_bottom`.
+    let height = area.height.saturating_sub(2) as usize; // account for borders
+    let total = app.logs.lines.len();
+
+    // Clamp the scroll so we never go past the top.
+    let max_scroll = total.saturating_sub(height);
+    let scroll = app.logs.scroll_from_bottom.min(max_scroll);
+
+    let end = total.saturating_sub(scroll);
+    let start = end.saturating_sub(height);
+
+    let lines: Vec<Line<'_>> = app.logs.lines[start..end]
+        .iter()
+        .map(|l| Line::from(Span::raw(l.clone())))
+        .collect();
+
+    let p = Paragraph::new(lines).block(block);
+    frame.render_widget(p, area);
+}

--- a/zallet/src/commands/tui/views/send.rs
+++ b/zallet/src/commands/tui/views/send.rs
@@ -1,0 +1,445 @@
+//! Send view: a form for `z_sendmany` with confirmation and inline operation polling.
+//!
+//! The "from" field is an account selector rather than free text: `z_sendmany` requires an
+//! address as its source, so the selected account is resolved to one of its addresses (a
+//! unified address where possible) at submit time.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use crate::commands::tui::app::{App, PRIVACY_POLICIES, SendField};
+
+/// Handles a key event for the send view.
+///
+/// View navigation (`Esc`, `Tab`, `BackTab`) is handled by the caller unless a text field
+/// is being edited, in which case all keys are routed here.
+pub(crate) async fn on_key(app: &mut App, key: KeyEvent) {
+    // While confirming, only y/n are meaningful.
+    if app.send.confirming {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                app.send.confirming = false;
+                submit(app).await;
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                app.send.confirming = false;
+                app.info(crate::fl!("tui-send-cancelled"));
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    // Editing mode: keystrokes go into the focused text field until Esc/Enter leaves it.
+    if app.send.editing {
+        match key.code {
+            KeyCode::Esc | KeyCode::Enter => app.send.editing = false,
+            KeyCode::Backspace => {
+                if let Some(buf) = text_field_mut(app) {
+                    buf.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let Some(buf) = text_field_mut(app) {
+                    buf.push(c);
+                }
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    // Navigation mode: keys move between fields and operate selectors.
+    match key.code {
+        KeyCode::Down | KeyCode::Char('j') => app.send.field = next_field(app.send.field),
+        KeyCode::Up | KeyCode::Char('k') => app.send.field = prev_field(app.send.field),
+
+        // Selectors respond to left/right (and h/l).
+        KeyCode::Left | KeyCode::Char('h') if app.send.field == SendField::From => {
+            select_prev_account(app)
+        }
+        KeyCode::Right | KeyCode::Char('l') if app.send.field == SendField::From => {
+            select_next_account(app)
+        }
+        KeyCode::Left | KeyCode::Char('h') if app.send.field == SendField::PrivacyPolicy => {
+            app.send.privacy_policy = app.send.privacy_policy.saturating_sub(1);
+        }
+        KeyCode::Right | KeyCode::Char('l') if app.send.field == SendField::PrivacyPolicy => {
+            app.send.privacy_policy = (app.send.privacy_policy + 1).min(PRIVACY_POLICIES.len() - 1);
+        }
+
+        // `Enter` and `i` (vim-style insert) both begin editing a text field. On the
+        // Submit row, `Enter` reviews & sends.
+        KeyCode::Char('i') if app.send.field.is_text() => {
+            app.send.editing = true;
+        }
+        KeyCode::Enter => {
+            if app.send.field.is_text() {
+                // Begin editing this text field.
+                app.send.editing = true;
+            } else if app.send.field == SendField::Submit {
+                // Review & send.
+                if let Err(msg) = validate(app) {
+                    app.error(msg);
+                } else {
+                    app.send.confirming = true;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn select_next_account(app: &mut App) {
+    if !app.data.accounts.is_empty() {
+        app.send.from_account = (app.send.from_account + 1) % app.data.accounts.len();
+    }
+}
+
+fn select_prev_account(app: &mut App) {
+    if !app.data.accounts.is_empty() {
+        let n = app.data.accounts.len();
+        app.send.from_account = (app.send.from_account + n - 1) % n;
+    }
+}
+
+fn validate(app: &App) -> Result<(), String> {
+    if app.data.accounts.is_empty() {
+        return Err(crate::fl!("tui-send-err-no-accounts"));
+    }
+    let account = app
+        .data
+        .accounts
+        .get(app.send.from_account)
+        .ok_or_else(|| crate::fl!("tui-send-err-no-source"))?;
+    if account.spend_source_address().is_none() {
+        return Err(crate::fl!("tui-send-err-no-spendable"));
+    }
+    if app.send.to.trim().is_empty() {
+        return Err(crate::fl!("tui-send-err-recipient-required"));
+    }
+    if app.send.amount.trim().is_empty() {
+        return Err(crate::fl!("tui-send-err-amount-required"));
+    }
+    if app.send.amount.trim().parse::<f64>().is_err() {
+        return Err(crate::fl!("tui-send-err-amount-nan"));
+    }
+    Ok(())
+}
+
+async fn submit(app: &mut App) {
+    let Some(account) = app.data.accounts.get(app.send.from_account) else {
+        app.error(crate::fl!("tui-send-err-no-source-selected"));
+        return;
+    };
+    let Some(from) = account.spend_source_address().map(|s| s.to_string()) else {
+        app.error(crate::fl!("tui-send-err-no-spendable"));
+        return;
+    };
+
+    let to = app.send.to.trim().to_string();
+    let amount = app.send.amount.trim().to_string();
+    let memo = {
+        let m = app.send.memo.trim();
+        if m.is_empty() {
+            None
+        } else {
+            Some(m.to_string())
+        }
+    };
+    let policy = PRIVACY_POLICIES[app.send.privacy_policy];
+
+    match app
+        .client()
+        .send_many(&from, &to, &amount, memo.as_deref(), policy)
+        .await
+    {
+        Ok(Ok(opid)) => {
+            app.info(crate::fl!("tui-send-submitted", opid = opid.clone()));
+            app.send.pending_opid = Some(opid);
+            app.send.pending_status = None;
+            app.poll_send().await;
+        }
+        Ok(Err(e)) if e.is_unlock_needed() => {
+            app.error(crate::fl!("tui-err-locked-press-u-upper"));
+        }
+        Ok(Err(e)) => app.error(crate::fl!(
+            "tui-err-rpc-call",
+            method = "z_sendmany",
+            error = e.to_string()
+        )),
+        Err(e) => app.error(e.to_string()),
+    }
+}
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(6)])
+        .split(area);
+
+    render_form(app, frame, chunks[0]);
+    render_status(app, frame, chunks[1]);
+}
+
+fn render_form(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let f = &app.send;
+    let policy = PRIVACY_POLICIES[f.privacy_policy];
+
+    // The "from" account selector.
+    let from_label = match app.data.accounts.get(f.from_account) {
+        Some(account) => {
+            let mut s = format!("◀ {} ▶", account.label());
+            if account.spend_source_address().is_none() {
+                s.push_str("  ");
+                s.push_str(&crate::fl!("tui-send-no-spendable-suffix"));
+            }
+            s
+        }
+        None => crate::fl!("tui-addr-no-accounts"),
+    };
+
+    let mut lines = vec![
+        Line::from(vec![
+            label_span(&crate::fl!("tui-send-from"), f.field == SendField::From),
+            Span::styled(from_label, Style::default().fg(Color::Cyan)),
+        ]),
+        input_line(
+            &crate::fl!("tui-send-to"),
+            &f.to,
+            f.field == SendField::To,
+            f.editing,
+        ),
+        input_line(
+            &crate::fl!("tui-send-amount"),
+            &f.amount,
+            f.field == SendField::Amount,
+            f.editing,
+        ),
+        input_line(
+            &crate::fl!("tui-send-memo"),
+            &f.memo,
+            f.field == SendField::Memo,
+            f.editing,
+        ),
+        Line::from(vec![
+            label_span(
+                &crate::fl!("tui-send-privacy-policy"),
+                f.field == SendField::PrivacyPolicy,
+            ),
+            Span::styled(format!("◀ {policy} ▶"), policy_style(f.privacy_policy)),
+        ]),
+        Line::from(""),
+        // The "Review & send" action row.
+        Line::from(Span::styled(
+            format!("  {}", crate::fl!("tui-send-review")),
+            if f.field == SendField::Submit {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Green)
+            },
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            crate::fl!("tui-send-fees-note"),
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    if f.privacy_policy > 0 {
+        lines.push(Line::from(Span::styled(
+            crate::fl!("tui-send-privacy-warning"),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    lines.push(Line::from(""));
+    let hint = if f.editing {
+        crate::fl!("tui-send-hint-editing")
+    } else if f.field.is_text() {
+        crate::fl!("tui-send-hint-text")
+    } else if f.field == SendField::Submit {
+        crate::fl!("tui-send-hint-submit")
+    } else {
+        crate::fl!("tui-send-hint-select")
+    };
+    lines.push(Line::from(Span::styled(
+        hint,
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-send-title")));
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn render_status(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-send-operation-title")));
+
+    let lines: Vec<Line<'_>> = if app.send.confirming {
+        let f = &app.send;
+        let from = app
+            .data
+            .accounts
+            .get(f.from_account)
+            .map(|a| a.label())
+            .unwrap_or_default();
+        vec![
+            Line::from(Span::styled(
+                crate::fl!("tui-send-confirm"),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(format!(
+                "  {}",
+                crate::fl!(
+                    "tui-send-confirm-summary",
+                    amount = f.amount.trim(),
+                    from = from,
+                    to = f.to.trim()
+                )
+            )),
+            Line::from(Span::styled(
+                format!("  {}", crate::fl!("tui-send-confirm-hint")),
+                Style::default().fg(Color::DarkGray),
+            )),
+        ]
+    } else if let Some(opid) = &app.send.pending_opid {
+        let status = app
+            .send
+            .pending_status
+            .as_ref()
+            .map(|s| s.status.clone())
+            .unwrap_or_else(|| crate::fl!("tui-send-queued"));
+        vec![
+            Line::from(crate::fl!("tui-send-operation", opid = opid.clone())),
+            Line::from(Span::styled(
+                crate::fl!("tui-send-status", status = status),
+                Style::default().fg(Color::Cyan),
+            )),
+        ]
+    } else if let Some(status) = &app.send.pending_status {
+        // Finished op; show the result/error.
+        match status.status.as_str() {
+            "success" => {
+                let txid = status
+                    .result
+                    .as_ref()
+                    .and_then(|r| r.get("txid"))
+                    .and_then(|t| t.as_str())
+                    .map(|t| t.to_string())
+                    .unwrap_or_else(|| crate::fl!("tui-value-unknown"));
+                vec![
+                    Line::from(Span::styled(
+                        crate::fl!("tui-send-succeeded"),
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD),
+                    )),
+                    Line::from(crate::fl!("tui-send-txid", txid = txid)),
+                ]
+            }
+            _ => vec![Line::from(Span::styled(
+                crate::fl!("tui-send-failed"),
+                Style::default().fg(Color::Red),
+            ))],
+        }
+    } else {
+        vec![Line::from(Span::styled(
+            crate::fl!("tui-send-placeholder"),
+            Style::default().fg(Color::DarkGray),
+        ))]
+    };
+
+    frame.render_widget(
+        Paragraph::new(lines).block(block).wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn input_line(label: &str, value: &str, focused: bool, editing: bool) -> Line<'static> {
+    // Only show the text cursor when actively editing this (focused) field.
+    let cursor = if focused && editing { "_" } else { "" };
+    let value_style = if focused && editing {
+        Style::default().fg(Color::White)
+    } else {
+        Style::default()
+    };
+    Line::from(vec![
+        label_span(label, focused),
+        Span::styled(format!("{value}{cursor}"), value_style),
+    ])
+}
+
+fn label_span(label: &str, focused: bool) -> Span<'static> {
+    let style = if focused {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    Span::styled(format!(" {label:>14}: "), style)
+}
+
+fn policy_style(index: usize) -> Style {
+    if index == 0 {
+        Style::default().fg(Color::Green)
+    } else {
+        Style::default().fg(Color::Yellow)
+    }
+}
+
+fn next_field(field: SendField) -> SendField {
+    match field {
+        SendField::From => SendField::To,
+        SendField::To => SendField::Amount,
+        SendField::Amount => SendField::Memo,
+        SendField::Memo => SendField::PrivacyPolicy,
+        SendField::PrivacyPolicy => SendField::Submit,
+        SendField::Submit => SendField::From,
+    }
+}
+
+fn prev_field(field: SendField) -> SendField {
+    match field {
+        SendField::From => SendField::Submit,
+        SendField::To => SendField::From,
+        SendField::Amount => SendField::To,
+        SendField::Memo => SendField::Amount,
+        SendField::PrivacyPolicy => SendField::Memo,
+        SendField::Submit => SendField::PrivacyPolicy,
+    }
+}
+
+/// Returns the editable text buffer for the currently-focused field, or `None` if the
+/// focused field is a selector rather than a text field.
+fn text_field_mut(app: &mut App) -> Option<&mut String> {
+    match app.send.field {
+        SendField::To => Some(&mut app.send.to),
+        SendField::Amount => Some(&mut app.send.amount),
+        SendField::Memo => Some(&mut app.send.memo),
+        SendField::From | SendField::PrivacyPolicy | SendField::Submit => None,
+    }
+}

--- a/zallet/src/commands/tui/views/transactions.rs
+++ b/zallet/src/commands/tui/views/transactions.rs
@@ -1,0 +1,187 @@
+//! Transactions view (paginated list + detail pane).
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::commands::tui::app::{App, TX_PAGE_SIZE};
+
+pub(crate) async fn on_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.tx_selected + 1 < app.data.transactions.len() {
+                app.tx_selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.tx_selected = app.tx_selected.saturating_sub(1);
+        }
+        KeyCode::Char(']') => {
+            // Next page (only if the current page was full).
+            if app.data.transactions.len() as u32 == TX_PAGE_SIZE {
+                app.tx_offset += TX_PAGE_SIZE;
+                app.tx_selected = 0;
+                app.refresh_transactions().await;
+            }
+        }
+        KeyCode::Char('[') => {
+            if app.tx_offset >= TX_PAGE_SIZE {
+                app.tx_offset -= TX_PAGE_SIZE;
+            } else {
+                app.tx_offset = 0;
+            }
+            app.tx_selected = 0;
+            app.refresh_transactions().await;
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn render(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(8)])
+        .split(area);
+
+    render_list(app, frame, chunks[0]);
+    render_detail(app, frame, chunks[1]);
+}
+
+fn render_list(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let page = app.tx_offset / TX_PAGE_SIZE + 1;
+    let title = format!(" {} ", crate::fl!("tui-tx-title", page = page));
+
+    if app.data.transactions.is_empty() {
+        let p = Paragraph::new(crate::fl!("tui-tx-empty"))
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(p, area);
+        return;
+    }
+
+    let items: Vec<ListItem<'_>> = app
+        .data
+        .transactions
+        .iter()
+        .map(|tx| {
+            let height = tx
+                .mined_height
+                .map(|h| h.to_string())
+                .unwrap_or_else(|| crate::fl!("tui-tx-unmined"));
+            let delta = format_delta(tx.account_balance_delta);
+            let delta_style = if tx.account_balance_delta >= 0 {
+                Style::default().fg(Color::Green)
+            } else {
+                Style::default().fg(Color::Red)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{height:>9}  "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(format!("{delta:>16}  "), delta_style),
+                Span::raw(truncate(&tx.txid, 24)),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut state = ListState::default();
+    state.select(Some(app.tx_selected.min(app.data.transactions.len() - 1)));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_detail(app: &App, frame: &mut Frame<'_>, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", crate::fl!("tui-tx-detail-title")));
+
+    let lines: Vec<Line<'_>> = match app.data.transactions.get(app.tx_selected) {
+        Some(tx) => {
+            let mut lines = vec![
+                field(&crate::fl!("tui-tx-field-txid"), tx.txid.clone()),
+                field(
+                    &crate::fl!("tui-tx-field-height"),
+                    tx.mined_height
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| crate::fl!("tui-tx-unmined")),
+                ),
+                field(
+                    &crate::fl!("tui-tx-field-delta"),
+                    format_delta(tx.account_balance_delta),
+                ),
+            ];
+            if let Some(fee) = tx.fee_paid {
+                lines.push(field(&crate::fl!("tui-tx-field-fee"), format_zat(fee)));
+            }
+            if let Some(t) = tx.block_time {
+                lines.push(field(&crate::fl!("tui-tx-field-block-time"), t.to_string()));
+            }
+            if let Some(uuid) = &tx.account_uuid {
+                lines.push(field(&crate::fl!("tui-tx-field-account"), uuid.clone()));
+            }
+            if tx.expired_unmined {
+                lines.push(Line::from(Span::styled(
+                    crate::fl!("tui-tx-expired"),
+                    Style::default().fg(Color::Red),
+                )));
+            }
+            lines
+        }
+        None => vec![Line::from(Span::styled(
+            crate::fl!("tui-tx-select"),
+            Style::default().fg(Color::DarkGray),
+        ))],
+    };
+
+    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    frame.render_widget(p, area);
+}
+
+fn field(label: &str, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:>11}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw(value),
+    ])
+}
+
+/// Formats a zatoshi-denominated balance delta as a signed ZEC string.
+fn format_delta(zat: i64) -> String {
+    let sign = if zat >= 0 { "+" } else { "-" };
+    format!("{sign}{}", format_zec(zat.unsigned_abs()))
+}
+
+fn format_zat(zat: i64) -> String {
+    format_zec(zat.unsigned_abs())
+}
+
+fn format_zec(zat: u64) -> String {
+    let whole = zat / 100_000_000;
+    let frac = zat % 100_000_000;
+    crate::fl!("tui-amount-zec", amount = format!("{whole}.{frac:08}"))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let head: String = s.chars().take(max - 1).collect();
+        format!("{head}…")
+    } else {
+        s.to_string()
+    }
+}

--- a/zallet/src/components/tracing.rs
+++ b/zallet/src/components/tracing.rs
@@ -1,10 +1,24 @@
+use std::fs::File;
 use std::io;
+use std::path::Path;
+use std::sync::Mutex;
 
 use tracing::level_filters::LevelFilter;
 use tracing_log::LogTracer;
-use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt};
+use tracing_subscriber::{EnvFilter, Layer, fmt::writer::BoxMakeWriter, layer::SubscriberExt};
 
 use abscissa_core::{Component, FrameworkError, FrameworkErrorKind, terminal::ColorChoice};
+
+/// Where the `tracing` subsystem should write its output.
+pub(crate) enum LogTarget<'a> {
+    /// Write to standard error (the default).
+    Stderr,
+    /// Write to a file at the given path.
+    ///
+    /// This is used by the interactive terminal UI, which takes over the terminal and
+    /// would otherwise have its display corrupted by interleaved log output.
+    File(&'a Path),
+}
 
 /// Abscissa component for initializing the `tracing` subsystem
 #[derive(Component, Debug)]
@@ -12,7 +26,10 @@ use abscissa_core::{Component, FrameworkError, FrameworkErrorKind, terminal::Col
 pub(crate) struct Tracing {}
 
 impl Tracing {
-    pub(crate) fn new(color_choice: ColorChoice) -> Result<Self, FrameworkError> {
+    pub(crate) fn new(
+        color_choice: ColorChoice,
+        target: LogTarget<'_>,
+    ) -> Result<Self, FrameworkError> {
         let env_filter = EnvFilter::builder()
             .with_default_directive(LevelFilter::INFO.into())
             .from_env_lossy();
@@ -22,15 +39,29 @@ impl Tracing {
         // into tracing events.
         LogTracer::init().map_err(|e| FrameworkErrorKind::ComponentError.context(e))?;
 
+        // Select the writer and whether to emit ANSI colour codes. When writing to a
+        // file, colour codes are always disabled so the log remains readable.
+        let (writer, ansi): (BoxMakeWriter, bool) = match target {
+            LogTarget::Stderr => (
+                BoxMakeWriter::new(io::stderr),
+                match color_choice {
+                    ColorChoice::Always => true,
+                    ColorChoice::AlwaysAnsi => true,
+                    ColorChoice::Auto => true,
+                    ColorChoice::Never => false,
+                },
+            ),
+            LogTarget::File(path) => {
+                let file = create_log_file(path)
+                    .map_err(|e| FrameworkErrorKind::ComponentError.context(e))?;
+                (BoxMakeWriter::new(Mutex::new(file)), false)
+            }
+        };
+
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let fmt_layer = tracing_subscriber::fmt::layer()
-            .with_writer(io::stderr)
-            .with_ansi(match color_choice {
-                ColorChoice::Always => true,
-                ColorChoice::AlwaysAnsi => true,
-                ColorChoice::Auto => true,
-                ColorChoice::Never => false,
-            })
+            .with_writer(writer)
+            .with_ansi(ansi)
             .with_filter(env_filter);
 
         let subscriber = tracing_subscriber::registry().with(fmt_layer);
@@ -44,5 +75,35 @@ impl Tracing {
             .map_err(|e| FrameworkErrorKind::ComponentError.context(e))?;
 
         Ok(Self {})
+    }
+}
+
+/// Creates (truncating) the log file at `path`, restricting it to the owner on Unix.
+///
+/// Although Zallet log lines are not expected to contain secrets, the data directory
+/// generally holds sensitive material, so the log is created mode 0600 for consistency
+/// with the other files Zallet writes there. The mode is applied at creation time (rather
+/// than after the fact) so the file is never momentarily world-readable.
+fn create_log_file(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            // Applied at creation; ignored for a pre-existing file (handled below).
+            .mode(0o600)
+            .open(path)?;
+        // Ensure the restrictive mode holds even when truncating a file that already
+        // existed (where the creation `mode` above has no effect). `set_permissions` on the
+        // open handle is an `fchmod`, so it is unaffected by the process umask.
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        Ok(file)
+    }
+    #[cfg(not(unix))]
+    {
+        File::create(path)
     }
 }


### PR DESCRIPTION
<img width="1146" height="1428" alt="image" src="https://github.com/user-attachments/assets/40538af9-91a5-49ef-8aea-b9d75c0f58c2" />

Adds `zallet tui`, an interactive terminal frontend for the wallet, gated behind a new `tui` cargo feature (which pulls in ratatui, crossterm, and qrcode alongside the existing rpc-cli client deps).

The TUI is fundamentally a JSON-RPC client, so there is a single tested code path regardless of where the server lives. It supports two modes:

- Self-hosted (default): boots the full wallet backend in-process (database, keystore, chain, and sync tasks) like `zallet start`, spawns a JSON-RPC server bound to an ephemeral loopback port with a freshly-generated in-memory credential, and connects to it over HTTP. The data directory lock is held for the duration of the session.
- Remote (`--connect HOST:PORT`): connects to an already-running `zallet start` instance using the `[[rpc.auth]]` credentials from the config. No backend is booted and the data directory lock is not taken.

To support the self-hosted mode, the JSON-RPC server gains a `spawn_ephemeral` entry point (binding `127.0.0.1:0` with an in-memory credential) and the authorization layer gains a single-user constructor. The existing `spawn` path is refactored to share construction via `spawn_inner`.

Stacked on https://github.com/zcash/wallet/pull/502

COR-1393