### PR TITLE
fix(ci): stage the zallet-zaino binary in the release deb/binary job

### DIFF
--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -257,9 +257,16 @@ jobs:
           PLATFORM_KEY="${{ matrix.platform_key }}"
           ARTIFACT_ROOT="build/runtime-artifact/${PLATFORM_KEY}"
 
-          # Basic sanity check: ensure the exported binary exists at the root (as /zallet in the export image)
+          # Basic sanity check: ensure both backend binaries exist at the root
+          # (as /zallet and /zallet-zaino in the export image; zebra-state is
+          # the default binary name, zaino ships as the additive zallet-zaino).
           if [[ ! -s "${ARTIFACT_ROOT}/zallet" ]]; then
             echo "Missing zallet binary under ${ARTIFACT_ROOT}" >&2
+            find "${ARTIFACT_ROOT}" -maxdepth 5 || true
+            exit 1
+          fi
+          if [[ ! -s "${ARTIFACT_ROOT}/zallet-zaino" ]]; then
+            echo "Missing zallet-zaino binary under ${ARTIFACT_ROOT}" >&2
             find "${ARTIFACT_ROOT}" -maxdepth 5 || true
             exit 1
           fi
@@ -267,8 +274,11 @@ jobs:
           # Prepare per-platform staging directory (including /usr/local for rsync)
           mkdir -p "build/${PLATFORM_KEY}/usr/local"
 
-          # Store the binary in a stable place for later steps, and force executable perms
-          install -m 0755 "${ARTIFACT_ROOT}/zallet" "build/${PLATFORM_KEY}/zallet"
+          # Store both backend binaries in a stable place for later steps
+          # (standalone binary + .deb staging both read them from here), and
+          # force executable perms.
+          install -m 0755 "${ARTIFACT_ROOT}/zallet"       "build/${PLATFORM_KEY}/zallet"
+          install -m 0755 "${ARTIFACT_ROOT}/zallet-zaino" "build/${PLATFORM_KEY}/zallet-zaino"
 
           # Copy the usr/local tree as-is (completions, manpages, docs, etc.)
           # If there is no usr/local in the artifact, this won't fail because of '|| true'


### PR DESCRIPTION
## Summary
- The "Stage exported binaries" step in `binaries-and-deb-release.yml` only ever copied `zallet` out of the runtime artifact root, never `zallet-zaino`, even though PR #538 made both binaries part of the runtime export (`Dockerfile.stagex` export stage for amd64, `build-arm64-nix.yml` for arm64).
- Two later steps in the same job already assumed `build/${PLATFORM_KEY}/zallet-zaino` existed (`cp` for the standalone binary artifact, `install` for `.deb` staging) and both fail with `No such file or directory` since nothing ever staged it.
- Adds the missing `install`, plus a matching sanity check for `zallet-zaino` mirroring the existing one for `zallet`.

## How found
Re-ran the release pipeline against the existing `v0.1.0-alpha.4` tag after #538 merged (`gh workflow run release.yml -f tag=v0.1.0-alpha.4`, run [28603304440](https://github.com/zcash/zallet/actions/runs/28603304440)). The container build + multi-arch manifest jobs succeeded, but both `linux-arm64` and `linux-amd64` legs of "Build standalone binaries and Debian packages" failed/cancelled on:
```
cp: cannot stat 'build/linux-arm64/zallet-zaino': No such file or directory
```

## Test plan
- [ ] `actionlint` passes (already verified locally, no errors)
- [ ] Re-run `release.yml` against `v0.1.0-alpha.4` after merge and confirm the deb/binary matrix jobs succeed for both architectures, producing `zallet-*-zaino` standalone binaries and `.deb`s with both `zallet-zaino` and `zallet-zebra-state` installed