### PR TITLE
ci: lint main Dockerfile with hadolint and pin apt versions

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -106,8 +106,14 @@ jobs:
         run: cargo fmt --all -- --check
 
   hadolint:
-    name: Hadolint (Dockerfile)
+    name: Hadolint (${{ matrix.dockerfile }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile
+          - Dockerfile.stagex
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -115,7 +121,7 @@ jobs:
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
-          dockerfile: Dockerfile.stagex
+          dockerfile: ${{ matrix.dockerfile }}
 
   shellcheck:
     name: Shellcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,19 @@
 FROM rust:1.91.1-slim-bookworm@sha256:8514999d4786ef12efe89239e86b3d0a021b94b9d35108c8efe6c79ca7dc1a65 AS builder
 
 # Build deps: protobuf (tonic/PROTOC), clang+llvm (bindgen / *-sys C/C++ deps),
-# pkg-config, and git (zaino-state's build.rs embeds the commit).
+# pkg-config, and git (zaino-state's build.rs embeds the commit). Versions are
+# pinned to the bookworm snapshot that the digest-pinned base resolves to; bump
+# them together with the base digest above.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential clang llvm-dev libclang-dev \
-        protobuf-compiler pkg-config git ca-certificates \
+        build-essential=12.9 \
+        clang=1:14.0-55.7~deb12u1 \
+        llvm-dev=1:14.0-55.7~deb12u1 \
+        libclang-dev=1:14.0-55.7~deb12u1 \
+        protobuf-compiler=3.21.12-3 \
+        pkg-config=1.8.1-1 \
+        git=1:2.39.5-0+deb12u3 \
+        ca-certificates=20230311+deb12u1 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PROTOC=/usr/bin/protoc
@@ -87,8 +95,10 @@ COPY --from=builder /out/usr/local/share/zallet /usr/local/share/zallet
 FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df AS runtime
 # --shadow-time + dropping the apt/dpkg/ldconfig caches keeps the layer free of
 # wall-clock timestamps that would otherwise drift the image digest day to day.
+# ca-certificates is version-pinned to the digest-pinned base's snapshot.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates=20230311+deb12u1 \
     && useradd --uid 1000 --user-group --no-create-home --shell /usr/sbin/nologin zallet \
     && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 COPY --from=builder /out/zallet /usr/local/bin/zallet


### PR DESCRIPTION
The hadolint job only linted Dockerfile.stagex, leaving the main Dockerfile unchecked. Run hadolint over both via a matrix so the required-lints gate covers each one.

Pin the apt package versions in Dockerfile to the bookworm snapshot the digest-pinned base images resolve to, fixing the two DL3008 warnings without suppressing the rule. Bump these pins together with the base digests when a Debian point update supersedes a version.