### PR TITLE
docs(book): document zaino backend selection and --no-default-features requirement

### DIFF
--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -61,3 +61,35 @@ directly from the main branch of its code repository:
 ```
 cargo install --locked --git https://github.com/zcash/wallet.git
 ```
+
+### Choosing a chain backend
+
+Zallet supports two chain backends, selected at compile time:
+
+| Backend | Default | Platform | Requires |
+|---------|---------|----------|---------|
+| `zebra-state` | Yes | Linux only | co-located `zebrad` with `indexer` feature + `[indexer.read_state_service]` config |
+| `zaino` | No | Linux, macOS, Windows | co-located `zebrad` JSON-RPC endpoint |
+
+The **`zebra-state` backend** is the default. It reads finalized chain state directly from
+a co-located `zebrad`'s state database and is the recommended choice for production
+mainnet use on Linux.
+
+The **`zaino` backend** fetches chain data over JSON-RPC (and optionally reads state
+directly when `[indexer.read_state_service]` is configured). It is the only backend that
+supports regtest and runs on non-Linux platforms.
+
+To build or install with the `zaino` backend, pass `--no-default-features --features zaino`
+(along with any other features you need):
+
+```
+# Install from crates.io with the zaino backend
+cargo install --locked --no-default-features --features zaino,rpc-cli zallet
+
+# Install the latest development version with the zaino backend
+cargo install --locked --git https://github.com/zcash/wallet.git \
+  --no-default-features --features zaino,rpc-cli
+```
+
+> Note: the two backends are mutually exclusive. Adding `--features zaino` without
+> `--no-default-features` will activate both at once and produce a compile error.

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -55,6 +55,11 @@ section are:
 
 ### Reading chain state from a local zebrad
 
+Zallet supports two chain backends that determine how it reads chain state: the default
+`zebra-state` backend and the `zaino` backend. The backend is selected at compile time;
+see [Choosing a chain backend](installation/README.md#choosing-a-chain-backend) for how
+to build with each one.
+
 Zallet can read finalized chain state directly from a co-located `zebrad`'s state
 database (opened read-only), rather than fetching every block over JSON-RPC. This is
 enabled by the `[indexer.read_state_service]` section.


### PR DESCRIPTION
## Summary

- Add a **"Choosing a chain backend"** section to the installation guide with a comparison table (zebra-state vs zaino: default, platform support, requirements), prose explaining when to use each, and correct `cargo install` commands using `--no-default-features`.
- Explicitly warn that adding `--features zaino` without `--no-default-features` activates both mutually exclusive backends simultaneously and produces a compile error.
- Add a cross-reference in `setup.md`'s backend section pointing to the new installation content.

Closes #533

## Test plan

- [ ] Verify table and prose in `guide/installation/README.md` are accurate against `zallet/Cargo.toml` feature definitions.
- [ ] Confirm the `cargo install` commands in the new section match the commands CI uses (`--no-default-features --features zaino,rpc-cli`).
- [ ] Build the book locally with `mdbook build` and check the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)