### PR TITLE
Make the sync history-recovery batch size configurable

### DIFF
--- a/book/src/cli/start.md
+++ b/book/src/cli/start.md
@@ -8,3 +8,24 @@ begin listening for JSON-RPC connections.
 
 You can shut down a running Zallet wallet with Ctrl+C if `zallet` is in the foreground,
 or (on Unix systems) by sending it the signal `SIGINT` or `SIGTERM`.
+
+## Tuning history recovery
+
+When Zallet syncs a wallet for the first time (or recovers history for newly imported
+keys), it downloads and trial-decrypts historical blocks in batches. The maximum number
+of blocks in a batch is controlled by the `recover_batch_size` option in the `[sync]`
+section of the [configuration file]:
+
+```toml
+[sync]
+# Download and scan up to 10,000 blocks per batch.
+recover_batch_size = 10000
+```
+
+Larger batches improve scanning throughput, but increase peak memory usage: every block
+in a batch is held in memory while it is downloaded and trial-decrypted. Mainnet blocks
+can currently be up to 2 MiB each, so a batch of `N` blocks can require on the order of
+`N × 2 MiB` of memory. The default of `1000` is conservative; operators running on
+server-class hardware may wish to raise it to speed up initial sync.
+
+[configuration file]: example-config.md

--- a/zallet/src/components/sync.rs
+++ b/zallet/src/components/sync.rs
@@ -76,10 +76,6 @@ pub(crate) use error::SyncError;
 mod locator;
 mod steps;
 
-/// The maximum number of blocks that the history-recovery task downloads and scans in a
-/// single batch.
-const RECOVER_BATCH_SIZE: u32 = 1000;
-
 #[derive(Debug)]
 pub(crate) struct WalletSync {}
 
@@ -90,6 +86,7 @@ impl WalletSync {
         chain: C,
     ) -> Result<(TaskHandle, TaskHandle, TaskHandle, TaskHandle), Error> {
         let params = config.consensus.network();
+        let recover_batch_size = config.sync.recover_batch_size();
 
         // The batch decryptor's built-in defaults (queue size 1000, batch-size threshold
         // 200, batch start delay 500ms) are appropriate for Zallet, so use them as-is.
@@ -150,7 +147,7 @@ impl WalletSync {
                     db_data.as_mut(),
                     upper_boundary,
                     decryptor,
-                    RECOVER_BATCH_SIZE,
+                    recover_batch_size,
                 )
                 .await?;
                 Ok(())

--- a/zallet/src/config.rs
+++ b/zallet/src/config.rs
@@ -68,6 +68,12 @@ pub struct ZalletConfig {
 
     /// Settings for the JSON-RPC interface.
     pub rpc: RpcSection,
+
+    /// Settings controlling how Zallet synchronizes the wallet with the chain.
+    ///
+    /// Defaulted so that configs written before this section existed continue to parse.
+    #[serde(default)]
+    pub sync: SyncSection,
 }
 
 impl ZalletConfig {
@@ -688,6 +694,30 @@ fn serialize_rpc_password<S: serde::Serializer>(
     }
 }
 
+/// Settings controlling how Zallet synchronizes the wallet with the chain.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Documented, DocumentedFields)]
+#[serde(deny_unknown_fields)]
+pub struct SyncSection {
+    /// The maximum number of blocks that the history-recovery task downloads and scans in
+    /// a single batch.
+    ///
+    /// Larger batches improve scanning throughput, but increase peak memory usage: every
+    /// block in a batch is held in memory while it is downloaded and trial-decrypted.
+    /// Mainnet blocks can currently be up to 2 MiB each, so a batch of N blocks can require
+    /// on the order of N * 2 MiB of memory.
+    pub recover_batch_size: Option<NonZeroU32>,
+}
+
+impl SyncSection {
+    /// The maximum number of blocks that the history-recovery task downloads and scans in
+    /// a single batch.
+    ///
+    /// Default is 1000.
+    pub fn recover_batch_size(&self) -> u32 {
+        self.recover_batch_size.map_or(1000, NonZeroU32::get)
+    }
+}
+
 impl ZalletConfig {
     /// Generates an example config file, with all default values included as comments.
     pub fn generate_example() -> String {
@@ -744,6 +774,7 @@ impl ZalletConfig {
             ),
             rpc("bind", &conf.rpc.bind),
             rpc("timeout", conf.rpc.timeout().as_secs()),
+            sync("recover_batch_size", conf.sync.recover_batch_size()),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -765,6 +796,7 @@ impl ZalletConfig {
         const NOTE_MANAGEMENT: &str = "note_management";
         const RPC: &str = "rpc";
         const RPC_AUTH: &str = "rpc.auth";
+        const SYNC: &str = "sync";
         fn builder<T: Serialize>(
             f: &'static str,
             d: T,
@@ -832,6 +864,12 @@ impl ZalletConfig {
             d: T,
         ) -> ((&'static str, &'static str), Option<toml::Value>) {
             field(RPC, f, d)
+        }
+        fn sync<T: Serialize>(
+            f: &'static str,
+            d: T,
+        ) -> ((&'static str, &'static str), Option<toml::Value>) {
+            field(SYNC, f, d)
         }
         fn field<T: Serialize>(
             s: &'static str,
@@ -1040,6 +1078,7 @@ impl ZalletConfig {
                     write_section::<NoteManagementSection>(&mut config, field_name, &sec_def)
                 }
                 RPC => write_section::<RpcSection>(&mut config, field_name, &sec_def),
+                SYNC => write_section::<SyncSection>(&mut config, field_name, &sec_def),
                 // Top-level fields correspond to CLI settings, and cannot be configured
                 // via a file.
                 _ => (),
@@ -1072,5 +1111,22 @@ zebra_state_path = "/home/user/.cache/zebra"
     fn read_state_service_section_requires_all_fields() {
         let toml = r#"grpc_address = "127.0.0.1:8231""#;
         assert!(toml::from_str::<ReadStateServiceSection>(toml).is_err());
+    }
+
+    #[test]
+    fn sync_section_uses_default_batch_size_when_unset() {
+        let section: super::SyncSection = toml::from_str("").unwrap();
+        assert_eq!(section.recover_batch_size(), 1000);
+    }
+
+    #[test]
+    fn sync_section_parses_override() {
+        let section: super::SyncSection = toml::from_str("recover_batch_size = 10000").unwrap();
+        assert_eq!(section.recover_batch_size(), 10000);
+    }
+
+    #[test]
+    fn sync_section_rejects_zero_batch_size() {
+        assert!(toml::from_str::<super::SyncSection>("recover_batch_size = 0").is_err());
     }
 }

--- a/zallet/tests/cmd/example_config.out/zallet.toml
+++ b/zallet/tests/cmd/example_config.out/zallet.toml
@@ -329,3 +329,18 @@ as_of_version = "0.1.0-alpha.4"
 # This can be generated with `zallet rpc add-user`.
 #pwhash = UNSET
 
+
+#
+# Settings controlling how Zallet synchronizes the wallet with the chain.
+#
+[sync]
+
+# The maximum number of blocks that the history-recovery task downloads and scans in
+# a single batch.
+#
+# Larger batches improve scanning throughput, but increase peak memory usage: every
+# block in a batch is held in memory while it is downloaded and trial-decrypted.
+# Mainnet blocks can currently be up to 2 MiB each, so a batch of N blocks can require
+# on the order of N * 2 MiB of memory.
+#recover_batch_size = 1000
+

--- a/zallet/tests/cmd/migrate_zcash_conf_mainnet.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_mainnet.toml
@@ -37,5 +37,7 @@ bind = [
 pwhash = "50bb6ea2ab224071ecc3ef195a3a8$9090d8985b8d9969aa2062d134ebb2d568cd585a383ed76931ac34c7d4c8ebf5"
 user = "foobar"
 
+[sync]
+
 """
 stderr = "..."

--- a/zallet/tests/cmd/migrate_zcash_conf_regtest.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_regtest.toml
@@ -37,5 +37,7 @@ as_of_version = "0.1.0-alpha.4"
 
 [rpc]
 
+[sync]
+
 """
 stderr = "..."

--- a/zallet/tests/cmd/migrate_zcash_conf_testnet.toml
+++ b/zallet/tests/cmd/migrate_zcash_conf_testnet.toml
@@ -29,5 +29,7 @@ as_of_version = "0.1.0-alpha.4"
 
 [rpc]
 
+[sync]
+
 """
 stderr = "..."


### PR DESCRIPTION
Adds a `[sync] recover_batch_size` configuration option controlling the maximum number of blocks the history-recovery task downloads and trial-decrypts per batch.

## Motivation

The batch size was previously hardcoded to 1000. Larger batches improve scanning throughput on well-resourced machines, at the cost of higher peak memory usage: each block in a batch is held in memory while it is downloaded and trial-decrypted, and mainnet blocks can currently be up to ~2 MiB, so a batch of `N` blocks needs on the order of `N × 2 MiB` of memory. Making it configurable lets operators trade memory for sync speed based on their hardware.

## Changes

- New `[sync]` config section with `recover_batch_size` (`Option<NonZeroU32>`; a value of `0` is rejected at parse time). The default is **1000**, preserving the previous behaviour.
- The field is `#[serde(default)]`, so configuration files written before this section existed continue to parse without a `[sync]` section.
- `recover_history` now uses the configured value instead of the hardcoded constant.
- Documented in the book (`start.md` → "Tuning history recovery") and in the generated example config.
- Unit tests covering the default, an override, and rejection of `0`; regenerated the `example-config` and `migrate-zcash-conf` golden snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
