### PR TITLE
ci: ship both zebra-state and zaino backends in one image + deb

### DIFF
--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -420,9 +420,12 @@ jobs:
           mkdir -p "${TARGET_DIR}" "${COMPLETIONS_DIR}" "${MANPAGES_DIR}"
 
           # Seed both backend binaries for cargo-deb --no-build (the `zallet`
-          # package ships `zallet` = zebra-state + `zallet-zaino` = zaino).
+          # package ships `zallet` = zebra-state + `zallet-zaino` = zaino), plus
+          # a `zallet-zebra-state` symlink so the default backend is nameable
+          # both ways. cargo-deb (^2.10) preserves a symlink asset as a symlink.
           install -m 0755 "build/${PLATFORM_KEY}/zallet"       "${TARGET_DIR}/zallet"
           install -m 0755 "build/${PLATFORM_KEY}/zallet-zaino" "${TARGET_DIR}/zallet-zaino"
+          ln -sf zallet "${TARGET_DIR}/zallet-zebra-state"
 
           # Copy the whole completions tree (whatever is inside)
           cp -a "${ROOT}/completions/." "${COMPLETIONS_DIR}/" 2>/dev/null || true

--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -299,7 +299,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p standalone
-          cp "build/${PLATFORM_KEY}/zallet" "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
+          # Default (zebra-state) binary keeps the plain suffixed name; the zaino
+          # backend ships as an additive `-zaino` standalone binary.
+          cp "build/${PLATFORM_KEY}/zallet"       "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
+          cp "build/${PLATFORM_KEY}/zallet-zaino" "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-zaino"
 
       - name: Generate provenance chain metadata
         env:
@@ -340,11 +343,15 @@ jobs:
           }
           EOF
 
-      - name: GPG sign standalone binary
+      - name: GPG sign standalone binaries
         env:
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
-          gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
+          set -euo pipefail
+          for b in "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}" \
+                   "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-zaino"; do
+            gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign "$b"
+          done
 
       - name: Generate SPDX SBOM for standalone binary
         env:
@@ -355,12 +362,14 @@ jobs:
           import os
           from pathlib import Path
 
-          binary_path = Path(f"standalone/zallet-{os.environ['RELEASE_VERSION']}-{os.environ['BINARY_SUFFIX']}")
-          if not binary_path.exists():
-              raise SystemExit(f"Missing binary at {binary_path}")
-          checksum = hashlib.sha256(binary_path.read_bytes()).hexdigest()
-          output = binary_path.parent / f"{binary_path.name}.sbom.spdx"
-          doc = f"""SPDXVersion: SPDX-2.3
+          base = f"standalone/zallet-{os.environ['RELEASE_VERSION']}-{os.environ['BINARY_SUFFIX']}"
+          # SBOM for both backend binaries (default zebra-state + additive zaino).
+          for binary_path in (Path(base), Path(f"{base}-zaino")):
+              if not binary_path.exists():
+                  raise SystemExit(f"Missing binary at {binary_path}")
+              checksum = hashlib.sha256(binary_path.read_bytes()).hexdigest()
+              output = binary_path.parent / f"{binary_path.name}.sbom.spdx"
+              doc = f"""SPDXVersion: SPDX-2.3
           DataLicense: CC0-1.0
           SPDXID: SPDXRef-DOCUMENT
           DocumentName: {binary_path.name}
@@ -373,20 +382,26 @@ jobs:
           FilesAnalyzed: false
           PackageChecksum: SHA256: {checksum}
           """
-          output.write_text(doc, encoding="utf-8")
+              output.write_text(doc, encoding="utf-8")
           PY
 
-      - name: Generate build provenance attestation for binary
+      - name: Generate build provenance attestation for binaries
         id: binary-attest
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-path: standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}
+          # Attest both backend binaries in one call (multi-line subject-path).
+          subject-path: |
+            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}
+            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}-zaino
 
       - name: Save binary attestation bundle
         env:
           BUNDLE_PATH: ${{ steps.binary-attest.outputs['bundle-path'] }}
         run: |
+          # One bundle covers both subjects; publish it under both names so each
+          # binary has a co-located .intoto.jsonl next to it in the Release.
           cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}.intoto.jsonl"
+          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}-zaino.intoto.jsonl"
 
       - name: Seed cargo target tree with the imported artifacts
         run: |
@@ -404,8 +419,10 @@ jobs:
 
           mkdir -p "${TARGET_DIR}" "${COMPLETIONS_DIR}" "${MANPAGES_DIR}"
 
-          # Seed binary for cargo-deb --no-build
-          install -m 0755 "build/${PLATFORM_KEY}/zallet" "${TARGET_DIR}/zallet"
+          # Seed both backend binaries for cargo-deb --no-build (the `zallet`
+          # package ships `zallet` = zebra-state + `zallet-zaino` = zaino).
+          install -m 0755 "build/${PLATFORM_KEY}/zallet"       "${TARGET_DIR}/zallet"
+          install -m 0755 "build/${PLATFORM_KEY}/zallet-zaino" "${TARGET_DIR}/zallet-zaino"
 
           # Copy the whole completions tree (whatever is inside)
           cp -a "${ROOT}/completions/." "${COMPLETIONS_DIR}/" 2>/dev/null || true

--- a/.github/workflows/build-arm64-nix.yml
+++ b/.github/workflows/build-arm64-nix.yml
@@ -81,7 +81,7 @@ jobs:
             extra-trusted-public-keys = ${{ env.NIX_CACHE_PUBKEY }}
             accept-flake-config = true
 
-      - name: Build static aarch64-musl zallet (reproducible)
+      - name: Build static aarch64-musl zallet (reproducible, zebra-state default)
         run: |
           nix build .#zallet --print-build-logs
           test -x ./result/bin/zallet
@@ -89,6 +89,18 @@ jobs:
           grep -q "aarch64" /tmp/zallet-file.txt
           grep -q "statically linked" /tmp/zallet-file.txt
           echo "arm64 zallet sha256: $(sha256sum ./result/bin/zallet)"
+          # Keep the default binary before the next `nix build` overwrites ./result.
+          install -D -m0755 ./result/bin/zallet /tmp/zallet-bins/zallet
+          cp -aL ./result/share/zallet /tmp/zallet-share 2>/dev/null || true
+
+      - name: Build static aarch64-musl zallet-zaino (reproducible, zaino backend)
+        run: |
+          nix build .#zallet-zaino --print-build-logs --out-link ./result-zaino
+          test -x ./result-zaino/bin/zallet-zaino
+          file ./result-zaino/bin/zallet-zaino | grep -q "aarch64"
+          file ./result-zaino/bin/zallet-zaino | grep -q "statically linked"
+          echo "arm64 zallet-zaino sha256: $(sha256sum ./result-zaino/bin/zallet-zaino)"
+          install -D -m0755 ./result-zaino/bin/zallet-zaino /tmp/zallet-bins/zallet-zaino
 
       - name: Stage the runtime artifact (export layout, linux-arm64)
         run: |
@@ -105,10 +117,12 @@ jobs:
           DEST="build/runtime/${SUFFIX}"
           SHARE="${DEST}/usr/local/share/zallet"
           mkdir -p "${SHARE}"
-          install -m0755 ./result/bin/zallet "${DEST}/zallet"
-          # result/share/zallet holds {completions,manpages,debian-copyright}
-          if [ -d ./result/share/zallet ]; then
-            cp -aL ./result/share/zallet/. "${SHARE}/"
+          # Both backend binaries, side by side (matches Dockerfile.stagex export).
+          install -m0755 /tmp/zallet-bins/zallet       "${DEST}/zallet"
+          install -m0755 /tmp/zallet-bins/zallet-zaino "${DEST}/zallet-zaino"
+          # share tree comes from the default (zebra-state) build only.
+          if [ -d /tmp/zallet-share ]; then
+            cp -aL /tmp/zallet-share/. "${SHARE}/"
           fi
           # Fallback for debian-copyright if the build didn't emit it into share.
           [ -f "${SHARE}/debian-copyright" ] || cp -f ./zallet/contrib/debian-copyright "${SHARE}/debian-copyright" 2>/dev/null || true

--- a/.github/workflows/build-arm64-nix.yml
+++ b/.github/workflows/build-arm64-nix.yml
@@ -117,9 +117,11 @@ jobs:
           DEST="build/runtime/${SUFFIX}"
           SHARE="${DEST}/usr/local/share/zallet"
           mkdir -p "${SHARE}"
-          # Both backend binaries, side by side (matches Dockerfile.stagex export).
+          # Both backend binaries, side by side (matches Dockerfile.stagex export),
+          # plus the zebra-state alias symlink.
           install -m0755 /tmp/zallet-bins/zallet       "${DEST}/zallet"
           install -m0755 /tmp/zallet-bins/zallet-zaino "${DEST}/zallet-zaino"
+          ln -sf zallet "${DEST}/zallet-zebra-state"
           # share tree comes from the default (zebra-state) build only.
           if [ -d /tmp/zallet-share ]; then
             cp -aL /tmp/zallet-share/. "${SHARE}/"

--- a/Dockerfile.stagex
+++ b/Dockerfile.stagex
@@ -42,7 +42,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         --locked \
         --target ${TARGET_ARCH}
 
-# Build the zallet binary
+# Build BOTH backend binaries. The `zaino` and `zebra-state` chain-data
+# backends are mutually exclusive Cargo features fixed at compile time, so each
+# is a separate build. The default (zebra-state) keeps the `zallet` name and is
+# the only one that emits the completions/manpages share tree; the zaino build
+# is installed as the additive `zallet-zaino` binary (renamed via --root, since
+# the crate's [[bin]] is always `zallet`).
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/src/zallet/target \
@@ -51,10 +56,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         --path zallet \
         --bin zallet \
         --target ${TARGET_ARCH} \
-        --features rpc-cli,zcashd-import \
+        --no-default-features \
+        --features zebra-state,rpc-cli,zcashd-import \
     && OUT="/usr/src/zallet/target/${TARGET_ARCH}/release" \
     \
-    # Copy completions, manpages and metadata out of the cache mount
+    # Copy completions, manpages and metadata out of the cache mount (default
+    # binary only — these are the `zallet` command's assets).
     && install -d /usr/local/share/zallet \
     && cp -a "${OUT}/completions" /usr/local/share/zallet/completions \
     && cp -a "${OUT}/manpages"  /usr/local/share/zallet/manpages \
@@ -62,11 +69,27 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
          "${OUT}/debian-copyright" \
          /usr/local/share/zallet/debian-copyright
 
+# zaino backend → additive `zallet-zaino` binary. Install into a separate root
+# then rename, because the crate's [[bin]] name is fixed to `zallet`.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/src/zallet/target \
+    cargo install \
+        --frozen \
+        --path zallet \
+        --bin zallet \
+        --target ${TARGET_ARCH} \
+        --no-default-features \
+        --features zaino,rpc-cli,zcashd-import \
+        --root /usr/local/zaino \
+    && install -D -m0755 /usr/local/zaino/bin/zallet /usr/local/cargo/bin/zallet-zaino
+
 # --- Stage 2: layer for local binary extraction ---
 FROM scratch AS export
 
-# Binary at the root for easy extraction
+# Both binaries at the root for easy extraction.
 COPY --from=builder /usr/local/cargo/bin/zallet /zallet
+COPY --from=builder /usr/local/cargo/bin/zallet-zaino /zallet-zaino
 
 # Export the whole zallet share tree (completions, manpages, metadata, etc.)
 COPY --from=builder /usr/local/share/zallet /usr/local/share/zallet
@@ -74,6 +97,9 @@ COPY --from=builder /usr/local/share/zallet /usr/local/share/zallet
 # --- Stage 3: Minimal runtime with stagex ---
 FROM scratch AS runtime
 USER 1000:1000
+# Ship both backends; default entrypoint is the zebra-state `zallet`. Consumers
+# that need the zaino backend (e.g. z3) set their command to `zallet-zaino`.
 COPY --from=export /zallet /usr/local/bin/zallet
+COPY --from=export /zallet-zaino /usr/local/bin/zallet-zaino
 WORKDIR /var/lib/zallet
 ENTRYPOINT ["zallet"]

--- a/Dockerfile.stagex
+++ b/Dockerfile.stagex
@@ -82,14 +82,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         --no-default-features \
         --features zaino,rpc-cli,zcashd-import \
         --root /usr/local/zaino \
-    && install -D -m0755 /usr/local/zaino/bin/zallet /usr/local/cargo/bin/zallet-zaino
+    && install -D -m0755 /usr/local/zaino/bin/zallet /usr/local/cargo/bin/zallet-zaino \
+    # Explicit alias for the default (zebra-state) binary, so the backend is
+    # nameable both ways: `zallet` (default) and `zallet-zebra-state`.
+    && ln -sf zallet /usr/local/cargo/bin/zallet-zebra-state
 
 # --- Stage 2: layer for local binary extraction ---
 FROM scratch AS export
 
-# Both binaries at the root for easy extraction.
+# All three names at the root: the two real binaries + the zebra-state alias.
 COPY --from=builder /usr/local/cargo/bin/zallet /zallet
 COPY --from=builder /usr/local/cargo/bin/zallet-zaino /zallet-zaino
+COPY --from=builder /usr/local/cargo/bin/zallet-zebra-state /zallet-zebra-state
 
 # Export the whole zallet share tree (completions, manpages, metadata, etc.)
 COPY --from=builder /usr/local/share/zallet /usr/local/share/zallet
@@ -97,9 +101,12 @@ COPY --from=builder /usr/local/share/zallet /usr/local/share/zallet
 # --- Stage 3: Minimal runtime with stagex ---
 FROM scratch AS runtime
 USER 1000:1000
-# Ship both backends; default entrypoint is the zebra-state `zallet`. Consumers
-# that need the zaino backend (e.g. z3) set their command to `zallet-zaino`.
+# Ship both backends. Default entrypoint is the zebra-state `zallet`, also
+# nameable as `zallet-zebra-state` (a symlink). Consumers that need the zaino
+# backend (e.g. z3, or anyone whose zebrad is NOT built with the `indexer`
+# feature) run `zallet-zaino`.
 COPY --from=export /zallet /usr/local/bin/zallet
 COPY --from=export /zallet-zaino /usr/local/bin/zallet-zaino
+COPY --from=export /zallet-zebra-state /usr/local/bin/zallet-zebra-state
 WORKDIR /var/lib/zallet
 ENTRYPOINT ["zallet"]

--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -12,6 +12,27 @@ the simplest options:
 > ALPHA software, and is rapidly changing. If you create a Zallet package before the 1.0.0
 > production release, please ensure you mark it as alpha software and regularly update it.
 
+## Chain-data backends (`zallet` vs `zallet-zaino`)
+
+Zallet reads chain data through one of two **mutually exclusive** backends, selected at
+compile time. The official Docker image and Debian package ship **both** binaries side by
+side, so you pick a backend by which binary you run:
+
+| Binary | Backend (Cargo feature) | How it reaches the chain | Regtest |
+|--------|-------------------------|--------------------------|---------|
+| `zallet` | `zebra-state` (default) | Reads finalized state directly from a co-located `zebrad`'s `ReadStateService`. Requires a shared state directory and a `zebrad` built with the `indexer` feature. | No |
+| `zallet-zaino` | `zaino` | Talks to Zebra over JSON-RPC; Zebra and Zallet can run as separate services/containers. | Yes |
+
+If you are unsure, use `zallet` (the default). Use `zallet-zaino` when Zallet and Zebra
+run in separate containers and communicate over JSON-RPC (for example, the
+[z3](https://github.com/ZcashFoundation/z3) stack), or when you need regtest support. The
+two binaries share the same CLI surface, config format, and subcommands; only the
+chain-data backend differs.
+
+The pre-compiled standalone binaries on the GitHub Releases page follow the same split:
+`zallet-<version>-linux-<arch>` (zebra-state) and `zallet-<version>-linux-<arch>-zaino`
+(zaino).
+
 ## Pre-compiled binaries
 
 > WARNING: This approach does not have automatic updates.

--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -20,14 +20,18 @@ side, so you pick a backend by which binary you run:
 
 | Binary | Backend (Cargo feature) | How it reaches the chain | Regtest |
 |--------|-------------------------|--------------------------|---------|
-| `zallet` | `zebra-state` (default) | Reads finalized state directly from a co-located `zebrad`'s `ReadStateService`. Requires a shared state directory and a `zebrad` built with the `indexer` feature. | No |
+| `zallet` | `zebra-state` (default) | Reads finalized state directly from a co-located `zebrad`'s `ReadStateService`. **Requires a `zebrad` built with the `indexer` feature** and a shared state directory. | No |
+| `zallet-zebra-state` | `zebra-state` | Symlink alias of `zallet` — same binary, explicit name for the default backend. | No |
 | `zallet-zaino` | `zaino` | Talks to Zebra over JSON-RPC; Zebra and Zallet can run as separate services/containers. | Yes |
 
-If you are unsure, use `zallet` (the default). Use `zallet-zaino` when Zallet and Zebra
-run in separate containers and communicate over JSON-RPC (for example, the
-[z3](https://github.com/ZcashFoundation/z3) stack), or when you need regtest support. The
-two binaries share the same CLI surface, config format, and subcommands; only the
-chain-data backend differs.
+**Which one?** `zallet` (the default) is the `zebra-state` backend and **only works
+against a `zebrad` that was built with the non-default `indexer` feature** (plus a shared
+state directory). If your `zebrad` is **not** built with `indexer` — including the stock
+`zfnd/zebra` images and the [z3](https://github.com/ZcashFoundation/z3) stack, or any
+setup where Zebra and Zallet run as separate containers talking over JSON-RPC, or when you
+need regtest — use **`zallet-zaino`** instead. `zallet-zebra-state` is just an explicit
+alias of `zallet` for when you want the backend named. All three share the same CLI
+surface, config format, and subcommands; only the chain-data backend differs.
 
 The pre-compiled standalone binaries on the GitHub Releases page follow the same split:
 `zallet-<version>-linux-<arch>` (zebra-state) and `zallet-<version>-linux-<arch>-zaino`

--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -12,30 +12,58 @@ the simplest options:
 > ALPHA software, and is rapidly changing. If you create a Zallet package before the 1.0.0
 > production release, please ensure you mark it as alpha software and regularly update it.
 
-## Chain-data backends (`zallet` vs `zallet-zaino`)
+## Choosing a chain backend
 
-Zallet reads chain data through one of two **mutually exclusive** backends, selected at
-compile time. The official Docker image and Debian package ship **both** binaries side by
-side, so you pick a backend by which binary you run:
+Zallet supports two **mutually exclusive** chain backends, selected at compile time:
 
-| Binary | Backend (Cargo feature) | How it reaches the chain | Regtest |
-|--------|-------------------------|--------------------------|---------|
-| `zallet` | `zebra-state` (default) | Reads finalized state directly from a co-located `zebrad`'s `ReadStateService`. **Requires a `zebrad` built with the `indexer` feature** and a shared state directory. | No |
-| `zallet-zebra-state` | `zebra-state` | Symlink alias of `zallet` — same binary, explicit name for the default backend. | No |
-| `zallet-zaino` | `zaino` | Talks to Zebra over JSON-RPC; Zebra and Zallet can run as separate services/containers. | Yes |
+| Backend | Default | Platform | Reaches the chain via | Requires | Regtest |
+|---------|:-------:|----------|-----------------------|----------|:-------:|
+| `zebra-state` | Yes | Linux only | co-located `zebrad`'s state database (`ReadStateService`) | `zebrad` built with the `indexer` feature + `[indexer.read_state_service]` config + shared state dir | No |
+| `zaino` | No | Linux, macOS, Windows | co-located `zebrad`'s JSON-RPC endpoint (optionally reads state directly when `[indexer.read_state_service]` is set) | co-located `zebrad` JSON-RPC endpoint | Yes |
 
-**Which one?** `zallet` (the default) is the `zebra-state` backend and **only works
-against a `zebrad` that was built with the non-default `indexer` feature** (plus a shared
-state directory). If your `zebrad` is **not** built with `indexer` — including the stock
-`zfnd/zebra` images and the [z3](https://github.com/ZcashFoundation/z3) stack, or any
-setup where Zebra and Zallet run as separate containers talking over JSON-RPC, or when you
-need regtest — use **`zallet-zaino`** instead. `zallet-zebra-state` is just an explicit
-alias of `zallet` for when you want the backend named. All three share the same CLI
-surface, config format, and subcommands; only the chain-data backend differs.
+The **`zebra-state` backend** is the default. It reads finalized chain state directly from
+a co-located `zebrad`'s state database and is the recommended choice for production
+mainnet use on Linux. It **only works against a `zebrad` built with the non-default
+`indexer` feature**.
 
-The pre-compiled standalone binaries on the GitHub Releases page follow the same split:
-`zallet-<version>-linux-<arch>` (zebra-state) and `zallet-<version>-linux-<arch>-zaino`
-(zaino).
+The **`zaino` backend** fetches chain data over JSON-RPC. It is the only backend that
+supports regtest and non-Linux platforms, and it does **not** require the `zebrad`
+`indexer` feature — so it is the right choice when Zebra and Zallet run as separate
+services/containers over JSON-RPC (for example, the stock `zfnd/zebra` images or the
+[z3](https://github.com/ZcashFoundation/z3) stack), or when you need regtest.
+
+### Pre-compiled artifacts (Docker image / Debian package)
+
+The official Docker image and Debian package ship **both** backends as separate binaries,
+so you pick one by which binary you run:
+
+| Binary | Backend | Notes |
+|--------|---------|-------|
+| `zallet` | `zebra-state` (default) | the default command / image `ENTRYPOINT` |
+| `zallet-zebra-state` | `zebra-state` | symlink alias of `zallet` — same binary, explicit name |
+| `zallet-zaino` | `zaino` | additive second binary |
+
+All three share the same CLI surface, config format, and subcommands; only the chain-data
+backend differs. The pre-compiled standalone binaries on the GitHub Releases page follow
+the same split: `zallet-<version>-linux-<arch>` (zebra-state) and
+`zallet-<version>-linux-<arch>-zaino` (zaino).
+
+### Building from source with a chosen backend
+
+To build or install with the `zaino` backend, pass `--no-default-features --features zaino`
+(along with any other features you need):
+
+```
+# Install from crates.io with the zaino backend
+cargo install --locked --no-default-features --features zaino,rpc-cli zallet
+
+# Install the latest development version with the zaino backend
+cargo install --locked --git https://github.com/zcash/wallet.git \
+  --no-default-features --features zaino,rpc-cli
+```
+
+> Note: the two backends are mutually exclusive. Adding `--features zaino` without
+> `--no-default-features` activates both at once and produces a compile error.
 
 ## Pre-compiled binaries
 

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -55,6 +55,11 @@ section are:
 
 ### Reading chain state from a local zebrad
 
+Zallet supports two chain backends that determine how it reads chain state: the default
+`zebra-state` backend and the `zaino` backend. The backend is selected at compile time;
+see [Choosing a chain backend](installation/README.md#choosing-a-chain-backend) for the
+comparison and for how to build or run with each one.
+
 Zallet can read finalized chain state directly from a co-located `zebrad`'s state
 database (opened read-only), rather than fetching every block over JSON-RPC. This is
 enabled by the `[indexer.read_state_service]` section.

--- a/flake.nix
+++ b/flake.nix
@@ -41,10 +41,18 @@
         #     static-musl link.
         # This mirrors how StageX's pre-integrated clang+libc++ pallet works on amd64.
         clangCC = pkgs.pkgsMusl.clangStdenv.cc;
-        zallet = craneLib.buildPackage ({
+        # Build the zallet binary with a given chain-data backend. `zaino` and
+        # `zebra-state` are mutually exclusive Cargo features fixed at compile
+        # time, so we produce one binary per backend. `binName` renames the
+        # installed binary (zebra-state keeps `zallet`; zaino becomes
+        # `zallet-zaino`) so one image/deb can ship both side by side. The
+        # generated share tree (completions/manpages) is always the `zallet`
+        # command's — it is only produced/collected for the default binary.
+        mkZallet = { backend, binName, collectShare }: craneLib.buildPackage ({
           inherit src;
+          pname = binName;
           strictDeps = true;
-          cargoExtraArgs = "--locked --bin zallet --features rpc-cli,zcashd-import";
+          cargoExtraArgs = "--locked --bin zallet --no-default-features --features ${backend},rpc-cli,zcashd-import";
           CARGO_BUILD_TARGET = muslTarget;
           # Static musl; use the musl clang as the linker so libc++ + crt resolve
           # coherently (a generic cc-wrapper mis-targets gnu vs musl here).
@@ -57,8 +65,13 @@
           # manpages and debian-copyright into target/<triple>/release/{completions,
           # manpages} + debian-copyright. crane installs only the binary, so copy
           # those generated assets into $out/share/zallet — the deb matrix +
-          # the StageX export layout expect them there.
+          # the StageX export layout expect them there. Only the default
+          # (zebra-state) binary carries the share tree + keeps the `zallet` name.
           postInstall = ''
+            if [ "${binName}" != "zallet" ]; then
+              mv "$out/bin/zallet" "$out/bin/${binName}"
+            fi
+          '' + pkgs.lib.optionalString collectShare ''
             # build.rs writes completions/ + manpages/ into the cargo target dir
             # (derived from OUT_DIR's 4th ancestor → <target>/<triple>/release).
             # crane's CARGO_TARGET_DIR isn't necessarily ./target, so SEARCH for
@@ -81,5 +94,14 @@
           "CC_${targetEnvSuffix}" = "${clangCC}/bin/cc";
           "CXX_${targetEnvSuffix}" = "${clangCC}/bin/c++";
         });
-      in { packages.default = zallet; packages.zallet = zallet; });
+        # Default backend (zebra-state): keeps the `zallet` binary name + owns the
+        # completions/manpages share tree that the deb + StageX export consume.
+        zallet = mkZallet { backend = "zebra-state"; binName = "zallet"; collectShare = true; };
+        # zaino backend: additive second binary `zallet-zaino`, no share tree.
+        zallet-zaino = mkZallet { backend = "zaino"; binName = "zallet-zaino"; collectShare = false; };
+      in {
+        packages.default = zallet;
+        packages.zallet = zallet;
+        packages.zallet-zaino = zallet-zaino;
+      });
 }

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -18,6 +18,14 @@ section = "utils"
 assets = [
     ["target/release/zallet", "usr/bin/", "755"],
 
+    # Additive second binary: the same wallet built with the mutually-exclusive
+    # `zaino` chain-data backend (talks to Zebra over JSON-RPC; supports
+    # regtest). The release CI seeds it next to `zallet` in target/release/ so a
+    # single `zallet` package ships both backends; the default `zallet` command
+    # is unchanged. Completions/manpages are the `zallet` command's and apply to
+    # both (same CLI surface).
+    ["target/release/zallet-zaino", "usr/bin/", "755"],
+
     # From the bash-completion FAQ (https://github.com/scop/bash-completion/blob/master/README.md#faq):
     # > Q. I author/maintain package X and would like to maintain my own completion code
     # >    for this package. Where should I put it to be sure that interactive bash shells

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -26,6 +26,11 @@ assets = [
     # both (same CLI surface).
     ["target/release/zallet-zaino", "usr/bin/", "755"],
 
+    # Explicit alias for the default (zebra-state) binary. Seeded as a symlink
+    # `zallet-zebra-state -> zallet` by the release CI; cargo-deb preserves it as
+    # a symlink in the package, so the backend is nameable both ways.
+    ["target/release/zallet-zebra-state", "usr/bin/", "777"],
+
     # From the bash-completion FAQ (https://github.com/scop/bash-completion/blob/master/README.md#faq):
     # > Q. I author/maintain package X and would like to maintain my own completion code
     # >    for this package. Where should I put it to be sure that interactive bash shells


### PR DESCRIPTION
## Problem

Zallet's chain-data backend is a **compile-time, mutually-exclusive** Cargo feature:

- **`zebra-state`** (default) — reads a co-located `zebrad`'s state directly via `ReadStateService`; **requires a `zebrad` built with the non-default `indexer` feature** + a shared state dir; **no regtest**.
- **`zaino`** (`--no-default-features --features zaino`) — talks to Zebra over **JSON-RPC** in separate containers; **supports regtest**.

The published `v0.1.0-alpha.4` image ships only the default `zebra-state` backend, so it can't run in split-container stacks like [z3](https://github.com/ZcashFoundation/z3): `zallet start` fails with `the zebra-state backend requires an [indexer.read_state_service] config section`. Because the backend is fixed at Zallet compile time, bumping Zebra/Zaino doesn't help — a zaino-backend image has to be published. This blocks [z3#49](https://github.com/ZcashFoundation/z3/pull/49).

## What this does

Build **both** backends and ship them together, **additively** — the existing `zallet` command is unchanged. Three invocable names:

| Name | Kind | Backend | Needs `zebrad` built with `indexer`? | Regtest |
|------|------|---------|:---:|:---:|
| **`zallet`** | real binary | `zebra-state` (default) | **Yes** | No |
| **`zallet-zebra-state`** | symlink → `zallet` | `zebra-state` | **Yes** | No |
| **`zallet-zaino`** | real binary | `zaino` | No | **Yes** |

`zallet` is the default and is byte-for-byte the previous default build. `zallet-zebra-state` is just an explicit alias (a symlink to the same binary). `zallet-zaino` is the only new binary.

> **Which one should I run?** `zallet` / `zallet-zebra-state` (zebra-state) **only work against a `zebrad` built with the non-default `indexer` feature** (plus a shared state dir). If your `zebrad` is **not** built with `indexer` — including the stock `zfnd/zebra` images, the z3 stack, any setup where Zebra and Zallet are separate containers over JSON-RPC, or regtest — run **`zallet-zaino`**. All three share the same CLI surface, config format, and subcommands; only the chain-data backend differs.

## Resulting artifacts

| Deliverable | zebra-state (default) | zaino |
|-------------|-----------------------|-------|
| **Docker image** `zodlinc/zallet:<tag>` | `/usr/local/bin/zallet` + `zallet-zebra-state` (symlink); `ENTRYPOINT` = `zallet` | `/usr/local/bin/zallet-zaino` |
| **Debian package** `zallet` (single package) | `/usr/bin/zallet` + `/usr/bin/zallet-zebra-state` (symlink) | `/usr/bin/zallet-zaino` |
| **Standalone binary** (GitHub Release) | `zallet-<version>-linux-<arch>` | `zallet-<version>-linux-<arch>-zaino` |

One image and one `.deb` carry both backends; you pick by which binary you run. (Standalone binaries stay single-binary by nature, so the zaino one is a separate `-zaino` file. `zallet-zebra-state` is a symlink only in the image + deb, where a filesystem exists.)

## Changes
- **`Dockerfile.stagex`** — two `cargo install` passes (`--no-default-features --features {zebra-state,zaino},rpc-cli,zcashd-import`); zaino installs to a separate `--root` and is renamed `zallet-zaino`; a `zallet-zebra-state -> zallet` symlink is created. Runtime ships all three names; `ENTRYPOINT` stays `zallet`.
- **`flake.nix`** (arm64/Nix) — parametrized `mkZallet`; exposes `packages.zallet` (default) + `packages.zallet-zaino`. Only the default carries the completions/manpages share tree (identical CLI surface).
- **`build-arm64-nix.yml`** — builds both flake packages; stages both binaries + the `zallet-zebra-state` symlink into the shared runtime artifact.
- **`binaries-and-deb-release.yml`** — seeds both binaries + the symlink for `cargo-deb`; signs + SBOMs both standalone binaries; one attestation covers both.
- **`zallet/Cargo.toml`** — cargo-deb assets add `zallet-zaino` and the `zallet-zebra-state` symlink (cargo-deb ^2.10 preserves symlink assets).
- **docs** — installation guide explains the three names, the `indexer` requirement, and when to pick `zallet-zaino`.

## Notes
- The default (`zallet` / zebra-state) is **byte-for-byte the prior default**: `--no-default-features --features zebra-state,...` is just the explicit form of the previous implicit `default = ["zebra-state"]`.
- The full multi-arch (StageX amd64 + Nix arm64) + SLSA/cosign/SBOM pipeline is preserved; both binaries flow through the existing single-image/single-deb release, so `release.yml` needs no change.
- CI already tests both backends separately (`ci.yml`), so the feature strings are proven.

## After merge
Dispatch a re-release with full SLSA (no re-tag): `gh workflow run release.yml -f tag=v0.1.0-alpha.4`. Then z3 re-points `Z3_ZALLET_IMAGE` → `zodlinc/zallet:v0.1.0-alpha.4` and runs `zallet-zaino`, unblocking z3#49.

## Docs: supersedes #534

#534 (@pacu, "document zaino backend selection") was closed unmerged in favor of this PR. Since both touched the same doc files (`book/src/guide/installation/README.md` + `setup.md`), its content is carried here: the "Choosing a chain backend" section with the comparison table (including the Linux-only vs cross-platform distinction), the `cargo install --no-default-features --features zaino` build commands, and the mutual-exclusivity compile-error warning. This PR extends that with the pre-built-artifact story — the `zallet` / `zallet-zebra-state` / `zallet-zaino` binaries shipped in the Docker image + Debian package. Also closes #533.
