### PR TITLE
sync: recover missed transparent spends via per-outpoint spend index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.0",
@@ -7430,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "bip32",
  "bitflags 2.10.0",
@@ -7475,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "corez",
  "hex",
@@ -7485,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7495,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "bech32 0.11.0",
  "bip0039",
@@ -7541,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.28.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7593,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "corez",
  "document-features",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "bip32",
  "bs58",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=aeabc1a9160bdf5511e0d22e709fbc1d307f6853#aeabc1a9160bdf5511e0d22e709fbc1d307f6853"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4cdba554f5545050da784fc9e1eb073ae958d819#4cdba554f5545050da784fc9e1eb073ae958d819"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,19 +158,20 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-# TEMPORARY: Pin librustzcash crates to upstream main
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "aeabc1a9160bdf5511e0d22e709fbc1d307f6853" }
+# TEMPORARY: pin librustzcash crates to the `spend-index` PR (zcash/librustzcash#2463)
+# until it merges and is released.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "4cdba554f5545050da784fc9e1eb073ae958d819" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,17 +28,83 @@ audit-as-crates-io = true
 [policy.age-core]
 audit-as-crates-io = true
 
+[policy.equihash]
+audit-as-crates-io = false
+
+[policy.f4jumble]
+audit-as-crates-io = false
+
+[policy.tower-batch-control]
+audit-as-crates-io = false
+
+[policy.tower-fallback]
+audit-as-crates-io = false
+
 [policy.zaino-common]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.zaino-fetch]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.zaino-proto]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.zaino-state]
-audit-as-crates-io = true
+audit-as-crates-io = false
+
+[policy.zcash_address]
+audit-as-crates-io = false
+
+[policy.zcash_client_backend]
+audit-as-crates-io = false
+
+[policy.zcash_client_sqlite]
+audit-as-crates-io = false
+
+[policy.zcash_encoding]
+audit-as-crates-io = false
+
+[policy.zcash_history]
+audit-as-crates-io = false
+
+[policy.zcash_keys]
+audit-as-crates-io = false
+
+[policy.zcash_primitives]
+audit-as-crates-io = false
+
+[policy.zcash_proofs]
+audit-as-crates-io = false
+
+[policy.zcash_protocol]
+audit-as-crates-io = false
+
+[policy.zcash_transparent]
+audit-as-crates-io = false
+
+[policy.zebra-chain]
+audit-as-crates-io = false
+
+[policy.zebra-consensus]
+audit-as-crates-io = false
+
+[policy.zebra-network]
+audit-as-crates-io = false
+
+[policy.zebra-node-services]
+audit-as-crates-io = false
+
+[policy.zebra-rpc]
+audit-as-crates-io = false
+
+[policy.zebra-script]
+audit-as-crates-io = false
+
+[policy.zebra-state]
+audit-as-crates-io = false
+
+[policy.zip321]
+audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -550,14 +616,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
 version = "0.6.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-iterator]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-streaming-iterator]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.ff]]
@@ -1704,14 +1762,6 @@ criteria = "safe-to-deploy"
 version = "0.5.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.tower-batch-control]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-fallback]]
-version = "0.2.41"
-criteria = "safe-to-deploy"
-
 [[exemptions.tower-layer]]
 version = "0.3.3"
 criteria = "safe-to-deploy"
@@ -1896,52 +1946,8 @@ criteria = "safe-to-deploy"
 version = "3.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.zaino-common]]
-version = "0.1.1@git:1f06894587914c063f612b575e6b86296d62c0c4"
-criteria = "safe-to-deploy"
-
-[[exemptions.zaino-fetch]]
-version = "0.2.0@git:1f06894587914c063f612b575e6b86296d62c0c4"
-criteria = "safe-to-deploy"
-
-[[exemptions.zaino-proto]]
-version = "0.1.1@git:1f06894587914c063f612b575e6b86296d62c0c4"
-criteria = "safe-to-deploy"
-
-[[exemptions.zaino-state]]
-version = "0.3.0@git:1f06894587914c063f612b575e6b86296d62c0c4"
-criteria = "safe-to-deploy"
-
 [[exemptions.zcash_script]]
 version = "0.4.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-chain]]
-version = "9.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-consensus]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-network]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-node-services]]
-version = "7.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-rpc]]
-version = "9.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-script]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-state]]
-version = "8.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -470,6 +470,16 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.9 -> 0.3.10"
 
+[[audits.bytecode-alliance.audits.fallible-iterator]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+notes = """
+This major version update has a few minor breaking changes but everything
+this crate has to do with iterators and `Result` and such. No `unsafe` or
+anything like that, all looks good.
+"""
+
 [[audits.bytecode-alliance.audits.fastrand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -2532,6 +2542,18 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-streaming-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.9"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fastrand]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -229,7 +229,15 @@ zebra-state = [
   "dep:jsonrpsee-http-client",
   "jsonrpsee/async-client",
   "dep:base64",
+  "zebra-state/indexer",
+  "spend-index",
 ]
+
+## Enables per-outpoint transparent spend detection: the wallet emits
+## `TransactionDataRequest::SpendsOfTransparentOutput` and the backend resolves spends via a
+## per-outpoint spend index. Enabled by `zebra-state` (which reaches Zebra's spend index); the
+## `zaino` backend leaves it off and uses address-based spend detection instead.
+spend-index = ["zcash_client_sqlite/spend-index"]
 
 ## `zallet rpc` CLI support
 rpc-cli = ["jsonrpsee/async-client", "dep:jsonrpsee-http-client"]

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -17,6 +17,8 @@ use zcash_primitives::{
     transaction::Transaction,
 };
 use zcash_protocol::{TxId, consensus::BlockHeight};
+#[cfg(feature = "spend-index")]
+use transparent::bundle::OutPoint;
 
 mod error;
 pub(crate) use error::ChainError;
@@ -135,6 +137,18 @@ pub(crate) trait ChainView: Clone + Send + Sync + 'static {
         txid: TxId,
     ) -> impl Future<Output = Result<TransactionStatus, ChainError>> + Send;
 
+    /// Returns the spend status of the transparent output `outpoint` on this view's chain.
+    ///
+    /// Spentness is authoritative (taken from the node's UTXO set); a per-outpoint spend index
+    /// is used only to resolve the spending transaction. A spent output whose spender cannot yet
+    /// be resolved is reported as [`SpendStatus::SpentSpenderUnknown`] so the caller retries
+    /// rather than concluding the output is unspent (see ZcashFoundation/zebra#10806).
+    #[cfg(feature = "spend-index")]
+    fn outpoint_spend_status(
+        &self,
+        outpoint: &OutPoint,
+    ) -> impl Future<Output = Result<SpendStatus, ChainError>> + Send;
+
     /// Returns the height of the given block if it is on this view's main chain.
     ///
     /// Gated to the `zcashd-import` migration: its only caller resolves block hashes to
@@ -203,6 +217,18 @@ pub(crate) struct ChainTx {
     pub(crate) block_time: Option<u32>,
 }
 
+/// The spend status of a transparent output, as reported by [`ChainView::outpoint_spend_status`].
+#[cfg(feature = "spend-index")]
+pub(crate) enum SpendStatus {
+    /// The output is unspent on this view's chain.
+    Unspent,
+    /// The output was spent by the transaction with this txid.
+    SpentBy(TxId),
+    /// The output is spent, but the spending transaction cannot yet be resolved (e.g. the
+    /// backend's spend index has not finished building); the caller should retry later.
+    SpentSpenderUnknown,
+}
+
 #[cfg(test)]
 mod tests {
     use std::ops::Range;
@@ -219,6 +245,10 @@ mod tests {
     use zcash_protocol::{TxId, consensus::BlockHeight};
 
     use super::{BlockLocator, ChainBlock, ChainError, ChainTx, ChainView};
+    #[cfg(feature = "spend-index")]
+    use super::SpendStatus;
+    #[cfg(feature = "spend-index")]
+    use transparent::bundle::OutPoint;
 
     /// A trivial in-memory [`ChainView`], proving the trait is implementable by a non-Zaino
     /// backend and locking the contract.
@@ -291,6 +321,14 @@ mod tests {
             _txid: TxId,
         ) -> Result<TransactionStatus, ChainError> {
             Ok(TransactionStatus::TxidNotRecognized)
+        }
+
+        #[cfg(feature = "spend-index")]
+        async fn outpoint_spend_status(
+            &self,
+            _outpoint: &OutPoint,
+        ) -> Result<SpendStatus, ChainError> {
+            Ok(SpendStatus::Unspent)
         }
 
         #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -8,6 +8,10 @@ use std::future::Future;
 use std::ops::Range;
 
 use futures::stream::BoxStream;
+#[cfg(not(feature = "spend-index"))]
+use transparent::address::TransparentAddress;
+#[cfg(feature = "spend-index")]
+use transparent::bundle::OutPoint;
 use zcash_client_backend::data_api::{
     TransactionStatus,
     chain::{ChainState, CommitmentTreeRoot},
@@ -17,8 +21,6 @@ use zcash_primitives::{
     transaction::Transaction,
 };
 use zcash_protocol::{TxId, consensus::BlockHeight};
-#[cfg(feature = "spend-index")]
-use transparent::bundle::OutPoint;
 
 mod error;
 pub(crate) use error::ChainError;
@@ -149,6 +151,25 @@ pub(crate) trait ChainView: Clone + Send + Sync + 'static {
         outpoint: &OutPoint,
     ) -> impl Future<Output = Result<SpendStatus, ChainError>> + Send;
 
+    /// Returns the outpoints `(txid, output_index)` currently unspent at `address` on this
+    /// view's chain, used (without a per-outpoint spend index) to cheaply decide whether any of
+    /// the wallet's tracked outputs at the address have been spent.
+    #[cfg(not(feature = "spend-index"))]
+    fn get_address_unspent_outpoints(
+        &self,
+        address: &TransparentAddress,
+    ) -> impl Future<Output = Result<Vec<(TxId, u32)>, ChainError>> + Send;
+
+    /// Returns the txids of transactions involving `address` mined within `range`
+    /// (start inclusive, end exclusive), used to recover the spending transaction once a missed
+    /// spend has been detected on a backend without a per-outpoint spend index.
+    #[cfg(not(feature = "spend-index"))]
+    fn get_address_tx_ids(
+        &self,
+        address: &TransparentAddress,
+        range: Range<BlockHeight>,
+    ) -> impl Future<Output = Result<Vec<TxId>, ChainError>> + Send;
+
     /// Returns the height of the given block if it is on this view's main chain.
     ///
     /// Gated to the `zcashd-import` migration: its only caller resolves block hashes to
@@ -244,9 +265,11 @@ mod tests {
     };
     use zcash_protocol::{TxId, consensus::BlockHeight};
 
-    use super::{BlockLocator, ChainBlock, ChainError, ChainTx, ChainView};
     #[cfg(feature = "spend-index")]
     use super::SpendStatus;
+    use super::{BlockLocator, ChainBlock, ChainError, ChainTx, ChainView};
+    #[cfg(not(feature = "spend-index"))]
+    use transparent::address::TransparentAddress;
     #[cfg(feature = "spend-index")]
     use transparent::bundle::OutPoint;
 
@@ -329,6 +352,23 @@ mod tests {
             _outpoint: &OutPoint,
         ) -> Result<SpendStatus, ChainError> {
             Ok(SpendStatus::Unspent)
+        }
+
+        #[cfg(not(feature = "spend-index"))]
+        async fn get_address_unspent_outpoints(
+            &self,
+            _address: &TransparentAddress,
+        ) -> Result<Vec<(TxId, u32)>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        #[cfg(not(feature = "spend-index"))]
+        async fn get_address_tx_ids(
+            &self,
+            _address: &TransparentAddress,
+            _range: Range<BlockHeight>,
+        ) -> Result<Vec<TxId>, ChainError> {
+            Ok(Vec::new())
         }
 
         #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]

--- a/zallet/src/components/chain/zaino.rs
+++ b/zallet/src/components/chain/zaino.rs
@@ -7,6 +7,8 @@ use futures::{StreamExt, stream::BoxStream};
 use incrementalmerkletree::frontier::CommitmentTree;
 use jsonrpsee::tracing::{error, info, warn};
 use tokio::net::lookup_host;
+#[cfg(not(feature = "spend-index"))]
+use transparent::address::TransparentAddress;
 use zaino_common::{CacheConfig, DatabaseConfig, StorageConfig};
 use zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector;
 use zaino_state::{
@@ -22,6 +24,8 @@ use zcash_client_backend::data_api::{
     TransactionStatus,
     chain::{ChainState, CommitmentTreeRoot},
 };
+#[cfg(not(feature = "spend-index"))]
+use zcash_keys::address::Address;
 use zcash_primitives::{
     block::{Block, BlockHash, BlockHeader},
     merkle_tree::read_commitment_tree,
@@ -31,6 +35,8 @@ use zcash_protocol::{
     TxId,
     consensus::{self, BlockHeight},
 };
+#[cfg(not(feature = "spend-index"))]
+use zebra_rpc::client::{GetAddressBalanceRequest, GetAddressTxIdsRequest};
 
 use crate::{
     components::TaskHandle,
@@ -534,6 +540,51 @@ impl ChainView for ZainoChainView {
             (None, orphans) if orphans.is_empty() => TransactionStatus::TxidNotRecognized,
             (None, _) => TransactionStatus::NotInMainChain,
         })
+    }
+
+    #[cfg(not(feature = "spend-index"))]
+    async fn get_address_unspent_outpoints(
+        &self,
+        address: &TransparentAddress,
+    ) -> Result<Vec<(TxId, u32)>, ChainError> {
+        let addr_str = Address::Transparent(*address).encode(&self.params);
+        let utxos = self
+            .chain
+            .get_address_utxos(GetAddressBalanceRequest::new(vec![addr_str]))
+            .await
+            .map_err(ChainError::backend)?;
+        Ok(utxos
+            .into_iter()
+            .map(|utxo| (TxId::from_bytes(utxo.txid().0), utxo.output_index().index()))
+            .collect())
+    }
+
+    #[cfg(not(feature = "spend-index"))]
+    async fn get_address_tx_ids(
+        &self,
+        address: &TransparentAddress,
+        range: Range<BlockHeight>,
+    ) -> Result<Vec<TxId>, ChainError> {
+        if range.is_empty() {
+            return Ok(Vec::new());
+        }
+        let addr_str = Address::Transparent(*address).encode(&self.params);
+        let start = u32::from(range.start);
+        // `range` is non-empty, so `range.end >= start + 1 >= 1`.
+        let end_inclusive = u32::from(range.end) - 1;
+        let hashes = self
+            .chain
+            .get_address_txids(GetAddressTxIdsRequest::new(
+                vec![addr_str],
+                Some(start),
+                Some(end_inclusive),
+            ))
+            .await
+            .map_err(ChainError::backend)?;
+        Ok(hashes
+            .into_iter()
+            .map(|hash| TxId::from_bytes(hash.0))
+            .collect())
     }
 
     /// Returns the height of the given block, if it is in the main chain within this

--- a/zallet/src/components/chain/zebra.rs
+++ b/zallet/src/components/chain/zebra.rs
@@ -29,7 +29,11 @@ use zcash_protocol::{
 use zebra_state::ReadStateService;
 
 use super::read_state::{AbortOnDrop, init_read_state_service};
+#[cfg(feature = "spend-index")]
+use super::SpendStatus;
 use super::{BlockLocator, Chain, ChainBlock, ChainError, ChainTx, ChainView};
+#[cfg(feature = "spend-index")]
+use transparent::bundle::OutPoint;
 use crate::{
     components::TaskHandle,
     config::ZalletConfig,
@@ -499,6 +503,23 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
         Ok(TransactionStatus::TxidNotRecognized)
     }
 
+    #[cfg(feature = "spend-index")]
+    async fn outpoint_spend_status(&self, outpoint: &OutPoint) -> Result<SpendStatus, ChainError> {
+        let zoutpoint = convert::to_zebra_outpoint(outpoint);
+        // Authoritative spentness from the UTXO set, independent of the (optional, lazily-built)
+        // spend index.
+        if self.reader.is_unspent(zoutpoint).await? {
+            return Ok(SpendStatus::Unspent);
+        }
+        // Spent: resolve the spending transaction via the spend index. A missing entry means the
+        // index has not caught up yet (ZcashFoundation/zebra#10806), so signal a retry rather
+        // than treating the output as unspent.
+        match self.reader.spending_transaction(zoutpoint).await? {
+            Some(h) => Ok(SpendStatus::SpentBy(convert::from_zebra_tx_hash(h))),
+            None => Ok(SpendStatus::SpentSpenderUnknown),
+        }
+    }
+
     #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
     async fn block_height(&self, hash: &BlockHash) -> Result<Option<BlockHeight>, ChainError> {
         Ok(self
@@ -593,6 +614,20 @@ mod tests {
             &self,
         ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
             Ok(vec![])
+        }
+        #[cfg(feature = "spend-index")]
+        async fn is_unspent(
+            &self,
+            _: zebra_chain::transparent::OutPoint,
+        ) -> Result<bool, ChainError> {
+            Ok(true)
+        }
+        #[cfg(feature = "spend-index")]
+        async fn spending_transaction(
+            &self,
+            _: zebra_chain::transparent::OutPoint,
+        ) -> Result<Option<zebra_chain::transaction::Hash>, ChainError> {
+            Ok(None)
         }
     }
 

--- a/zallet/src/components/chain/zebra.rs
+++ b/zallet/src/components/chain/zebra.rs
@@ -28,18 +28,18 @@ use zcash_protocol::{
 };
 use zebra_state::ReadStateService;
 
-use super::read_state::{AbortOnDrop, init_read_state_service};
 #[cfg(feature = "spend-index")]
 use super::SpendStatus;
+use super::read_state::{AbortOnDrop, init_read_state_service};
 use super::{BlockLocator, Chain, ChainBlock, ChainError, ChainTx, ChainView};
-#[cfg(feature = "spend-index")]
-use transparent::bundle::OutPoint;
 use crate::{
     components::TaskHandle,
     config::ZalletConfig,
     error::{Error, ErrorKind},
     network::Network,
 };
+#[cfg(feature = "spend-index")]
+use transparent::bundle::OutPoint;
 
 mod convert;
 mod reader;

--- a/zallet/src/components/chain/zebra/convert.rs
+++ b/zallet/src/components/chain/zebra/convert.rs
@@ -25,6 +25,23 @@ pub(super) fn to_zebra_txid(txid: TxId) -> zebra_chain::transaction::Hash {
     zebra_chain::transaction::Hash(*txid.as_ref())
 }
 
+/// `zebra-chain` transaction hash → wallet txid (same internal byte order).
+#[cfg(feature = "spend-index")]
+pub(super) fn from_zebra_tx_hash(h: zebra_chain::transaction::Hash) -> TxId {
+    TxId::from_bytes(h.0)
+}
+
+/// Wallet transparent outpoint → `zebra-chain` transparent outpoint.
+#[cfg(feature = "spend-index")]
+pub(super) fn to_zebra_outpoint(
+    outpoint: &transparent::bundle::OutPoint,
+) -> zebra_chain::transparent::OutPoint {
+    zebra_chain::transparent::OutPoint::from_usize(
+        zebra_chain::transaction::Hash(*outpoint.hash()),
+        outpoint.n() as usize,
+    )
+}
+
 /// `zebra-chain` height → wallet height.
 pub(super) fn height(h: zebra_chain::block::Height) -> BlockHeight {
     BlockHeight::from_u32(h.0)

--- a/zallet/src/components/chain/zebra/reader.rs
+++ b/zallet/src/components/chain/zebra/reader.rs
@@ -10,9 +10,9 @@ use zcash_client_backend::data_api::chain::CommitmentTreeRoot;
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
-use zebra_state::{HashOrHeight, ReadRequest, ReadResponse, ReadStateService};
 #[cfg(feature = "spend-index")]
 use zebra_state::Spend;
+use zebra_state::{HashOrHeight, ReadRequest, ReadResponse, ReadStateService};
 
 use super::super::{BlockLocator, ChainBlock, ChainError};
 use super::convert;

--- a/zallet/src/components/chain/zebra/reader.rs
+++ b/zallet/src/components/chain/zebra/reader.rs
@@ -11,6 +11,8 @@ use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_state::{HashOrHeight, ReadRequest, ReadResponse, ReadStateService};
+#[cfg(feature = "spend-index")]
+use zebra_state::Spend;
 
 use super::super::{BlockLocator, ChainBlock, ChainError};
 use super::convert;
@@ -81,6 +83,23 @@ pub(crate) trait ChainReader: Clone + Send + Sync + 'static {
     ) -> impl Future<
         Output = Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError>,
     > + Send;
+
+    /// Whether `outpoint` is unspent on the best chain. Authoritative (reads the UTXO set, not
+    /// the optional spend index).
+    #[cfg(feature = "spend-index")]
+    fn is_unspent(
+        &self,
+        outpoint: zebra_chain::transparent::OutPoint,
+    ) -> impl Future<Output = Result<bool, ChainError>> + Send;
+
+    /// The id of the transaction that spends `outpoint`, if the spend index has recorded it.
+    /// `None` may mean either unspent or not-yet-indexed, so callers must establish spentness
+    /// via [`ChainReader::is_unspent`] first.
+    #[cfg(feature = "spend-index")]
+    fn spending_transaction(
+        &self,
+        outpoint: zebra_chain::transparent::OutPoint,
+    ) -> impl Future<Output = Result<Option<zebra_chain::transaction::Hash>, ChainError>> + Send;
 }
 
 /// [`ChainReader`] backed by a `zebra-state` `ReadStateService`.
@@ -290,6 +309,34 @@ impl ChainReader for ReadStateChainReader {
                 })
                 .collect(),
             other => unreachable!("unexpected response to OrchardSubtrees: {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "spend-index")]
+    async fn is_unspent(
+        &self,
+        outpoint: zebra_chain::transparent::OutPoint,
+    ) -> Result<bool, ChainError> {
+        match self
+            .call(ReadRequest::UnspentBestChainUtxo(outpoint))
+            .await?
+        {
+            ReadResponse::UnspentBestChainUtxo(opt) => Ok(opt.is_some()),
+            other => unreachable!("unexpected response to UnspentBestChainUtxo: {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "spend-index")]
+    async fn spending_transaction(
+        &self,
+        outpoint: zebra_chain::transparent::OutPoint,
+    ) -> Result<Option<zebra_chain::transaction::Hash>, ChainError> {
+        match self
+            .call(ReadRequest::SpendingTransactionId(Spend::from(outpoint)))
+            .await?
+        {
+            ReadResponse::TransactionId(opt) => Ok(opt),
+            other => unreachable!("unexpected response to SpendingTransactionId: {other:?}"),
         }
     }
 }

--- a/zallet/src/components/database/connection.rs
+++ b/zallet/src/components/database/connection.rs
@@ -704,6 +704,15 @@ impl WalletWrite for DbConnection {
         self.with_mut(|mut db_data| db_data.notify_address_checked(request, as_of_height))
     }
 
+    #[cfg(feature = "spend-index")]
+    fn notify_output_verified_unspent(
+        &mut self,
+        outpoint: OutPoint,
+        as_of_height: BlockHeight,
+    ) -> Result<(), Self::Error> {
+        self.with_mut(|mut db_data| db_data.notify_output_verified_unspent(outpoint, as_of_height))
+    }
+
     fn mark_transparent_addresses_exposed(
         &mut self,
         exposures: &[(TransparentAddress, BlockHeight)],

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -39,7 +39,16 @@ use std::time::Duration;
 
 use futures::{StreamExt as _, TryStreamExt as _};
 use jsonrpsee::tracing::{self, debug, info, warn};
+#[cfg(not(feature = "spend-index"))]
+use std::collections::HashSet;
+#[cfg(not(feature = "spend-index"))]
+use std::ops::Range;
 use tokio::{sync::Notify, time};
+#[cfg(not(feature = "spend-index"))]
+use zcash_client_backend::data_api::{
+    InputSource, TransactionsInvolvingAddress, TransparentOutputFilter,
+    wallet::{ConfirmationsPolicy, TargetHeight},
+};
 use zcash_client_backend::{
     data_api::{
         TransactionDataRequest, TransactionStatus, WalletRead, WalletWrite, scanning::ScanPriority,
@@ -49,6 +58,8 @@ use zcash_client_backend::{
     sync::decryptor,
 };
 use zcash_client_sqlite::AccountUuid;
+#[cfg(not(feature = "spend-index"))]
+use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zip32::Scope;
 
@@ -531,6 +542,88 @@ async fn recover_history<C: Chain>(
     }
 }
 
+/// Computes the half-open block range `[start, end)` to query for a transparent-address data
+/// request, and the height to report to `notify_address_checked` as the highest block inspected.
+///
+/// `block_range_end` is exclusive; when unset it defaults to one past `view_tip` so the tip block
+/// is covered, and an explicit end is clamped to that bound. `as_of_height` is the last block
+/// covered (`end - 1`).
+#[cfg(not(feature = "spend-index"))]
+fn address_request_bounds(
+    block_range_start: BlockHeight,
+    block_range_end: Option<BlockHeight>,
+    view_tip: BlockHeight,
+) -> (Range<BlockHeight>, BlockHeight) {
+    let tip_exclusive = view_tip + 1;
+    let end = block_range_end
+        .map(|e| std::cmp::min(e, tip_exclusive))
+        .unwrap_or(tip_exclusive);
+    let end = std::cmp::max(end, block_range_start);
+    let as_of_height = BlockHeight::from_u32(u32::from(end).saturating_sub(1));
+    (block_range_start..end, as_of_height)
+}
+
+/// Services a [`TransactionDataRequest::TransactionsInvolvingAddress`] spend-search request on a
+/// backend without a per-outpoint spend index (the `zaino` build).
+///
+/// Cheap path first: diff the wallet's tracked unspent outputs at the address against the chain's
+/// current unspent set. Only if one of ours is missing (i.e. actually spent on chain) is the
+/// potentially-large address transaction history fetched and ingested to record the spend. The
+/// address is then recorded as checked so the request is not re-issued for the same range. (For
+/// requests with no tracked outputs at the address — e.g. ephemeral-address discovery — this just
+/// advances the watermark; full-block scanning covers those receipts.)
+#[cfg(not(feature = "spend-index"))]
+async fn service_address_request<V: ChainView>(
+    chain_view: &V,
+    params: &Network,
+    db_data: &mut DbConnection,
+    request: TransactionsInvolvingAddress,
+    view_tip: BlockHeight,
+) -> Result<(), SyncError> {
+    let address = request.address();
+    let (range, as_of_height) = address_request_bounds(
+        request.block_range_start(),
+        request.block_range_end(),
+        view_tip,
+    );
+
+    let chain_unspent: HashSet<(TxId, u32)> = chain_view
+        .get_address_unspent_outpoints(&address)
+        .await
+        .map_err(SyncError::Chain)?
+        .into_iter()
+        .collect();
+    let our_outputs = db_data.get_spendable_transparent_outputs(
+        &address,
+        TargetHeight::from(view_tip + 1),
+        ConfirmationsPolicy::MIN,
+        TransparentOutputFilter::All,
+    )?;
+    let any_spent = our_outputs.iter().any(|output| {
+        let outpoint = output.outpoint();
+        !chain_unspent.contains(&(*outpoint.txid(), outpoint.n()))
+    });
+
+    if any_spent {
+        let txids = chain_view
+            .get_address_tx_ids(&address, range)
+            .await
+            .map_err(SyncError::Chain)?;
+        for txid in txids {
+            if let Some(tx) = chain_view
+                .get_transaction(txid)
+                .await
+                .map_err(SyncError::Chain)?
+            {
+                decrypt_and_store_transaction(params, db_data, &tx.inner, tx.mined_height)?;
+            }
+        }
+    }
+
+    db_data.notify_address_checked(request, as_of_height)?;
+    Ok(())
+}
+
 /// Fetches information that the wallet requests to complete its view of transaction
 /// history.
 #[tracing::instrument(skip_all)]
@@ -553,7 +646,6 @@ async fn data_requests<C: Chain>(
             continue;
         }
 
-        #[cfg(feature = "spend-index")]
         let view_tip = chain_view.tip().await.map_err(SyncError::Chain)?.height;
         info!("{} transaction data requests to service", requests.len());
         for request in requests {
@@ -591,11 +683,21 @@ async fn data_requests<C: Chain>(
                             .set_transaction_status(txid, TransactionStatus::TxidNotRecognized)?;
                     }
                 }
-                // Under `spend-index`, spend detection uses `GetSpendingTx` (below);
+                // With `spend-index`, spend detection uses `GetSpendingTx` (below) and any
                 // remaining `TransactionsInvolvingAddress` requests are ephemeral-address
-                // discovery, covered by full-block scanning. (The `zaino` build, with
-                // `spend-index` off, services these via address queries instead.)
+                // discovery, covered by full-block scanning. Without it (the `zaino` build),
+                // these carry the spend-search requests and are serviced via address queries.
+                #[cfg(feature = "spend-index")]
                 TransactionDataRequest::TransactionsInvolvingAddress(_) => (),
+                #[cfg(not(feature = "spend-index"))]
+                TransactionDataRequest::TransactionsInvolvingAddress(request) => {
+                    if let Err(e) =
+                        service_address_request(&chain_view, params, db_data, request, view_tip)
+                            .await
+                    {
+                        warn!("Failed to service transparent-address data request: {e}");
+                    }
+                }
                 #[cfg(feature = "spend-index")]
                 TransactionDataRequest::GetSpendingTx(outpoint) => {
                     use crate::components::chain::SpendStatus;
@@ -714,5 +816,45 @@ mod tests {
             "bad bytes",
         ))));
         assert!(!is_retryable(&SyncError::BatchDecryptorUnavailable));
+    }
+
+    #[cfg(not(feature = "spend-index"))]
+    #[test]
+    fn address_request_bounds_clamps_and_reports_as_of() {
+        use super::address_request_bounds;
+
+        let tip = BlockHeight::from_u32(4_090_000);
+
+        // Explicit end below the tip is used as-is; as_of is end - 1.
+        let (range, as_of) = address_request_bounds(
+            BlockHeight::from_u32(1_810_000),
+            Some(BlockHeight::from_u32(1_900_000)),
+            tip,
+        );
+        assert_eq!(
+            range,
+            BlockHeight::from_u32(1_810_000)..BlockHeight::from_u32(1_900_000)
+        );
+        assert_eq!(as_of, BlockHeight::from_u32(1_899_999));
+
+        // Open end defaults to tip + 1; as_of is the tip.
+        let (range, as_of) = address_request_bounds(BlockHeight::from_u32(1_810_000), None, tip);
+        assert_eq!(
+            range,
+            BlockHeight::from_u32(1_810_000)..BlockHeight::from_u32(4_090_001)
+        );
+        assert_eq!(as_of, tip);
+
+        // An end past the tip is clamped to tip + 1.
+        let (range, as_of) = address_request_bounds(
+            BlockHeight::from_u32(1_810_000),
+            Some(BlockHeight::from_u32(9_000_000)),
+            tip,
+        );
+        assert_eq!(
+            range,
+            BlockHeight::from_u32(1_810_000)..BlockHeight::from_u32(4_090_001)
+        );
+        assert_eq!(as_of, tip);
     }
 }

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -553,6 +553,8 @@ async fn data_requests<C: Chain>(
             continue;
         }
 
+        #[cfg(feature = "spend-index")]
+        let view_tip = chain_view.tip().await.map_err(SyncError::Chain)?.height;
         info!("{} transaction data requests to service", requests.len());
         for request in requests {
             match request {
@@ -589,8 +591,43 @@ async fn data_requests<C: Chain>(
                             .set_transaction_status(txid, TransactionStatus::TxidNotRecognized)?;
                     }
                 }
-                // Ignore these, we do all transparent detection through full blocks.
+                // Under `spend-index`, spend detection uses `GetSpendingTx` (below);
+                // remaining `TransactionsInvolvingAddress` requests are ephemeral-address
+                // discovery, covered by full-block scanning. (The `zaino` build, with
+                // `spend-index` off, services these via address queries instead.)
                 TransactionDataRequest::TransactionsInvolvingAddress(_) => (),
+                #[cfg(feature = "spend-index")]
+                TransactionDataRequest::GetSpendingTx(outpoint) => {
+                    use crate::components::chain::SpendStatus;
+                    match chain_view.outpoint_spend_status(&outpoint).await {
+                        Ok(SpendStatus::Unspent) => {
+                            // Confirmed unspent through the snapshot tip; record so the request
+                            // is not re-issued for this range.
+                            db_data.notify_output_verified_unspent(outpoint, view_tip)?;
+                        }
+                        Ok(SpendStatus::SpentBy(txid)) => {
+                            info!("Recovering spend of {outpoint:?} by {txid}");
+                            if let Some(tx) = chain_view
+                                .get_transaction(txid)
+                                .await
+                                .map_err(SyncError::Chain)?
+                            {
+                                decrypt_and_store_transaction(
+                                    params,
+                                    db_data,
+                                    &tx.inner,
+                                    tx.mined_height,
+                                )?;
+                            }
+                        }
+                        Ok(SpendStatus::SpentSpenderUnknown) => {
+                            // Spent, but the spend index has not yet recorded the spender
+                            // (ZcashFoundation/zebra#10806); leave queued to retry later.
+                            debug!("Spend of {outpoint:?} not yet resolvable; will retry");
+                        }
+                        Err(e) => warn!("Failed to service spend query for {outpoint:?}: {e}"),
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
On top of `zebra-chain-view`. Addresses #507.

## Problem

Transparent spends can be missed by chain scanning. `zcash_client_sqlite` records a transparent spend only when the spending input's outpoint is already present in `transparent_received_outputs` at the time the spending block is processed. Because scanning is priority-based (out of order), a spend block processed *before* the block that created the output is never matched, and there is no retroactive re-scan. The wallet's designed recovery mechanism — `TransactionDataRequest::TransactionsInvolvingAddress` — was previously ignored by the sync engine, so these spends were never recovered and the affected outputs were reported as unspent.

Observed live: a testnet wallet (imported from `zcashd`) over-reported its transparent balance by 15 ZEC, with 6 spent-on-chain outputs shown as unspent at an imported address.

## Change

Implements the `zebra-state` side of per-outpoint spend recovery, using the new `spend-index` feature in zcash/librustzcash#2463. With `spend-index` enabled, `transaction_data_requests` emits `TransactionDataRequest::GetSpendingTx(outpoint)` for each unspent transparent output, and the sync engine services it via a new `ChainView::outpoint_spend_status`:

- Spentness is read **authoritatively** from the node's UTXO set (`ReadRequest::UnspentBestChainUtxo`), independent of the lazily-built spend index.
- The spending transaction is resolved via `ReadRequest::SpendingTransactionId` (Zebra's `indexer` feature) and ingested with `decrypt_and_store_transaction`.
- A spent output whose spender is not yet indexed — the index is backfilled lazily with no completion signal, see ZcashFoundation/zebra#10806 — is left queued and retried, never treated as unspent.

When the output is confirmed unspent through the snapshot tip, `notify_output_verified_unspent` advances the per-outpoint watermark so the request is not re-issued.

The `zebra-state` feature now enables `zebra-state/indexer` and the new zallet `spend-index` feature (→ `zcash_client_sqlite/spend-index`).

The `zaino` backend (with `spend-index` off) continues to build with no regression; its address-index-based recovery (the light-server `getaddresstxids`/`getaddressutxos` fallback — the other half of #507) is a follow-up.

## Tests / verification

- `zebra-state`: builds + 128 unit tests pass; clippy clean.
- `zaino`: builds (no regression).
- The librustzcash side (zcash/librustzcash#2463) adds a `spend_index_queries_are_valid_sql` test exercising both new SQL statements.
- Live end-to-end recovery (the 15 ZEC on the affected testnet wallet) is still to be verified against a running `indexer`-enabled zebrad.

## Notes

- Depends on zcash/librustzcash#2463. `[patch.crates-io]` temporarily pins the librustzcash crates to rev `22db69ca` until that PR merges and is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
