### PR TITLE
Refactoring phase 1:  Make chain backend dynamically loadable

### DIFF
--- a/zallet/src/application.rs
+++ b/zallet/src/application.rs
@@ -1,6 +1,7 @@
 //! Zallet Abscissa Application
 
 use std::path::Path;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
@@ -13,10 +14,29 @@ use abscissa_core::{
 use abscissa_tokio::TokioComponent;
 use i18n_embed::unic_langid::LanguageIdentifier;
 
-use crate::{cli::EntryPoint, components::tracing::Tracing, config::ZalletConfig, fl, i18n};
+use crate::{
+    cli::EntryPoint,
+    components::{chain::ChainRuntime, tracing::Tracing},
+    config::ZalletConfig,
+    fl, i18n,
+};
 
 /// Application state
 pub static APP: AppCell<ZalletApp> = AppCell::new();
+
+/// The chain backend registered for this process.
+static CHAIN_RUNTIME: OnceLock<&'static dyn ChainRuntime> = OnceLock::new();
+
+/// Returns the chain backend registered at boot.
+///
+/// Panics if called before [`boot`]; commands only run inside a booted application,
+/// so this is unreachable in practice.
+pub(crate) fn chain_runtime() -> &'static dyn ChainRuntime {
+    CHAIN_RUNTIME
+        .get()
+        .copied()
+        .expect("chain backend is registered before commands run")
+}
 
 /// When Zallet is shutting down, wait at most this long for Tokio tasks to finish.
 const TOKIO_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(20);
@@ -135,6 +155,25 @@ pub fn boot(requested_languages: Vec<LanguageIdentifier>) {
     // We load languages here so that the app's CLI usage text can be localized.
     i18n::load_languages(&requested_languages);
 
+    // Register the compile-time-selected chain backend. Once the backends move to
+    // their own crates (zcash/zallet#540), each backend binary registers its own
+    // factory here instead.
+    let _ = CHAIN_RUNTIME.set(crate::components::chain::DEFAULT_CHAIN_RUNTIME);
+
     // Now do the normal Abscissa boot.
     abscissa_core::boot(&APP);
+}
+
+#[cfg(test)]
+mod tests {
+    /// Registration hands back the registered backend through `chain_runtime`.
+    ///
+    /// (A full boot isn't runnable in a unit test; registration is the part this
+    /// module owns.)
+    #[test]
+    fn chain_runtime_registration() {
+        let _ = super::CHAIN_RUNTIME.set(crate::components::chain::DEFAULT_CHAIN_RUNTIME);
+        // Must not panic:
+        let _rt = super::chain_runtime();
+    }
 }

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -33,7 +33,7 @@ use zip32::{AccountId, fingerprint::SeedFingerprint};
 use crate::{
     cli::MigrateZcashdWalletCmd,
     components::{
-        chain::{Chain, ChainBackend, ChainError, ChainView},
+        chain::{Chain, ChainError, ChainFactory, ChainView},
         database::Database,
         keystore::KeyStore,
     },
@@ -41,6 +41,11 @@ use crate::{
     fl,
     prelude::*,
 };
+
+#[cfg(feature = "zaino")]
+use crate::components::chain::ZainoBackend;
+#[cfg(feature = "zebra-state")]
+use crate::components::chain::ZebraBackend;
 
 use super::{AsyncRunnable, migrate_zcash_conf};
 
@@ -55,8 +60,10 @@ pub const ZCASHD_LEGACY_SOURCE: &str = "zcashd_legacy";
 /// key derivation after the zcashd v4.7.0 upgrade.
 pub const ZCASHD_MNEMONIC_SOURCE: &str = "zcashd_mnemonic";
 
-impl AsyncRunnable for MigrateZcashdWalletCmd {
-    async fn run(&self) -> Result<(), Error> {
+impl MigrateZcashdWalletCmd {
+    /// Runs the zcashd-wallet migration against the chain backend produced by
+    /// `factory`.
+    pub(crate) async fn run_with<F: ChainFactory>(&self, factory: &F) -> Result<(), Error> {
         let config = APP.config();
 
         if !self.this_is_alpha_code_and_you_will_need_to_redo_the_migration_later {
@@ -67,7 +74,7 @@ impl AsyncRunnable for MigrateZcashdWalletCmd {
         let (chain, _chain_indexer_task_handle) = if self.no_scan {
             (None, None)
         } else {
-            let (c, h) = ChainBackend::new(&config).await?;
+            let (c, h) = factory.build(&config).await?;
             (Some(c), Some(h))
         };
         let db = Database::open(&config).await?;
@@ -89,6 +96,16 @@ impl AsyncRunnable for MigrateZcashdWalletCmd {
         .await?;
 
         Ok(())
+    }
+}
+
+impl AsyncRunnable for MigrateZcashdWalletCmd {
+    async fn run(&self) -> Result<(), Error> {
+        #[cfg(feature = "zebra-state")]
+        let factory = ZebraBackend;
+        #[cfg(feature = "zaino")]
+        let factory = ZainoBackend;
+        self.run_with(&factory).await
     }
 }
 

--- a/zallet/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet/src/commands/migrate_zcashd_wallet.rs
@@ -42,11 +42,6 @@ use crate::{
     prelude::*,
 };
 
-#[cfg(feature = "zaino")]
-use crate::components::chain::ZainoBackend;
-#[cfg(feature = "zebra-state")]
-use crate::components::chain::ZebraBackend;
-
 use super::{AsyncRunnable, migrate_zcash_conf};
 
 /// The ZIP 32 account identifier of the zcashd account used for maintaining legacy `getnewaddress`
@@ -101,11 +96,9 @@ impl MigrateZcashdWalletCmd {
 
 impl AsyncRunnable for MigrateZcashdWalletCmd {
     async fn run(&self) -> Result<(), Error> {
-        #[cfg(feature = "zebra-state")]
-        let factory = ZebraBackend;
-        #[cfg(feature = "zaino")]
-        let factory = ZainoBackend;
-        self.run_with(&factory).await
+        crate::application::chain_runtime()
+            .run_migrate_zcashd_wallet(self)
+            .await
     }
 }
 

--- a/zallet/src/commands/start.rs
+++ b/zallet/src/commands/start.rs
@@ -18,11 +18,6 @@ use crate::{
     prelude::*,
 };
 
-#[cfg(feature = "zaino")]
-use crate::components::chain::ZainoBackend;
-#[cfg(feature = "zebra-state")]
-use crate::components::chain::ZebraBackend;
-
 #[cfg(zallet_build = "wallet")]
 use crate::components::keystore::KeyStore;
 
@@ -169,11 +164,7 @@ impl StartCmd {
 
 impl AsyncRunnable for StartCmd {
     async fn run(&self) -> Result<(), Error> {
-        #[cfg(feature = "zebra-state")]
-        let factory = ZebraBackend;
-        #[cfg(feature = "zaino")]
-        let factory = ZainoBackend;
-        StartCmd::run_with(&factory).await
+        crate::application::chain_runtime().run_start().await
     }
 }
 

--- a/zallet/src/commands/start.rs
+++ b/zallet/src/commands/start.rs
@@ -7,7 +7,7 @@ use crate::{
     cli::StartCmd,
     commands::AsyncRunnable,
     components::{
-        chain::{ChainBackend, check_consensus_compatibility},
+        chain::{ChainFactory, check_consensus_compatibility},
         database::Database,
         json_rpc::JsonRpc,
         sync::WalletSync,
@@ -18,11 +18,17 @@ use crate::{
     prelude::*,
 };
 
+#[cfg(feature = "zaino")]
+use crate::components::chain::ZainoBackend;
+#[cfg(feature = "zebra-state")]
+use crate::components::chain::ZebraBackend;
+
 #[cfg(zallet_build = "wallet")]
 use crate::components::keystore::KeyStore;
 
-impl AsyncRunnable for StartCmd {
-    async fn run(&self) -> Result<(), Error> {
+impl StartCmd {
+    /// Runs `zallet start` against the chain backend produced by `factory`.
+    pub(crate) async fn run_with<F: ChainFactory>(factory: &F) -> Result<(), Error> {
         let config = APP.config();
         let _lock = config.lock_datadir()?;
 
@@ -53,7 +59,7 @@ impl AsyncRunnable for StartCmd {
         let keystore = KeyStore::new(&config, db.clone())?;
 
         // Start monitoring the chain.
-        let (chain, chain_indexer_task_handle) = ChainBackend::new(&config).await?;
+        let (chain, chain_indexer_task_handle) = factory.build(&config).await?;
 
         // Refuse to start if the backing full node already follows consensus rules we
         // cannot interpret. If the only incompatibilities are still in the future, this
@@ -158,6 +164,16 @@ impl AsyncRunnable for StartCmd {
         info!("All tasks have been asked to stop, waiting for remaining tasks to finish");
 
         res
+    }
+}
+
+impl AsyncRunnable for StartCmd {
+    async fn run(&self) -> Result<(), Error> {
+        #[cfg(feature = "zebra-state")]
+        let factory = ZebraBackend;
+        #[cfg(feature = "zaino")]
+        let factory = ZainoBackend;
+        StartCmd::run_with(&factory).await
     }
 }
 

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -33,6 +33,8 @@ use crate::error::{Error, ErrorKind};
 use crate::fl;
 use crate::network::{NETWORK_UPGRADES, Network};
 
+use crate::{components::TaskHandle, config::ZalletConfig};
+
 mod error;
 pub(crate) use error::ChainError;
 
@@ -43,13 +45,16 @@ mod read_state;
 
 #[cfg(feature = "zaino")]
 mod zaino;
+// TODO(#540 phase 1, task 2): the backend factories gain consumers and these allows are removed.
 #[cfg(feature = "zaino")]
-pub(crate) use zaino::ZainoChain;
+#[allow(unused_imports)]
+pub(crate) use zaino::{ZainoBackend, ZainoChain};
 
 #[cfg(feature = "zebra-state")]
 mod zebra;
 #[cfg(feature = "zebra-state")]
-pub(crate) use zebra::ZebraChain;
+#[allow(unused_imports)]
+pub(crate) use zebra::{ZebraBackend, ZebraChain};
 
 /// The concrete chain backend selected at compile time by the `zaino` / `zebra-state`
 /// feature. Construction sites name this; everything else is generic over [`Chain`].
@@ -57,6 +62,25 @@ pub(crate) use zebra::ZebraChain;
 pub(crate) type ChainBackend = ZainoChain;
 #[cfg(feature = "zebra-state")]
 pub(crate) type ChainBackend = ZebraChain;
+
+/// A capability for constructing the process's chain backend.
+///
+/// Implemented by a unit struct in each backend module. The selected factory is
+/// registered at boot and consumed through a dyn-safe runtime boundary;
+/// everything downstream of construction is statically dispatched over [`Chain`].
+// TODO(#540 phase 1, task 3): the factory is registered at boot and this allow removed.
+#[allow(dead_code)]
+pub(crate) trait ChainFactory: Send + Sync + 'static {
+    /// The concrete chain backend this factory constructs.
+    type Chain: Chain;
+
+    /// Connects to the chain-data source described by `config`, returning the
+    /// backend handle and the task driving its indexer.
+    fn build(
+        &self,
+        config: &ZalletConfig,
+    ) -> impl Future<Output = Result<(Self::Chain, TaskHandle), Error>> + Send;
+}
 
 /// A handle to a source of Zcash chain data.
 ///

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::future::Future;
 use std::ops::Range;
 
-use futures::stream::BoxStream;
+use futures::{future::BoxFuture, stream::BoxStream};
 use nonempty::NonEmpty;
 use serde::Deserialize;
 use tracing::{error, info, warn};
@@ -69,6 +69,45 @@ pub(crate) trait ChainFactory: Send + Sync + 'static {
         config: &ZalletConfig,
     ) -> impl Future<Output = Result<(Self::Chain, TaskHandle), Error>> + Send;
 }
+
+/// The dyn-safe boundary through which commands reach the registered chain backend.
+///
+/// The blanket impl over [`ChainFactory`] encloses the whole chain-dependent tail of
+/// each command, so the concrete [`Chain`] type never crosses this boundary — type
+/// erasure costs one virtual call per command invocation.
+pub(crate) trait ChainRuntime: Send + Sync {
+    /// Runs the chain-dependent body of `zallet start`.
+    fn run_start(&self) -> BoxFuture<'_, Result<(), Error>>;
+
+    /// Runs the chain-dependent body of `zallet migrate-zcashd-wallet`.
+    #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+    fn run_migrate_zcashd_wallet<'a>(
+        &'a self,
+        cmd: &'a crate::cli::MigrateZcashdWalletCmd,
+    ) -> BoxFuture<'a, Result<(), Error>>;
+}
+
+impl<F: ChainFactory> ChainRuntime for F {
+    fn run_start(&self) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(crate::cli::StartCmd::run_with(self))
+    }
+
+    #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+    fn run_migrate_zcashd_wallet<'a>(
+        &'a self,
+        cmd: &'a crate::cli::MigrateZcashdWalletCmd,
+    ) -> BoxFuture<'a, Result<(), Error>> {
+        Box::pin(cmd.run_with(self))
+    }
+}
+
+/// The chain backend factory selected at compile time by the `zaino` / `zebra-state`
+/// feature. Registered with the application at boot; everything else reaches the
+/// backend through [`ChainRuntime`].
+#[cfg(feature = "zaino")]
+pub(crate) const DEFAULT_CHAIN_RUNTIME: &(dyn ChainRuntime) = &ZainoBackend;
+#[cfg(feature = "zebra-state")]
+pub(crate) const DEFAULT_CHAIN_RUNTIME: &(dyn ChainRuntime) = &ZebraBackend;
 
 /// A handle to a source of Zcash chain data.
 ///

--- a/zallet/src/components/chain.rs
+++ b/zallet/src/components/chain.rs
@@ -45,31 +45,19 @@ mod read_state;
 
 #[cfg(feature = "zaino")]
 mod zaino;
-// TODO(#540 phase 1, task 2): the backend factories gain consumers and these allows are removed.
 #[cfg(feature = "zaino")]
-#[allow(unused_imports)]
-pub(crate) use zaino::{ZainoBackend, ZainoChain};
+pub(crate) use zaino::ZainoBackend;
 
 #[cfg(feature = "zebra-state")]
 mod zebra;
 #[cfg(feature = "zebra-state")]
-#[allow(unused_imports)]
-pub(crate) use zebra::{ZebraBackend, ZebraChain};
-
-/// The concrete chain backend selected at compile time by the `zaino` / `zebra-state`
-/// feature. Construction sites name this; everything else is generic over [`Chain`].
-#[cfg(feature = "zaino")]
-pub(crate) type ChainBackend = ZainoChain;
-#[cfg(feature = "zebra-state")]
-pub(crate) type ChainBackend = ZebraChain;
+pub(crate) use zebra::ZebraBackend;
 
 /// A capability for constructing the process's chain backend.
 ///
 /// Implemented by a unit struct in each backend module. The selected factory is
 /// registered at boot and consumed through a dyn-safe runtime boundary;
 /// everything downstream of construction is statically dispatched over [`Chain`].
-// TODO(#540 phase 1, task 3): the factory is registered at boot and this allow removed.
-#[allow(dead_code)]
 pub(crate) trait ChainFactory: Send + Sync + 'static {
     /// The concrete chain backend this factory constructs.
     type Chain: Chain;

--- a/zallet/src/components/chain/zaino.rs
+++ b/zallet/src/components/chain/zaino.rs
@@ -48,7 +48,8 @@ use crate::{
 
 use super::read_state::{AbortOnDrop, init_read_state_service};
 use super::{
-    BlockLocator, Chain, ChainBlock, ChainError, ChainTx, ChainView, ReportedUpgrade, UpgradeStatus,
+    BlockLocator, Chain, ChainBlock, ChainError, ChainFactory, ChainTx, ChainView, ReportedUpgrade,
+    UpgradeStatus,
 };
 
 /// Classifies a block-fetch error, distinguishing transient reorg-window failures from
@@ -265,6 +266,20 @@ impl From<NetworkUpgradeStatus> for UpgradeStatus {
             NetworkUpgradeStatus::Pending => UpgradeStatus::Pending,
             NetworkUpgradeStatus::Disabled => UpgradeStatus::Disabled,
         }
+    }
+}
+
+/// Factory for the `zaino` chain backend.
+// TODO(#540 phase 1, task 2): constructed by the command layer; allow removed then.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ZainoBackend;
+
+impl ChainFactory for ZainoBackend {
+    type Chain = ZainoChain;
+
+    async fn build(&self, config: &ZalletConfig) -> Result<(ZainoChain, TaskHandle), Error> {
+        ZainoChain::new(config).await
     }
 }
 

--- a/zallet/src/components/chain/zaino.rs
+++ b/zallet/src/components/chain/zaino.rs
@@ -270,8 +270,6 @@ impl From<NetworkUpgradeStatus> for UpgradeStatus {
 }
 
 /// Factory for the `zaino` chain backend.
-// TODO(#540 phase 1, task 2): constructed by the command layer; allow removed then.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ZainoBackend;
 

--- a/zallet/src/components/chain/zebra.rs
+++ b/zallet/src/components/chain/zebra.rs
@@ -31,7 +31,9 @@ use zebra_state::ReadStateService;
 #[cfg(feature = "spend-index")]
 use super::SpendStatus;
 use super::read_state::{AbortOnDrop, init_read_state_service};
-use super::{BlockLocator, Chain, ChainBlock, ChainError, ChainTx, ChainView, ReportedUpgrade};
+use super::{
+    BlockLocator, Chain, ChainBlock, ChainError, ChainFactory, ChainTx, ChainView, ReportedUpgrade,
+};
 use crate::{
     components::TaskHandle,
     config::ZalletConfig,
@@ -114,6 +116,20 @@ impl ZebraChain {
         });
 
         Ok((chain, task))
+    }
+}
+
+/// Factory for the `zebra-state` chain backend.
+// TODO(#540 phase 1, task 2): constructed by the command layer; allow removed then.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ZebraBackend;
+
+impl ChainFactory for ZebraBackend {
+    type Chain = ZebraChain;
+
+    async fn build(&self, config: &ZalletConfig) -> Result<(ZebraChain, TaskHandle), Error> {
+        ZebraChain::new(config).await
     }
 }
 

--- a/zallet/src/components/chain/zebra.rs
+++ b/zallet/src/components/chain/zebra.rs
@@ -120,8 +120,6 @@ impl ZebraChain {
 }
 
 /// Factory for the `zebra-state` chain backend.
-// TODO(#540 phase 1, task 2): constructed by the command layer; allow removed then.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ZebraBackend;
 


### PR DESCRIPTION
This is the first stage of the refactoring to allow the zebrad and zaino backends to drift relative to one another with respect to the version of `zebra_state` that they depend on.