### PR TITLE
Payment: use methods on steps

### DIFF
--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -13,7 +13,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::wallet::Account;
 use zcash_keys::address::Address;
-use zcash_protocol::{PoolType, ShieldedPool, TxId, memo::MemoBytes, value::Zatoshis};
+use zcash_protocol::{PoolType, TxId, memo::MemoBytes, value::Zatoshis};
 
 use crate::{
     components::{chain::Chain, database::DbConnection},
@@ -294,39 +294,14 @@ pub(super) fn enforce_privacy_policy<FeeRuleT, NoteRef>(
     privacy_policy: PrivacyPolicy,
 ) -> Result<(), IncompatiblePrivacyPolicy> {
     for step in proposal.steps() {
-        // TODO: Break out this granularity from `Step::involves`
-        let input_in_pool = |pool_type: PoolType| match pool_type {
-            PoolType::Transparent => step.is_shielding() || !step.transparent_inputs().is_empty(),
-            PoolType::SAPLING => step.shielded_inputs().iter().any(|s_in| {
-                s_in.notes()
-                    .iter()
-                    .any(|note| matches!(note.note().protocol(), ShieldedPool::Sapling))
-            }),
-            PoolType::ORCHARD => step.shielded_inputs().iter().any(|s_in| {
-                s_in.notes()
-                    .iter()
-                    .any(|note| matches!(note.note().protocol(), ShieldedPool::Orchard))
-            }),
-            // The wallet does not yet spend Ironwood notes, so no step has Ironwood inputs.
-            PoolType::Shielded(ShieldedPool::Ironwood) => false,
-        };
-        let output_in_pool =
-            |pool_type: PoolType| step.payment_pools().values().any(|pool| *pool == pool_type);
-        let change_in_pool = |pool_type: PoolType| {
-            step.balance()
-                .proposed_change()
-                .iter()
-                .any(|c| c.output_pool() == pool_type)
-        };
-
-        let has_transparent_recipient = output_in_pool(PoolType::Transparent);
-        let has_transparent_change = change_in_pool(PoolType::Transparent);
+        let has_transparent_recipient = step.output_in_pool(PoolType::Transparent);
+        let has_transparent_change = step.change_in_pool(PoolType::Transparent);
         let has_sapling_recipient =
-            output_in_pool(PoolType::SAPLING) || change_in_pool(PoolType::SAPLING);
+            step.output_in_pool(PoolType::SAPLING) || step.change_in_pool(PoolType::SAPLING);
         let has_orchard_recipient =
-            output_in_pool(PoolType::ORCHARD) || change_in_pool(PoolType::ORCHARD);
+            step.output_in_pool(PoolType::ORCHARD) || step.change_in_pool(PoolType::ORCHARD);
 
-        if input_in_pool(PoolType::Transparent) {
+        if step.input_in_pool(PoolType::Transparent) {
             let received_addrs = step
                 .transparent_inputs()
                 .iter()
@@ -356,7 +331,7 @@ pub(super) fn enforce_privacy_policy<FeeRuleT, NoteRef>(
             if !privacy_policy.allow_revealed_recipients() {
                 return Err(IncompatiblePrivacyPolicy::TransparentChange);
             }
-        } else if input_in_pool(PoolType::ORCHARD) && has_sapling_recipient {
+        } else if step.input_in_pool(PoolType::ORCHARD) && has_sapling_recipient {
             // TODO: This should only trigger when there is a non-fee valueBalance.
             if !privacy_policy.allow_revealed_amounts() {
                 // TODO: Determine whether this is due to the presence of an explicit
@@ -364,7 +339,7 @@ pub(super) fn enforce_privacy_policy<FeeRuleT, NoteRef>(
                 // within a single pool.
                 return Err(IncompatiblePrivacyPolicy::RevealingSaplingAmount);
             }
-        } else if input_in_pool(PoolType::SAPLING) && has_orchard_recipient {
+        } else if step.input_in_pool(PoolType::SAPLING) && has_orchard_recipient {
             // TODO: This should only trigger when there is a non-fee valueBalance.
             if !privacy_policy.allow_revealed_amounts() {
                 return Err(IncompatiblePrivacyPolicy::RevealingOrchardAmount);

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -892,7 +892,7 @@ async fn data_requests<C: Chain>(
                                 decrypt_and_store_transaction(
                                     params,
                                     db_data,
-                                    &tx.inner(),
+                                    tx.inner(),
                                     tx.mined_height(),
                                 )?;
                             }


### PR DESCRIPTION
Old patch, but still useful. Small refacto.

Depends on https://github.com/zcash/librustzcash/pull/2497.

Would also require an update on the zebra and zaino sides.