### PR TITLE
database: report wallet db path in network-mismatch error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ be considered breaking changes.
   not defined.
 - Zallet now refuses to open wallet databases from incompatible earlier alpha
   releases instead of attempting to migrate them.
+- The network-mismatch startup error now reports the path of the wallet database
+  and explains that a database is permanently tied to one network, so the cause
+  and the available remedies are clear.
 - `z_sendmany` no longer drop standalone transparent signing keys when the same
   address backs multiple proposal inputs. Keys are now accumulated per address
   rather than overwritten.

--- a/zallet/i18n/en-US/zallet.ftl
+++ b/zallet/i18n/en-US/zallet.ftl
@@ -137,8 +137,11 @@ err-init-zallet-already-running =
     Cannot obtain a lock on data directory {$datadir}. {-zallet} is probably already running.
 
 err-init-config-db-mismatch =
-    The wallet database was created for network type {$db_network_type}, but the
-    config is using network type {$config_network_type}.
+    The wallet database at {$db_path} was created for network type
+    {$db_network_type}, but the config is using network type
+    {$config_network_type}. A wallet database is permanently tied to one network;
+    set 'network' back to {$db_network_type}, or use a different data directory to
+    create a fresh {$config_network_type} wallet.
 err-init-db-incompatible-alpha =
     This wallet database was created by an incompatible alpha version of {-zallet}.
     To use this {-zallet} release, start again with a fresh Zallet wallet or a

--- a/zallet/src/components/database.rs
+++ b/zallet/src/components/database.rs
@@ -81,7 +81,7 @@ impl Database {
             // migrations, some of which make use of the network params), to avoid
             // leaving the database in an inconsistent state. We can assume the network
             // metadata table is present, as it's added by the initial migrations.
-            handle.with_raw(|conn, _| verify_existing_database(conn, config))?;
+            handle.with_raw(|conn, _| verify_existing_database(conn, config, &path))?;
 
             info!("Applying latest database migrations");
         } else {
@@ -177,14 +177,16 @@ impl Database {
 fn verify_existing_database(
     conn: &rusqlite::Connection,
     config: &ZalletConfig,
+    db_path: &std::path::Path,
 ) -> Result<(), Error> {
     verify_alpha_db_compatibility(conn)?;
-    verify_wallet_network_type(conn, config)
+    verify_wallet_network_type(conn, config, db_path)
 }
 
 fn verify_wallet_network_type(
     conn: &rusqlite::Connection,
     config: &ZalletConfig,
+    db_path: &std::path::Path,
 ) -> Result<(), Error> {
     let wallet_network_type = conn
         .query_row(
@@ -200,6 +202,7 @@ fn verify_wallet_network_type(
         Err(ErrorKind::Init
             .context(fl!(
                 "err-init-config-db-mismatch",
+                db_path = db_path.display().to_string(),
                 db_network_type = crate::network::kind::type_to_str(&wallet_network_type.0),
                 config_network_type = crate::network::kind::type_to_str(&config.consensus.network),
             ))

--- a/zallet/src/components/database/tests.rs
+++ b/zallet/src/components/database/tests.rs
@@ -211,8 +211,7 @@ fn network_mismatch_still_reports_network_error() {
 
     let err = open_database(&config).expect_err("network mismatch must be rejected");
     assert!(
-        err.to_string()
-            .contains("The wallet database was created for network type"),
+        err.to_string().contains("was created for network type"),
         "unexpected error: {err}",
     );
 }


### PR DESCRIPTION
The network-mismatch startup error previously named neither the offending
wallet database nor why the two networks could not be reconciled. Include the
database path and a short explanation that a wallet database is permanently
tied to one network, pointing at the two remedies (restore the original
network, or use a new data directory).