### PR TITLE
migrate: report a friendly error when db_dump is unavailable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7340,6 +7340,7 @@ dependencies = [
  "tracing-subscriber",
  "trycmd",
  "uuid",
+ "which 8.0.0",
  "xdg 2.5.2",
  "zaino-common",
  "zaino-fetch",

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -142,6 +142,7 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 transparent.workspace = true
 uuid.workspace = true
+which = { workspace = true, optional = true }
 xdg.workspace = true
 zaino-common.workspace = true
 zaino-fetch.workspace = true
@@ -219,6 +220,7 @@ transparent-key-import = [
 ## Allows `zallet` to import zcashd wallets.
 zcashd-import = [
   "transparent-key-import",
+  "dep:which",
   "dep:zewif",
   "dep:zewif-zcashd",
   "zcash_client_backend/zcashd-compat",

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -109,19 +109,31 @@ impl MigrateZcashdWalletCmd {
         // Resolve the `db_dump` utility. An explicit `--zcashd-install-dir` uses that
         // installation's binary; otherwise prefer the BDB 6.2 `db_dump` vendored by
         // `zewif-zcashd` (via `BDBDump::from_file`), which falls back to one on the `PATH`.
+        let db_dump_unavailable = || {
+            MigrateError::Wrapped(
+                ErrorKind::Generic
+                    .context(fl!("err-migrate-wallet-db-dump-not-found"))
+                    .into(),
+            )
+        };
         let db_dump = match &self.zcashd_install_dir {
             Some(path) => {
                 let db_dump_path = path.join("zcutil").join("bin").join("db_dump");
                 if !db_dump_path.is_file() {
-                    return Err(MigrateError::Wrapped(
-                        ErrorKind::Generic
-                            .context(fl!("err-migrate-wallet-db-dump-not-found"))
-                            .into(),
-                    ));
+                    return Err(db_dump_unavailable());
                 }
                 BDBDump::from_file_with_path(db_dump_path.as_path(), wallet_path.as_path())
             }
-            None => BDBDump::from_file(wallet_path.as_path()),
+            None => {
+                // `from_file` tries the vendored `db_dump` and then one on the `PATH`. If
+                // it fails and there is no `db_dump` on the `PATH` either, report it as
+                // unavailable rather than surfacing a raw execution error.
+                let dumped = BDBDump::from_file(wallet_path.as_path());
+                if dumped.is_err() && which::which("db_dump").is_err() {
+                    return Err(db_dump_unavailable());
+                }
+                dumped
+            }
         }
         .map_err(|e| MigrateError::Zewif {
             error_type: ZewifError::BdbDump,


### PR DESCRIPTION
Restore the "db_dump not found" guidance that was lost when the command switched to the vendored db_dump. `BDBDump::from_file` resolves the vendored copy or one on the PATH internally, so when it fails we probe the PATH with `which`: if no `db_dump` is found there either, surface the not-found guidance instead of a raw execution error.

This probe runs only after a failure, so it never blocks the happy path where the vendored copy is used. It cannot distinguish a genuinely missing db_dump from a corrupt wallet on a build where only the vendored copy exists; the latter is then reported as "not found", an acceptable trade since it only affects an error path.