### PR TITLE
Extract the shared amount parameter into a reusable payments type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +4213,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4320,12 @@ checksum = "8246feae3db61428fd0bb94285c690b460e4517d83152377543ca802357785f1"
 dependencies = [
  "pulldown-cmark",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
@@ -4494,6 +4534,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4973,6 +5022,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -6400,6 +6461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7307,6 +7374,7 @@ dependencies = [
  "once_cell",
  "orchard",
  "phf 0.12.1",
+ "proptest",
  "quote",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ tower = "0.4"
 
 # Testing
 once_cell = "1.2"
+proptest = "1.9"
 regex = "1.4"
 tempfile = "3"
 trycmd = "0.15"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1246,6 +1246,10 @@ criteria = "safe-to-deploy"
 version = "1.0.103"
 criteria = "safe-to-deploy"
 
+[[exemptions.proptest]]
+version = "1.11.0"
+criteria = "safe-to-run"
+
 [[exemptions.prost]]
 version = "0.13.4"
 criteria = "safe-to-deploy"
@@ -1453,6 +1457,10 @@ criteria = "safe-to-deploy"
 [[exemptions.rustls-webpki]]
 version = "0.103.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.rusty-fork]]
+version = "0.3.1"
+criteria = "safe-to-run"
 
 [[exemptions.ryu]]
 version = "1.0.18"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -699,6 +699,12 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.29 -> 0.3.32"
 
+[[audits.bytecode-alliance.audits.rand_xorshift]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "Minor updates for a new `rand` crate version, nothing awry."
+
 [[audits.bytecode-alliance.audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -805,6 +811,15 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.2.4"
 notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
+
+[[audits.bytecode-alliance.audits.unarray]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = """
+Crate is sound, albeit leaky, and not actively malicious. Probably not the best
+crate to use in practice but it's suitable for testing dependencies.
+"""
 
 [[audits.bytecode-alliance.audits.vcpkg]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -933,6 +948,18 @@ criteria = "safe-to-deploy"
 version = "1.4.0"
 notes = "Contains no unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bit-set]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.5.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bit-vec]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.6.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.bitflags]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -1294,6 +1321,12 @@ criteria = "safe-to-deploy"
 delta = "0.2.9 -> 0.2.13"
 notes = "Audited at https://fxrev.dev/946396"
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quick-error]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.2.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -2415,6 +2448,30 @@ who = "Emilio Cobos Álvarez <emilio@crisal.io>"
 criteria = "safe-to-deploy"
 delta = "0.69.4 -> 0.72.0"
 notes = "I'm the primary maintainer of this crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.3 -> 0.6.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.bitflags]]
@@ -3940,6 +3997,12 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.13.5 -> 0.14.1"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rand_xorshift]]
+who = "Sean Bowe <ewillbefull@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.redjubjub]]
 who = "Daira Emma Hopwood <daira@jacaranda.org>"

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -198,6 +198,7 @@ uuid.workspace = true
 [dev-dependencies]
 abscissa_core = { workspace = true, features = ["testing"] }
 once_cell.workspace = true
+proptest.workspace = true
 regex.workspace = true
 trycmd.workspace = true
 

--- a/zallet/src/components/json_rpc/methods.rs
+++ b/zallet/src/components/json_rpc/methods.rs
@@ -12,7 +12,7 @@ use crate::components::{
 #[cfg(zallet_build = "wallet")]
 use {
     super::asyncop::{AsyncOperation, ContextInfo, OperationId},
-    crate::components::keystore::KeyStore,
+    crate::components::{json_rpc::payments::AmountParameter, keystore::KeyStore},
     serde::Serialize,
     tokio::sync::RwLock,
 };
@@ -172,7 +172,7 @@ pub(crate) trait Rpc {
     /// - `offset`: An optional number of transactions to skip over before a page of results is
     ///   returned. Defaults to zero.
     /// - `limit`: An optional upper bound on the number of results that should be returned in a
-    ///   page.  
+    ///   page.
     ///
     /// WARNING: This is currently an experimental feature; arguments and result data may change at
     /// any time.
@@ -606,7 +606,7 @@ pub(crate) trait WalletRpc {
     async fn z_send_many(
         &self,
         fromaddress: String,
-        amounts: Vec<z_send_many::AmountParameter>,
+        amounts: Vec<AmountParameter>,
         minconf: Option<u32>,
         fee: Option<JsonValue>,
         privacy_policy: Option<String>,
@@ -1017,7 +1017,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
     async fn z_send_many(
         &self,
         fromaddress: String,
-        amounts: Vec<z_send_many::AmountParameter>,
+        amounts: Vec<AmountParameter>,
         minconf: Option<u32>,
         fee: Option<JsonValue>,
         privacy_policy: Option<String>,

--- a/zallet/src/components/json_rpc/methods/openrpc.rs
+++ b/zallet/src/components/json_rpc/methods/openrpc.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use crate::components::json_rpc::payments::AmountParameter;
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
 use schemars::{JsonSchema, Schema, SchemaGenerator, generate::SchemaSettings};
@@ -7,7 +8,7 @@ use serde::Serialize;
 
 // Imports to work around deficiencies in the build script.
 #[cfg(zallet_build = "wallet")]
-use super::{super::asyncop::OperationId, recover_accounts, z_send_many};
+use super::{super::asyncop::OperationId, recover_accounts};
 
 // See `generate_rpc_help()` in `build.rs` for how this is generated.
 include!(concat!(env!("OUT_DIR"), "/rpc_openrpc.rs"));

--- a/zallet/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet/src/components/json_rpc/methods/z_send_many.rs
@@ -1,14 +1,11 @@
-use std::collections::HashSet;
 use std::convert::Infallible;
 use std::num::NonZeroU32;
 
 use abscissa_core::Application;
 use jsonrpsee::core::{JsonValue, RpcResult};
-use schemars::JsonSchema;
 use secrecy::ExposeSecret;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
-use zcash_address::{ZcashAddress, unified};
+use zcash_address::unified;
 use zcash_client_backend::data_api::wallet::SpendingKeys;
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_backend::{
@@ -21,7 +18,6 @@ use zcash_client_backend::{
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard::MultiOutputChangeStrategy},
     wallet::OvkPolicy,
-    zip321::{Payment, TransactionRequest},
 };
 use zcash_client_sqlite::ReceivedNoteId;
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
@@ -38,11 +34,11 @@ use crate::{
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
             payments::{
-                IncompatiblePrivacyPolicy, PrivacyPolicy, SendResult, broadcast_transactions,
-                enforce_privacy_policy, get_account_for_address, parse_memo,
+                AmountParameter, IncompatiblePrivacyPolicy, PrivacyPolicy, SendResult,
+                broadcast_transactions, build_request, enforce_privacy_policy,
+                get_account_for_address,
             },
             server::LegacyCode,
-            utils::zatoshis_from_value,
         },
         keystore::KeyStore,
     },
@@ -52,21 +48,6 @@ use crate::{
 
 #[cfg(feature = "zcashd-import")]
 use crate::components::json_rpc::utils::collect_standalone_transparent_keys;
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-pub(crate) struct AmountParameter {
-    /// A taddr, zaddr, or Unified Address.
-    address: String,
-
-    /// The numeric amount in ZEC.
-    amount: JsonValue,
-
-    /// If the address is a zaddr, raw data represented in hexadecimal string format. If
-    /// the output is being sent to a transparent address, it’s an error to include this
-    /// field.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    memo: Option<String>,
-}
 
 /// Response to a `z_sendmany` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -99,63 +80,12 @@ pub(crate) async fn call<C: Chain>(
     // TODO: Check that Sapling is active, by inspecting height of `chain` snapshot.
     //       https://github.com/zcash/wallet/issues/237
 
-    if amounts.is_empty() {
-        return Err(
-            LegacyCode::InvalidParameter.with_static("Invalid parameter, amounts array is empty.")
-        );
-    }
-
     if fee.is_some() {
         return Err(LegacyCode::InvalidParameter
             .with_static("Zallet always calculates fees internally; the fee field must be null."));
     }
 
-    let mut recipient_addrs = HashSet::new();
-    let mut payments = vec![];
-    let mut total_out = Zatoshis::ZERO;
-
-    for amount in &amounts {
-        let addr: ZcashAddress = amount.address.parse().map_err(|_| {
-            LegacyCode::InvalidParameter.with_message(format!(
-                "Invalid parameter, unknown address format: {}",
-                amount.address,
-            ))
-        })?;
-
-        if !recipient_addrs.insert(addr.clone()) {
-            return Err(LegacyCode::InvalidParameter.with_message(format!(
-                "Invalid parameter, duplicated recipient address: {}",
-                amount.address,
-            )));
-        }
-
-        let memo = amount.memo.as_deref().map(parse_memo).transpose()?;
-        let value = zatoshis_from_value(&amount.amount)?;
-
-        let payment = Payment::new(addr, Some(value), memo, None, None, vec![]).map_err(|e| {
-            LegacyCode::InvalidParameter.with_static(match e {
-                zcash_client_backend::zip321::PaymentError::TransparentMemo => {
-                    "Cannot send memo to transparent recipient"
-                }
-                zcash_client_backend::zip321::PaymentError::ZeroValuedTransparentOutput => {
-                    "Cannot send zero-valued output to transparent recipient"
-                }
-            })
-        })?;
-
-        payments.push(payment);
-        total_out = (total_out + value)
-            .ok_or_else(|| LegacyCode::InvalidParameter.with_static("Value too large"))?;
-    }
-
-    if payments.is_empty() {
-        return Err(LegacyCode::InvalidParameter.with_static("No recipients"));
-    }
-
-    let request = TransactionRequest::new(payments).map_err(|e| {
-        // TODO: Map errors to `zcashd` shape.
-        LegacyCode::InvalidParameter.with_message(format!("Invalid payment request: {e}"))
-    })?;
+    let request = build_request(&amounts)?;
 
     let account = match fromaddress.as_str() {
         // Select from the legacy transparent address pool.

--- a/zallet/src/components/json_rpc/payments.rs
+++ b/zallet/src/components/json_rpc/payments.rs
@@ -643,3 +643,172 @@ impl SendResult {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod arb {
+    //! Reusable test constructors for [`AmountParameter`], shared across the send-path RPC
+    //! method tests (`z_sendmany` and, later, the account-based send methods).
+    use serde_json::json;
+
+    use super::AmountParameter;
+
+    // Transparent addresses reused from the `validate_address` / `fund_source` tests.
+    pub(crate) const T_ADDR_1: &str = "t1VydNnkjBzfL1iAMyUbwGKJAF7PgvuCfMY";
+    pub(crate) const T_ADDR_2: &str = "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd";
+    pub(crate) const SAPLING_ADDR: &str =
+        "zs1qqqqqqqqqqqqqqqqqqcguyvaw2vjk4sdyeg0lc970u659lvhqq7t0np6hlup5lusxle75c8v35z";
+    // Unified addresses (carrying Orchard/Sapling/transparent receivers) from the
+    // librustzcash test vectors.
+    pub(crate) const UNIFIED_ADDR_1: &str = "u10j2s9sy4dmuakf57z58jc5t8yuswega82jpd2hk3q62l6fsphwyjxvmvfwy8skvvvea6dnkl8l9zpjf3m27qsav9y9nlj59hagmjf5xh0xxyqr8lymnmtjn6gzgrn04dr5s0k9k9wuxc2udzjh4llv47zm6jn6ff0j65s54h3m6p0n9ajswrqzpvy8eh4d5pvypyc6rp5m07uwmjp4sr0upca5hl7gr4pxg45m7vlnx5r7va4n6mfyr98twvjrhcyalwhddelnnjrkhcj0wcp5eyas2c2kcadrxyzw28vvv47q74";
+    pub(crate) const UNIFIED_ADDR_2: &str = "u13j3q8q8f9hx2nx0w9l52dqksy4png7fgm0lqjh8ahn9enyvz5z9xnwzdcdjmpf756s2y88rnyr9px4f4k9w03sl6fr4vwsqcvg8ggfjx";
+
+    // A pool of distinct, valid recipient addresses spanning the transparent, Sapling, and
+    // unified (Orchard) protocols.
+    pub(crate) const ADDR_POOL: &[&str] = &[
+        T_ADDR_1,
+        T_ADDR_2,
+        SAPLING_ADDR,
+        UNIFIED_ADDR_1,
+        UNIFIED_ADDR_2,
+    ];
+
+    /// Constructs an [`AmountParameter`] paying `zec` (a decimal ZEC string) to `address`.
+    pub(crate) fn amount(address: &str, zec: &str) -> AmountParameter {
+        serde_json::from_value(json!({ "address": address, "amount": zec }))
+            .expect("valid AmountParameter")
+    }
+
+    /// Constructs an [`AmountParameter`] paying `zec` to `address` carrying a hex `memo`.
+    pub(crate) fn amount_with_memo(address: &str, zec: &str, memo: &str) -> AmountParameter {
+        serde_json::from_value(json!({ "address": address, "amount": zec, "memo": memo }))
+            .expect("valid AmountParameter")
+    }
+}
+
+#[cfg(test)]
+mod build_request_tests {
+    use std::collections::HashSet;
+
+    use proptest::prelude::*;
+
+    use super::arb::*;
+    use super::*;
+    use crate::components::json_rpc::utils::zec_str;
+
+    fn err_message(amounts: &[AmountParameter]) -> String {
+        build_request(amounts)
+            .expect_err("build_request should fail")
+            .message()
+            .to_string()
+    }
+
+    #[test]
+    fn rejects_empty_array() {
+        assert_eq!(
+            err_message(&[]),
+            "Invalid parameter, amounts array is empty.",
+        );
+    }
+
+    #[test]
+    fn builds_single_recipient() {
+        let request = build_request(&[amount(T_ADDR_1, "0.1")]).expect("valid request");
+        assert_eq!(request.payments().len(), 1);
+    }
+
+    #[test]
+    fn builds_multiple_distinct_recipients() {
+        let request = build_request(&[amount(T_ADDR_1, "0.1"), amount(T_ADDR_2, "0.2")])
+            .expect("valid request");
+        assert_eq!(request.payments().len(), 2);
+    }
+
+    #[test]
+    fn rejects_duplicate_recipient() {
+        let msg = err_message(&[amount(T_ADDR_1, "0.1"), amount(T_ADDR_1, "0.2")]);
+        assert_eq!(
+            msg,
+            format!("Invalid parameter, duplicated recipient address: {T_ADDR_1}"),
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_address_format() {
+        let msg = err_message(&[amount("not-an-address", "0.1")]);
+        assert_eq!(
+            msg,
+            "Invalid parameter, unknown address format: not-an-address",
+        );
+    }
+
+    #[test]
+    fn rejects_memo_to_transparent_recipient() {
+        // The memo is valid hex (so memo parsing succeeds), but transparent recipients
+        // cannot carry a memo.
+        let msg = err_message(&[amount_with_memo(T_ADDR_1, "0.1", "00")]);
+        assert_eq!(msg, "Cannot send memo to transparent recipient");
+    }
+
+    #[test]
+    fn builds_batch_across_all_protocols_at_once() {
+        // An exchange paying out to recipients on different protocols (transparent, Sapling,
+        // and two unified/Orchard) in a single transaction.
+        let request = build_request(&[
+            amount(T_ADDR_1, "0.1"),
+            amount(SAPLING_ADDR, "0.2"),
+            amount(UNIFIED_ADDR_1, "0.3"),
+            amount(UNIFIED_ADDR_2, "0.4"),
+        ])
+        .expect("a mixed-protocol batch should build a request");
+        assert_eq!(request.payments().len(), 4);
+    }
+
+    proptest! {
+        /// For any non-empty list of recipients drawn from the address pool, `build_request`
+        /// succeeds with one payment per recipient exactly when all addresses are distinct,
+        /// and otherwise rejects the request as a duplicate.
+        #[test]
+        fn dedups_iff_all_recipients_distinct(
+            indices in prop::collection::vec(0..ADDR_POOL.len(), 1..8),
+        ) {
+            let amounts = indices
+                .iter()
+                .map(|&i| amount(ADDR_POOL[i], "0.1"))
+                .collect::<Vec<_>>();
+
+            let unique = indices.iter().collect::<HashSet<_>>().len();
+            let result = build_request(&amounts);
+
+            if unique == indices.len() {
+                let request = result.expect("distinct recipients should build a request");
+                prop_assert_eq!(request.payments().len(), indices.len());
+            } else {
+                let err = result.expect_err("duplicate recipients should be rejected");
+                prop_assert!(err.message().contains("duplicated recipient address"));
+            }
+        }
+
+        /// An exchange-style batch withdrawal: any set of distinct recipients drawn from the
+        /// mixed-protocol pool, each with its own amount, builds a request with exactly that
+        /// many payments. Exercises N recipients spanning the transparent, Sapling, and
+        /// unified (Orchard) protocols simultaneously.
+        #[test]
+        fn builds_distinct_mixed_protocol_batches(
+            pool_indices in prop::sample::subsequence(
+                (0..ADDR_POOL.len()).collect::<Vec<_>>(),
+                1..=ADDR_POOL.len(),
+            ),
+            zatoshis in prop::collection::vec(1u64..=1_000_000_000, ADDR_POOL.len()),
+        ) {
+            let amounts = pool_indices
+                .iter()
+                .enumerate()
+                .map(|(i, &pool_idx)| amount(ADDR_POOL[pool_idx], &zec_str(zatoshis[i])))
+                .collect::<Vec<_>>();
+
+            let request = build_request(&amounts)
+                .expect("a batch of distinct mixed-protocol recipients should build a request");
+            prop_assert_eq!(request.payments().len(), pool_indices.len());
+        }
+    }
+}

--- a/zallet/src/components/json_rpc/payments.rs
+++ b/zallet/src/components/json_rpc/payments.rs
@@ -1,12 +1,19 @@
 use std::{collections::HashSet, fmt};
 
 use abscissa_core::Application;
+use jsonrpsee::core::JsonValue;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
-use serde::Serialize;
-use zcash_client_backend::{data_api::WalletRead, proposal::Proposal};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use zcash_address::ZcashAddress;
+use zcash_client_backend::{
+    data_api::WalletRead,
+    proposal::Proposal,
+    zip321::{Payment, TransactionRequest},
+};
 use zcash_client_sqlite::wallet::Account;
 use zcash_keys::address::Address;
-use zcash_protocol::{PoolType, ShieldedProtocol, TxId, memo::MemoBytes};
+use zcash_protocol::{PoolType, ShieldedProtocol, TxId, memo::MemoBytes, value::Zatoshis};
 
 use crate::{
     components::{chain::Chain, database::DbConnection},
@@ -14,7 +21,91 @@ use crate::{
     prelude::APP,
 };
 
-use super::server::LegacyCode;
+use super::{server::LegacyCode, utils::zatoshis_from_value};
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub(crate) struct AmountParameter {
+    /// A taddr, zaddr, or Unified Address.
+    address: String,
+
+    /// The numeric amount in ZEC.
+    amount: JsonValue,
+
+    /// If the address is a zaddr, raw data represented in hexadecimal string format. If
+    /// the output is being sent to a transparent address, it’s an error to include this
+    /// field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    memo: Option<String>,
+}
+
+impl AmountParameter {
+    pub fn address(&self) -> &String {
+        &self.address
+    }
+
+    pub fn amount(&self) -> &JsonValue {
+        &self.amount
+    }
+
+    pub fn memo(&self) -> &Option<String> {
+        &self.memo
+    }
+}
+
+/// Parses an array of output amounts into a ZIP 321 transaction request.
+///
+/// Rejects an empty array, duplicate recipient addresses, malformed addresses, and total
+/// output value overflow.
+pub(super) fn build_request(amounts: &[AmountParameter]) -> RpcResult<TransactionRequest> {
+    if amounts.is_empty() {
+        return Err(
+            LegacyCode::InvalidParameter.with_static("Invalid parameter, amounts array is empty.")
+        );
+    }
+
+    let mut recipient_addrs = HashSet::new();
+    let mut payments = vec![];
+    let mut total_out = Zatoshis::ZERO;
+
+    for amount in amounts {
+        let addr: ZcashAddress = amount.address().parse().map_err(|_| {
+            LegacyCode::InvalidParameter.with_message(format!(
+                "Invalid parameter, unknown address format: {}",
+                amount.address(),
+            ))
+        })?;
+
+        if !recipient_addrs.insert(addr.clone()) {
+            return Err(LegacyCode::InvalidParameter.with_message(format!(
+                "Invalid parameter, duplicated recipient address: {}",
+                amount.address(),
+            )));
+        }
+
+        let memo = amount.memo().as_deref().map(parse_memo).transpose()?;
+        let value = zatoshis_from_value(amount.amount())?;
+
+        let payment = Payment::new(addr, Some(value), memo, None, None, vec![]).map_err(|e| {
+            LegacyCode::InvalidParameter.with_static(match e {
+                zcash_client_backend::zip321::PaymentError::TransparentMemo => {
+                    "Cannot send memo to transparent recipient"
+                }
+                zcash_client_backend::zip321::PaymentError::ZeroValuedTransparentOutput => {
+                    "Cannot send zero-valued output to transparent recipient"
+                }
+            })
+        })?;
+
+        payments.push(payment);
+        total_out = (total_out + value)
+            .ok_or_else(|| LegacyCode::InvalidParameter.with_static("Value too large"))?;
+    }
+
+    TransactionRequest::new(payments).map_err(|e| {
+        // TODO: Map errors to `zcashd` shape.
+        LegacyCode::InvalidParameter.with_message(format!("Invalid payment request: {e}"))
+    })
+}
 
 /// A strategy to use for managing privacy when constructing a transaction.
 ///

--- a/zallet/src/components/json_rpc/utils.rs
+++ b/zallet/src/components/json_rpc/utils.rs
@@ -578,6 +578,15 @@ fn parse_fixed_point(mut val: &str, decimals: i64) -> Option<i64> {
     Some(mantissa)
 }
 
+/// Formats an integer number of zatoshis as a decimal ZEC string (8 fractional digits).
+///
+/// The formatting inverse of [`zatoshis_from_value`], for constructing amount fixtures in
+/// tests.
+#[cfg(test)]
+pub(crate) fn zec_str(zatoshis: u64) -> String {
+    format!("{}.{:08}", zatoshis / 100_000_000, zatoshis % 100_000_000)
+}
+
 #[cfg(test)]
 mod tests {
     use zcash_protocol::value::{COIN, ZatBalance};


### PR DESCRIPTION
Extracting logic from https://github.com/zcash/zallet/pull/531. The idea is to have !531 as small as possible, and merge relatively unrelated changes to main, to decrease the reviewer time on the actual feature, while we're merging NU6.3 related changes.

-----

Move the `AmountParameter` request type out of `z_send_many` into `json_rpc::payments` (with accessor methods) and extract the shared `build_request` amount-parsing helper, so the type and parsing can be reused by other send-path RPC methods. Update `z_sendmany`, the method trait, and the OpenRPC generation to reference the relocated type.