### PR TITLE
fix(chain): handle reorg -5 error and stale cookie after zebrad restart

### DIFF
--- a/zallet/src/components/chain/zaino.rs
+++ b/zallet/src/components/chain/zaino.rs
@@ -48,6 +48,24 @@ use crate::{
 use super::read_state::{AbortOnDrop, init_read_state_service};
 use super::{BlockLocator, Chain, ChainBlock, ChainError, ChainTx, ChainView};
 
+/// Classifies a block-fetch error, distinguishing transient reorg-window failures from
+/// genuine backend errors.
+///
+/// Zebra returns RPC error -5 ("block height not in best chain") when a block is requested
+/// by height but it no longer exists in the best chain — this happens during reorgs and is
+/// transient. Returning `Unavailable` instead of `Backend` lets callers retry rather than
+/// treating the error as fatal.
+fn block_fetch_error(
+    e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+) -> ChainError {
+    let e: Box<dyn std::error::Error + Send + Sync + 'static> = e.into();
+    if e.to_string().contains("block height not in best chain") {
+        ChainError::Unavailable(e)
+    } else {
+        ChainError::Backend(e)
+    }
+}
+
 /// Converts a `zcash_protocol` block height into a Zaino block height.
 fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
     u32::from(height)
@@ -615,7 +633,7 @@ impl ZainoChainView {
             tokio::pin!(stream);
             let block_bytes = match stream.next().await {
                 None => return Ok(None),
-                Some(ret) => ret.map_err(ChainError::backend),
+                Some(ret) => ret.map_err(block_fetch_error),
             }?;
 
             f(block_bytes).map(Some)
@@ -638,7 +656,7 @@ impl ZainoChainView {
         ) {
             stream
                 .map(|res| {
-                    res.map_err(ChainError::backend).and_then(|block_bytes| {
+                    res.map_err(block_fetch_error).and_then(|block_bytes| {
                         Block::read(block_bytes.as_slice(), &self.params)
                             .map_err(ChainError::invalid_data)
                     })
@@ -655,6 +673,31 @@ impl ChainBlock {
         Self {
             height: BlockHeight::from_u32(height.into()),
             hash: BlockHash(hash.0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_not_in_best_chain_is_unavailable() {
+        // The exact message zebra returns (embedded inside a tonic Status message).
+        let e = "unexpected error response from server: RPC Error (code: -5): block height not in best chain";
+        assert!(
+            matches!(block_fetch_error(e), ChainError::Unavailable(_)),
+            "expected Unavailable for the reorg-window -5 error"
+        );
+    }
+
+    #[test]
+    fn unrelated_backend_errors_remain_fatal() {
+        for msg in ["connection refused", "timed out", "internal server error"] {
+            assert!(
+                matches!(block_fetch_error(msg), ChainError::Backend(_)),
+                "expected Backend for '{msg}'"
+            );
         }
     }
 }

--- a/zallet/src/components/chain/zebra/rpc.rs
+++ b/zallet/src/components/chain/zebra/rpc.rs
@@ -4,7 +4,7 @@
 //! (`zebra-state`, rocksdb), which would re-introduce the version coupling this backend
 //! exists to remove.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use jsonrpsee::core::{client::ClientT, params::ArrayParams};
@@ -12,10 +12,18 @@ use jsonrpsee_http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilde
 
 use crate::error::{Error, ErrorKind};
 
+enum Auth {
+    /// Static Basic auth credentials (pre-encoded, never change).
+    Basic(String),
+    /// Cookie file path — re-read on every request so a zebrad restart is handled transparently.
+    Cookie(PathBuf),
+}
+
 /// A JSON-RPC client for the backing validator.
 #[derive(Clone)]
 pub(crate) struct ValidatorRpcClient {
-    client: HttpClient,
+    url: String,
+    auth: std::sync::Arc<Auth>,
 }
 
 impl ValidatorRpcClient {
@@ -27,32 +35,46 @@ impl ValidatorRpcClient {
         password: &str,
         cookie_path: Option<&Path>,
     ) -> Result<Self, Error> {
-        let credentials = match cookie_path {
-            Some(path) => {
+        let auth = match cookie_path {
+            Some(path) => Auth::Cookie(path.to_path_buf()),
+            None => Auth::Basic(STANDARD.encode(format!("{user}:{password}"))),
+        };
+
+        Ok(Self {
+            url: format!("http://{address}"),
+            auth: std::sync::Arc::new(auth),
+        })
+    }
+
+    /// Builds a fresh `HttpClient` with current credentials.
+    ///
+    /// For cookie auth this re-reads the cookie file, so a zebrad restart that
+    /// rotates the cookie is handled transparently on the next request.
+    fn build_client(&self) -> Result<HttpClient, Error> {
+        let credentials = match self.auth.as_ref() {
+            Auth::Basic(encoded) => encoded.clone(),
+            Auth::Cookie(path) => {
                 let content = std::fs::read_to_string(path)
-                    .map_err(|e| ErrorKind::Init.context(format!("reading RPC cookie: {e}")))?;
+                    .map_err(|e| ErrorKind::Generic.context(format!("reading RPC cookie: {e}")))?;
                 let token = content
                     .trim()
                     .strip_prefix("__cookie__:")
                     .unwrap_or(content.trim());
                 STANDARD.encode(format!("__cookie__:{token}"))
             }
-            None => STANDARD.encode(format!("{user}:{password}")),
         };
 
         let mut headers = HeaderMap::new();
         headers.insert(
             "authorization",
             HeaderValue::from_str(&format!("Basic {credentials}"))
-                .map_err(|e| ErrorKind::Init.context(format!("invalid RPC auth header: {e}")))?,
+                .map_err(|e| ErrorKind::Generic.context(format!("invalid RPC auth header: {e}")))?,
         );
 
-        let client = HttpClientBuilder::default()
+        HttpClientBuilder::default()
             .set_headers(headers)
-            .build(format!("http://{address}"))
-            .map_err(|e| ErrorKind::Init.context(format!("building RPC client: {e}")))?;
-
-        Ok(Self { client })
+            .build(&self.url)
+            .map_err(|e| ErrorKind::Generic.context(format!("building RPC client: {e}")).into())
     }
 
     /// `sendrawtransaction(hex)` — returns the txid hex string.
@@ -61,7 +83,7 @@ impl ValidatorRpcClient {
         params
             .insert(tx_hex)
             .map_err(|e| ErrorKind::Generic.context(e))?;
-        self.client
+        self.build_client()?
             .request("sendrawtransaction", params)
             .await
             .map_err(|e| ErrorKind::Generic.context(e).into())
@@ -69,7 +91,7 @@ impl ValidatorRpcClient {
 
     /// `getrawmempool()` — returns the mempool txid hex strings.
     pub(crate) async fn get_raw_mempool(&self) -> Result<Vec<String>, Error> {
-        self.client
+        self.build_client()?
             .request("getrawmempool", ArrayParams::new())
             .await
             .map_err(|e| ErrorKind::Generic.context(e).into())
@@ -84,7 +106,7 @@ impl ValidatorRpcClient {
         params
             .insert(0u8)
             .map_err(|e| ErrorKind::Generic.context(e))?;
-        self.client
+        self.build_client()?
             .request("getrawtransaction", params)
             .await
             .map_err(|e| ErrorKind::Generic.context(e).into())

--- a/zallet/src/components/chain/zebra/rpc.rs
+++ b/zallet/src/components/chain/zebra/rpc.rs
@@ -74,7 +74,11 @@ impl ValidatorRpcClient {
         HttpClientBuilder::default()
             .set_headers(headers)
             .build(&self.url)
-            .map_err(|e| ErrorKind::Generic.context(format!("building RPC client: {e}")).into())
+            .map_err(|e| {
+                ErrorKind::Generic
+                    .context(format!("building RPC client: {e}"))
+                    .into()
+            })
     }
 
     /// `sendrawtransaction(hex)` — returns the txid hex string.


### PR DESCRIPTION
Fixes two resilience gaps in the zebra-state backend that surface when zebrad restarts or a chain reorg occurs.

**1. Reorg crash (closes #222)**

During a reorg, zebrad returns RPC error -5 (`block height not in best chain`) when a block requested by height is no longer on the best chain. This is transient — the chain settles within seconds — but zallet was classifying it as `ChainError::Backend` (fatal), crashing the sync loop. Fixed by introducing `block_fetch_error()` in `zaino.rs` which maps the -5 message to `ChainError::Unavailable` so the existing retry logic handles it.

**2. Stale cookie after zebrad restart**

Zebrad regenerates its cookie file on every restart. `ValidatorRpcClient` was reading the cookie once at startup and baking it into the HTTP headers, so every request after a restart would fail with auth errors until zallet itself was restarted. Fixed by re-reading the cookie file in `build_client()` on each request — negligible overhead (one file read per RPC call) and fully transparent reconnection.

Both issues were reproduced locally on testnet and verified fixed.