### PR TITLE
rpc: make z_importkey generic over Chain

### DIFF
--- a/zallet/src/components/json_rpc/methods/import_key.rs
+++ b/zallet/src/components/json_rpc/methods/import_key.rs
@@ -2,12 +2,12 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zaino_state::FetchServiceSubscriber;
 use zcash_client_backend::data_api::{AccountPurpose, WalletRead, WalletWrite};
 use zcash_keys::{encoding::decode_extended_spending_key, keys::UnifiedFullViewingKey};
 use zcash_protocol::consensus::{BlockHeight, NetworkConstants};
 
 use crate::components::{
+    chain::Chain,
     database::DbConnection,
     json_rpc::{server::LegacyCode, utils::fetch_account_birthday},
     keystore::KeyStore,
@@ -64,10 +64,10 @@ fn decode_key_and_address(
     Ok((extsk, address))
 }
 
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
-    chain: FetchServiceSubscriber,
+    chain: C,
     key: &str,
     rescan: Option<&str>,
     start_height: Option<u64>,
@@ -140,7 +140,7 @@ pub(crate) async fn call(
             _ => unreachable!(),
         };
 
-        let birthday = fetch_account_birthday(wallet, &chain, effective_height).await?;
+        let birthday = fetch_account_birthday(&chain, effective_height).await?;
 
         wallet
             .import_account_ufvk(

--- a/zallet/src/components/json_rpc/utils.rs
+++ b/zallet/src/components/json_rpc/utils.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use jsonrpsee::{
     core::{JsonValue, RpcResult},
-    types::{ErrorCode as RpcErrorCode, ErrorObjectOwned},
+    types::ErrorCode as RpcErrorCode,
 };
 use rust_decimal::Decimal;
 use schemars::{JsonSchema, json_schema};
@@ -20,18 +20,15 @@ use super::server::LegacyCode;
 
 #[cfg(zallet_build = "wallet")]
 use {
-    crate::components::{database::DbConnection, keystore::KeyStore},
+    crate::components::{
+        chain::{Chain, ChainView},
+        database::DbConnection,
+        keystore::KeyStore,
+    },
     std::collections::HashSet,
-    zaino_state::{FetchServiceSubscriber, ZcashIndexer},
-    zcash_client_backend::{
-        data_api::{Account, AccountBirthday, WalletRead, chain::ChainState},
-        proto::service::TreeState,
-    },
+    zcash_client_backend::data_api::{Account, AccountBirthday, WalletRead, chain::ChainState},
     zcash_primitives::block::BlockHash,
-    zcash_protocol::{
-        consensus::{NetworkType, Parameters},
-        value::BalanceError,
-    },
+    zcash_protocol::value::BalanceError,
     zip32::fingerprint::SeedFingerprint,
 };
 
@@ -129,9 +126,8 @@ pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
 /// commitment trees are empty. For non-zero heights, fetches the real treestate from
 /// the chain indexer so the sync engine can validate note commitment tree continuity.
 #[cfg(zallet_build = "wallet")]
-pub(super) async fn fetch_account_birthday(
-    wallet: &DbConnection,
-    chain: &FetchServiceSubscriber,
+pub(super) async fn fetch_account_birthday<C: Chain>(
+    chain: &C,
     height: BlockHeight,
 ) -> RpcResult<AccountBirthday> {
     if height == BlockHeight::from_u32(0) {
@@ -147,50 +143,27 @@ pub(super) async fn fetch_account_birthday(
     }
 
     let treestate_height = height.saturating_sub(1);
-    let treestate = chain
-        .z_get_treestate(treestate_height.to_string())
+    let chain_view = chain
+        .snapshot()
         .await
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+    let chain_state = chain_view
+        .tree_state_as_of(treestate_height)
+        .await
+        // A failure to fetch the treestate from the chain is an internal error, not a
+        // problem with the caller's parameters.
         .map_err(|e| {
-            // A failure to fetch the treestate from the chain indexer is an internal
-            // error, not a problem with the caller's parameters.
-            ErrorObjectOwned::owned(
-                RpcErrorCode::InternalError.code(),
-                format!("Failed to get treestate at height {treestate_height}: {e}"),
-                None::<()>,
-            )
+            LegacyCode::Database.with_message(format!(
+                "Failed to get treestate at height {treestate_height}: {e}"
+            ))
+        })?
+        .ok_or_else(|| {
+            LegacyCode::Database.with_message(format!(
+                "Failed to get treestate at height {treestate_height}: above chain tip"
+            ))
         })?;
 
-    let (hash, height, time, sapling, orchard) = (
-        treestate.hash(),
-        treestate.height(),
-        treestate.time(),
-        treestate.sapling(),
-        treestate.orchard(),
-    );
-    let treestate = TreeState {
-        network: match wallet.params().network_type() {
-            NetworkType::Main => "main".into(),
-            NetworkType::Test => "test".into(),
-            NetworkType::Regtest => "regtest".into(),
-        },
-        height: height.0.into(),
-        hash: hash.to_string(),
-        time,
-        sapling_tree: sapling
-            .commitments()
-            .final_state()
-            .as_ref()
-            .map(hex::encode)
-            .unwrap_or_default(),
-        orchard_tree: orchard
-            .commitments()
-            .final_state()
-            .as_ref()
-            .map(hex::encode)
-            .unwrap_or_default(),
-    };
-
-    AccountBirthday::from_treestate(treestate, None).map_err(|_| RpcErrorCode::InternalError.into())
+    Ok(AccountBirthday::from_parts(chain_state, None))
 }
 
 pub(crate) fn parse_txid(txid_str: &str) -> RpcResult<TxId> {


### PR DESCRIPTION
Fixes the `main` build, which broke after #400 (`z_importkey`/`z_exportkey`) merged.

#400's CI last ran 2026-06-08, before the *"make the JSON-RPC layer generic over Chain"* refactor landed on `main` (2026-06-19 … 06-22, #492). That refactor turned `self.chain()` into a generic `C: Chain`, but #400's `import_key::call` and its `fetch_account_birthday` helper still took a concrete `FetchServiceSubscriber`. The two were textually mergeable but type-incompatible, so once both were on `main` the build failed with:

```
error[E0308]: `?` operator has incompatible types
 --> zallet/src/components/json_rpc/methods.rs:1009:13
1009 |     self.chain().await?,
     expected `FetchServiceSubscriber`, found type parameter `C`
```

This migrates `import_key::call` and `fetch_account_birthday` to the generic `Chain`/`ChainView` API, mirroring the pattern the refactor applied to the other RPC methods (e.g. `get_new_account`): `fetch_account_birthday` now snapshots the chain and reads the treestate via `ChainView::tree_state_as_of`, building the birthday from the resulting `ChainState`.

Verified locally on current `main`: `cargo build -p zallet`, `cargo clippy -p zallet --all-targets`, `cargo fmt --check`, and `cargo test -p zallet import_key` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)