### PR TITLE
fix(ci): stage zallet-zaino + zallet-zebra-state in the arm64 Docker image

### DIFF
--- a/.github/workflows/build-arm64-nix.yml
+++ b/.github/workflows/build-arm64-nix.yml
@@ -180,12 +180,19 @@ jobs:
         run: |
           set -Eeuo pipefail
           REPO="docker.io/${NS}/${IMG}"
-          # Minimal scratch image around the static musl binary, matching the
-          # amd64 StageX runtime stage (USER 1000, ENTRYPOINT zallet).
-          mkdir -p ctx && cp build/runtime/linux-arm64/zallet ctx/zallet
+          # Minimal scratch image around the static musl binaries, matching the
+          # amd64 StageX runtime stage (both backends + the zebra-state alias
+          # symlink, USER 1000, ENTRYPOINT zallet). -a preserves the symlink
+          # itself rather than following it.
+          mkdir -p ctx
+          cp -a build/runtime/linux-arm64/zallet             ctx/zallet
+          cp -a build/runtime/linux-arm64/zallet-zaino        ctx/zallet-zaino
+          cp -a build/runtime/linux-arm64/zallet-zebra-state  ctx/zallet-zebra-state
           cat > ctx/Dockerfile <<'DF'
           FROM scratch
           COPY zallet /usr/local/bin/zallet
+          COPY zallet-zaino /usr/local/bin/zallet-zaino
+          COPY zallet-zebra-state /usr/local/bin/zallet-zebra-state
           USER 1000:1000
           ENTRYPOINT ["zallet"]
           DF


### PR DESCRIPTION
## Summary
- The arm64 Nix job (`build-arm64-nix.yml`) already stages all three names correctly under `build/runtime/linux-arm64/` (`zallet`, `zallet-zaino`, `zallet-zebra-state` symlink) - the `.deb` and standalone binaries for arm64 already ship all three.
- But the scratch Docker image assembled in "Build + push the arm64 image variant" only ever copied `zallet` into the build context, and the synthetic `Dockerfile` inside that step only had one `COPY` line.
- Confirmed via `crane export` against the published `v0.1.0-alpha.4` arm64 image digest (`sha256:cc3367fe...`): only `/usr/local/bin/zallet` is present. The amd64 variant (built from `Dockerfile.stagex`'s export/runtime stages) correctly ships all three.
- Adds the two missing `cp` lines and `COPY` directives so the arm64 image matches the amd64 StageX runtime stage exactly.

## Base branch
Targeting `release/v0.1.0-alpha.4-dual-backend` (not `main`) since that's the branch used to publish the current `v0.1.0-alpha.4` GitHub Release, and this fix needs to land there to re-run the image publish for that release. Will also need cherry-picking to `main` separately since `main`'s `build-arm64-nix.yml` has the same bug.

## Test plan
- [ ] Re-run the `container_arm64` job (or full release) and verify with `crane export`/`docker manifest inspect` that the published arm64 image contains `zallet`, `zallet-zaino`, and `zallet-zebra-state`.