### PR TITLE
fix: make the z_importkey path generic over the chain backend

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: main
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: main
+  merge_group:
 
 permissions: {}
 

--- a/zallet/src/components/json_rpc/methods/import_key.rs
+++ b/zallet/src/components/json_rpc/methods/import_key.rs
@@ -2,12 +2,12 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zaino_state::FetchServiceSubscriber;
 use zcash_client_backend::data_api::{AccountPurpose, WalletRead, WalletWrite};
 use zcash_keys::{encoding::decode_extended_spending_key, keys::UnifiedFullViewingKey};
 use zcash_protocol::consensus::{BlockHeight, NetworkConstants};
 
 use crate::components::{
+    chain::Chain,
     database::DbConnection,
     json_rpc::{server::LegacyCode, utils::fetch_account_birthday},
     keystore::KeyStore,
@@ -64,10 +64,10 @@ fn decode_key_and_address(
     Ok((extsk, address))
 }
 
-pub(crate) async fn call(
+pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
-    chain: FetchServiceSubscriber,
+    chain: C,
     key: &str,
     rescan: Option<&str>,
     start_height: Option<u64>,
@@ -140,7 +140,7 @@ pub(crate) async fn call(
             _ => unreachable!(),
         };
 
-        let birthday = fetch_account_birthday(wallet, &chain, effective_height).await?;
+        let birthday = fetch_account_birthday(&chain, effective_height).await?;
 
         wallet
             .import_account_ufvk(

--- a/zallet/src/components/json_rpc/utils.rs
+++ b/zallet/src/components/json_rpc/utils.rs
@@ -20,18 +20,15 @@ use super::server::LegacyCode;
 
 #[cfg(zallet_build = "wallet")]
 use {
-    crate::components::{database::DbConnection, keystore::KeyStore},
+    crate::components::{
+        chain::{Chain, ChainView},
+        database::DbConnection,
+        keystore::KeyStore,
+    },
     std::collections::HashSet,
-    zaino_state::{FetchServiceSubscriber, ZcashIndexer},
-    zcash_client_backend::{
-        data_api::{Account, AccountBirthday, WalletRead, chain::ChainState},
-        proto::service::TreeState,
-    },
+    zcash_client_backend::data_api::{Account, AccountBirthday, WalletRead, chain::ChainState},
     zcash_primitives::block::BlockHash,
-    zcash_protocol::{
-        consensus::{NetworkType, Parameters},
-        value::BalanceError,
-    },
+    zcash_protocol::value::BalanceError,
     zip32::fingerprint::SeedFingerprint,
 };
 
@@ -129,9 +126,8 @@ pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
 /// commitment trees are empty. For non-zero heights, fetches the real treestate from
 /// the chain indexer so the sync engine can validate note commitment tree continuity.
 #[cfg(zallet_build = "wallet")]
-pub(super) async fn fetch_account_birthday(
-    wallet: &DbConnection,
-    chain: &FetchServiceSubscriber,
+pub(super) async fn fetch_account_birthday<C: Chain>(
+    chain: &C,
     height: BlockHeight,
 ) -> RpcResult<AccountBirthday> {
     if height == BlockHeight::from_u32(0) {
@@ -146,9 +142,18 @@ pub(super) async fn fetch_account_birthday(
         ));
     }
 
+    // The chain state anchoring the birthday is the note commitment tree state as of the
+    // block *preceding* the birthday height.
     let treestate_height = height.saturating_sub(1);
-    let treestate = chain
-        .z_get_treestate(treestate_height.to_string())
+    let chain_view = chain.snapshot().await.map_err(|e| {
+        ErrorObjectOwned::owned(
+            RpcErrorCode::InternalError.code(),
+            format!("Failed to obtain a chain snapshot: {e}"),
+            None::<()>,
+        )
+    })?;
+    let chain_state = chain_view
+        .tree_state_as_of(treestate_height)
         .await
         .map_err(|e| {
             // A failure to fetch the treestate from the chain indexer is an internal
@@ -158,39 +163,16 @@ pub(super) async fn fetch_account_birthday(
                 format!("Failed to get treestate at height {treestate_height}: {e}"),
                 None::<()>,
             )
+        })?
+        .ok_or_else(|| {
+            ErrorObjectOwned::owned(
+                RpcErrorCode::InternalError.code(),
+                format!("No treestate available at height {treestate_height}"),
+                None::<()>,
+            )
         })?;
 
-    let (hash, height, time, sapling, orchard) = (
-        treestate.hash(),
-        treestate.height(),
-        treestate.time(),
-        treestate.sapling(),
-        treestate.orchard(),
-    );
-    let treestate = TreeState {
-        network: match wallet.params().network_type() {
-            NetworkType::Main => "main".into(),
-            NetworkType::Test => "test".into(),
-            NetworkType::Regtest => "regtest".into(),
-        },
-        height: height.0.into(),
-        hash: hash.to_string(),
-        time,
-        sapling_tree: sapling
-            .commitments()
-            .final_state()
-            .as_ref()
-            .map(hex::encode)
-            .unwrap_or_default(),
-        orchard_tree: orchard
-            .commitments()
-            .final_state()
-            .as_ref()
-            .map(hex::encode)
-            .unwrap_or_default(),
-    };
-
-    AccountBirthday::from_treestate(treestate, None).map_err(|_| RpcErrorCode::InternalError.into())
+    Ok(AccountBirthday::from_parts(chain_state, None))
 }
 
 pub(crate) fn parse_txid(txid_str: &str) -> RpcResult<TxId> {


### PR DESCRIPTION
The JSON-RPC implementation is generic over the chain backend (`impl<C: Chain> WalletRpcServer for WalletRpcImpl<C>`), and `chain()` returns `C`. The `z_importkey` path, however, was wired against the concrete `FetchServiceSubscriber`: both `import_key::call` and its `fetch_account_birthday` helper took the Zaino type, so passing `self.chain().await?` (of type `C`) into `import_key::call` failed to compile (`error[E0308]` at methods.rs:1009), breaking the build under `--all-features`.

Genericize both over `C: Chain`, and derive the account birthday through the `ChainView` treestate API (`chain.snapshot()` -> `ChainView::tree_state_as_of`) the same way `get_new_account` does, rather than Zaino's `z_get_treestate`. As a result `fetch_account_birthday` no longer needs the wallet handle (it only used it for the network name when building a proto `TreeState`, which is gone).


Claude-Session: https://claude.ai/code/session_016w2xtjkLc7gQXBmi1J3gDs