### PR TITLE
Log config file when relative path given and show error when not existent

### DIFF
--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -152,6 +152,8 @@ err-init-identity-not-passphrase-encrypted = {$path} is not encrypted with a pas
 err-init-path-not-utf8 = {$path} is not currently supported (not UTF-8)
 err-init-identity-not-usable = Identity file at {$path} is not usable: {$error}
 err-init-rpc-auth-invalid = Invalid '{-cfg-rpc-auth}' configuration
+err-config-file-not-found = Configuration file at {$path} does not exist.
+err-config-file-invalid = Failed to parse configuration file at {$path}: {$error}
 
 ## Keystore errors
 

--- a/zallet/src/application.rs
+++ b/zallet/src/application.rs
@@ -1,10 +1,11 @@
 //! Zallet Abscissa Application
 
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use abscissa_core::{
-    Application, Component, FrameworkError, StandardPaths,
+    Application, Component, FrameworkError, FrameworkErrorKind, StandardPaths,
     application::{self, AppCell},
     config::{self, CfgCell},
     terminal::component::Terminal,
@@ -12,7 +13,7 @@ use abscissa_core::{
 use abscissa_tokio::TokioComponent;
 use i18n_embed::unic_langid::LanguageIdentifier;
 
-use crate::{cli::EntryPoint, components::tracing::Tracing, config::ZalletConfig, i18n};
+use crate::{cli::EntryPoint, components::tracing::Tracing, config::ZalletConfig, fl, i18n};
 
 /// Application state
 pub static APP: AppCell<ZalletApp> = AppCell::new();
@@ -50,6 +51,35 @@ impl Application for ZalletApp {
 
     fn config(&self) -> config::Reader<ZalletConfig> {
         self.config.read()
+    }
+
+    /// Overridden so config errors name the file: a missing config reports
+    /// `err-config-file-not-found`, and a parse error reports
+    /// `err-config-file-invalid` with the offending path (the framework
+    /// otherwise omits it).
+    fn load_config(&mut self, path: &Path) -> Result<Self::Cfg, FrameworkError> {
+        let abs = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+
+        if !path.exists() {
+            return Err(FrameworkErrorKind::ConfigError
+                .context(fl!(
+                    "err-config-file-not-found",
+                    path = abs.display().to_string()
+                ))
+                .into());
+        }
+
+        let contents =
+            std::fs::read_to_string(path).map_err(|e| FrameworkErrorKind::IoError.context(e))?;
+        toml::from_str(&contents).map_err(|e| {
+            FrameworkErrorKind::ConfigError
+                .context(fl!(
+                    "err-config-file-invalid",
+                    path = abs.display().to_string(),
+                    error = e.to_string()
+                ))
+                .into()
+        })
     }
 
     fn state(&self) -> &application::State<Self> {

--- a/zallet/src/cli.rs
+++ b/zallet/src/cli.rs
@@ -34,6 +34,8 @@ pub struct EntryPoint {
     /// Specify the data directory for the Zallet wallet.
     ///
     /// This must be an absolute path.
+    ///
+    /// [default: $HOME/.zallet]
     #[arg(short, long)]
     pub(crate) datadir: Option<PathBuf>,
 

--- a/zallet/src/commands.rs
+++ b/zallet/src/commands.rs
@@ -88,6 +88,22 @@ pub(crate) fn resolve_datadir_path(datadir: &Path, path: &Path) -> PathBuf {
     datadir.join(path)
 }
 
+/// Resolves the configuration file path for a given datadir and optional config override.
+///
+/// If `config_override` is `Some`, it is used as the config file path:
+/// - Absolute paths are returned as-is.
+/// - Relative paths are resolved relative to `datadir`.
+///
+/// If `config_override` is `None`, defaults to `CONFIG_FILE`.
+pub(crate) fn resolve_config_path(datadir: &Path, config_override: Option<&Path>) -> PathBuf {
+    let config_buf = config_override.unwrap_or_else(|| Path::new(CONFIG_FILE));
+    if config_buf.is_absolute() {
+        config_buf.to_path_buf()
+    } else {
+        resolve_datadir_path(datadir, config_buf)
+    }
+}
+
 impl EntryPoint {
     /// Returns the data directory to use for this Zallet command.
     fn datadir(&self) -> Result<PathBuf, FrameworkError> {
@@ -134,17 +150,11 @@ impl Runnable for EntryPoint {
 
 impl Configurable<ZalletConfig> for EntryPoint {
     fn config_path(&self) -> Option<PathBuf> {
-        // Check if the config file exists, and if it does not, ignore it.
-        // If you'd like for a missing configuration file to be a hard error
-        // instead, always return `Some(CONFIG_FILE)` here.
-        let filename = resolve_datadir_path(
-            &self.datadir().ok()?,
-            self.config
-                .as_deref()
-                .unwrap_or_else(|| Path::new(CONFIG_FILE)),
-        );
+        let filename = resolve_config_path(&self.datadir().ok()?, self.config.as_deref());
 
-        if filename.exists() {
+        // An explicit `--config` is always returned (loading fails loudly if
+        // missing); a missing default config is ignored.
+        if self.config.is_some() || filename.exists() {
             Some(filename)
         } else {
             None
@@ -152,9 +162,13 @@ impl Configurable<ZalletConfig> for EntryPoint {
     }
 
     fn process_config(&self, mut config: ZalletConfig) -> Result<ZalletConfig, FrameworkError> {
-        // Components access top-level CLI settings solely through `ZalletConfig`.
-        // Load them in here.
-        config.datadir = Some(self.datadir()?);
+        let datadir = self.datadir()?;
+
+        // Log the resolved path, not the raw `--config` argument.
+        let config_path = resolve_config_path(&datadir, self.config.as_deref());
+        tracing::info!(config = %config_path.display(), "Loading configuration");
+
+        config.datadir = Some(datadir);
 
         match &self.cmd {
             ZalletCmd::Start(cmd) => cmd.override_config(config),
@@ -222,5 +236,41 @@ async fn shutdown() {
             .expect("listening for ctrl-c signal should never fail");
 
         info!("Received Ctrl-C, starting shutdown");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_config_path_defaults_to_datadir() {
+        let datadir = Path::new("/data");
+        assert_eq!(
+            resolve_config_path(datadir, None),
+            Path::new("/data").join(CONFIG_FILE),
+        );
+    }
+
+    #[test]
+    fn resolve_config_path_relative_override_is_prefixed_by_datadir() {
+        let datadir = Path::new("/data");
+        assert_eq!(
+            resolve_config_path(datadir, Some(Path::new("zallet.toml"))),
+            PathBuf::from("/data/zallet.toml"),
+        );
+        assert_eq!(
+            resolve_config_path(datadir, Some(Path::new("sub/zallet.toml"))),
+            PathBuf::from("/data/sub/zallet.toml"),
+        );
+    }
+
+    #[test]
+    fn resolve_config_path_absolute_override_is_used_directly() {
+        let datadir = Path::new("/data");
+        assert_eq!(
+            resolve_config_path(datadir, Some(Path::new("/etc/zallet/zallet.toml"))),
+            PathBuf::from("/etc/zallet/zallet.toml"),
+        );
     }
 }

--- a/zallet/tests/acceptance.rs
+++ b/zallet/tests/acceptance.rs
@@ -102,6 +102,8 @@ fn setup_new_wallet() {
             .run();
         let stderr = cmd.stderr();
         wait_until_running(stderr);
+        // Every command first logs the configuration file it is loading.
+        stderr.expect_regex(".*Loading configuration.*");
         stderr.expect_regex(".*Creating empty database.*");
         cmd.wait().unwrap().expect_code(0);
     }
@@ -116,6 +118,8 @@ fn setup_new_wallet() {
             .run();
         let stderr = cmd.stderr();
         wait_until_running(stderr);
+        // Every command first logs the configuration file it is loading.
+        stderr.expect_regex(".*Loading configuration.*");
         stderr.expect_regex(".*Applying latest database migrations.*");
         cmd.wait().unwrap().expect_code(0);
     }
@@ -199,6 +203,8 @@ fn generate_encryption_identity_drives_setup() {
             .run();
         let stderr = cmd.stderr();
         wait_until_running(stderr);
+        // Every command first logs the configuration file it is loading.
+        stderr.expect_regex(".*Loading configuration.*");
         stderr.expect_regex(".*Creating empty database.*");
         cmd.wait().unwrap().expect_code(0);
     }
@@ -214,6 +220,8 @@ fn generate_encryption_identity_drives_setup() {
             .run();
         let stderr = cmd.stderr();
         wait_until_running(stderr);
+        // Every command first logs the configuration file it is loading.
+        stderr.expect_regex(".*Loading configuration.*");
         stderr.expect_regex(".*Applying latest database migrations.*");
         cmd.wait().unwrap().expect_code(0);
     }

--- a/zallet/tests/cmd/example_config.toml
+++ b/zallet/tests/cmd/example_config.toml
@@ -4,4 +4,4 @@ stdin = ""
 stdout = """
 zallet config written to zallet.toml
 """
-stderr = ""
+stderr = "..."

--- a/zallet/tests/cmd/migrate_zcash_conf_mainnet.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_mainnet.toml
@@ -38,4 +38,4 @@ pwhash = "50bb6ea2ab224071ecc3ef195a3a8$9090d8985b8d9969aa2062d134ebb2d568cd585a
 user = "foobar"
 
 """
-stderr = ""
+stderr = "..."

--- a/zallet/tests/cmd/migrate_zcash_conf_regtest.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_regtest.toml
@@ -38,4 +38,4 @@ as_of_version = "0.1.0-alpha.4"
 [rpc]
 
 """
-stderr = ""
+stderr = "..."

--- a/zallet/tests/cmd/migrate_zcash_conf_testnet.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_testnet.toml
@@ -30,4 +30,4 @@ as_of_version = "0.1.0-alpha.4"
 [rpc]
 
 """
-stderr = ""
+stderr = "..."


### PR DESCRIPTION
I was confused to not see my configuration loaded correctly when I was doing `-c zallet.toml start`. This fixes it and also a log shows which file has been loaded.