### PR TITLE
Migrate zcashd wallets via ZeWIF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -243,18 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures",
- "password-hash",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +262,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -306,7 +294,7 @@ checksum = "a273e731a7fb8c2268fd2932c9e9a3469f4fd171d85d070d2687190229653bd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -401,156 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bc-components"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d5d6fc6db90642e4b2b015e2596f2d6a03e518e4fa7d331c4cd9b755b63601"
-dependencies = [
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "bc-tags",
- "bc-ur",
- "dcbor",
- "hex",
- "miniz_oxide",
- "pqcrypto-mldsa",
- "pqcrypto-mlkem",
- "pqcrypto-traits",
- "rand_core 0.9.5",
- "ssh-key",
- "sskr",
- "thiserror 2.0.18",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "bc-crypto"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9644245d48f4ab1bfa8c7eebfbd20d2bea7895e220de766f66876c5a71b14712"
-dependencies = [
- "argon2",
- "bc-rand 0.4.2",
- "chacha20poly1305",
- "crc32fast",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.8.6",
- "scrypt",
- "secp256k1 0.30.0",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
-]
-
-[[package]]
-name = "bc-crypto"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e74e8d1d886ad04ed17badc8856d7303168cabe9201bba100a621171aa41bd7"
-dependencies = [
- "argon2",
- "bc-rand 0.5.0",
- "chacha20poly1305",
- "crc32fast",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.9.4",
- "scrypt",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
-]
-
-[[package]]
-name = "bc-envelope"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354dbf4de7d815ca449fda9ec7a8273715e4d0330af28b2bcb9b7b78f0ea6e11"
-dependencies = [
- "bc-components",
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "bc-ur",
- "bytes",
- "dcbor",
- "hex",
- "itertools",
- "known-values",
- "paste",
- "ssh-key",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bc-rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdade83e92b8dfb9acbccd68e09f9e9555dbaf64c7bc2e5fbb894fcc9b53b413"
-dependencies = [
- "getrandom 0.2.17",
- "lazy_static",
- "num-traits",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_xoshiro 0.6.0",
-]
-
-[[package]]
-name = "bc-rand"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc4ad6720290bd702e6a559a02d643f5f07b0c20bfedfd23798e5da5fc4ff06"
-dependencies = [
- "getrandom 0.3.4",
- "lazy_static",
- "num-traits",
- "rand 0.9.4",
- "rand_core 0.9.5",
- "rand_xoshiro 0.7.0",
-]
-
-[[package]]
-name = "bc-shamir"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d283bf658d34e351bf65dd105a01d2a4e480750b58a218e768cd641a2d0eceb4"
-dependencies = [
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bc-tags"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a274cd8f4a11b1b6f6b31518cc8861d2f882ea8e19ad2e79507f91842803264"
-dependencies = [
- "dcbor",
- "paste",
-]
-
-[[package]]
-name = "bc-ur"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d8f86a33812525e0e66754cfdb8f340125d71488392c6345f2a052a0112504"
-dependencies = [
- "dcbor",
- "thiserror 2.0.18",
- "ur",
-]
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +399,12 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bellman"
@@ -607,7 +451,7 @@ dependencies = [
  "hmac 0.13.0-pre.4",
  "rand_core 0.6.4",
  "ripemd 0.2.0-pre.4",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
@@ -629,58 +473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcoin-consensus-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
-dependencies = [
- "bitcoin-internals",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
-dependencies = [
- "bitcoin-consensus-encoding",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
-dependencies = [
- "bitcoin-io",
- "hex-conservative 0.2.2",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,15 +488,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -965,7 +748,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1071,12 +854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,21 +929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,25 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1268,7 +1017,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1283,7 +1031,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1293,20 +1041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
 dependencies = [
  "petgraph 0.7.1",
-]
-
-[[package]]
-name = "dcbor"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf662b6347d10dd5ab7370287b76923eb88818d46434de8c424b091523f5e54"
-dependencies = [
- "chrono",
- "half",
- "hex",
- "paste",
- "thiserror 2.0.18",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1351,16 +1085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1101,7 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1387,7 +1111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1404,27 +1127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,7 +1134,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1451,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6b3e31251e87acd1b74911aed84071c8364fc9087972748ade2f1094ccce34"
 dependencies = [
  "documented-macros",
- "phf 0.12.1",
+ "phf",
  "thiserror 2.0.18",
 ]
 
@@ -1467,23 +1169,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "dsa"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
-dependencies = [
- "digest 0.10.7",
- "num-bigint-dig",
- "num-traits",
- "pkcs8",
- "rfc6979",
- "sha2 0.10.9",
- "signature",
- "zeroize",
+ "syn",
 ]
 
 [[package]]
@@ -1499,68 +1185,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "embed-licensing-core"
@@ -1920,7 +1548,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1975,7 +1603,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2022,7 +1649,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2079,17 +1706,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -2230,24 +1846,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "hex-conservative"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "hkdf"
@@ -2460,7 +2058,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn",
  "unic-langid",
 ]
 
@@ -2474,7 +2072,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2809,7 +2407,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2875,20 +2473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "known-values"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987eb566c2bd304ace0df103a86fd4a79035bc39acad2353571bdaab325f154d"
-dependencies = [
- "bc-components",
- "dcbor",
- "dirs",
- "paste",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,15 +2519,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3052,22 +2627,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "0.19.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -3166,22 +2741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,17 +2752,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -3271,14 +2819,8 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
@@ -3368,44 +2910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p521"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
-dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "rand_core 0.6.4",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,12 +2968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,15 +2976,6 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3518,33 +3007,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_macros 0.12.1",
- "phf_shared 0.12.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -3554,20 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
  "fastrand",
- "phf_shared 0.12.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3576,20 +3032,11 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
 dependencies = [
- "phf_generator 0.12.1",
- "phf_shared 0.12.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "syn",
 ]
 
 [[package]]
@@ -3618,7 +3065,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3640,27 +3087,6 @@ dependencies = [
  "wait-timeout",
  "which 4.4.2",
  "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -3718,67 +3144,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pqcrypto-internals"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a326caf27cbf2ac291ca7fd56300497ba9e76a8cc6a7d95b7a18b57f22b61d"
-dependencies = [
- "cc",
- "dunce",
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
-name = "pqcrypto-mldsa"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f812cd126a2582599478a434fea75937b4b05d234c64a49e0cea129e130528"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "paste",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-mlkem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb14d207f3749e8a59a026c22ceaa72d70fff931cfbf4c8d9b08f3fc56dc6e60"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-traits"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
+ "syn",
 ]
 
 [[package]]
@@ -3809,7 +3181,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3865,7 +3237,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.118",
+ "syn",
  "tempfile",
 ]
 
@@ -3879,7 +3251,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4003,24 +3375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,17 +3435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,7 +3451,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4139,16 +3482,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
 
 [[package]]
 name = "ring"
@@ -4206,27 +3539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rtoolbox"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4272,7 +3584,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn",
  "walkdir",
 ]
 
@@ -4472,7 +3784,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4517,48 +3829,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
-dependencies = [
- "bitcoin_hashes 0.14.101",
- "rand 0.8.6",
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes 0.14.101",
- "rand 0.9.4",
- "secp256k1-sys 0.11.0",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -4566,15 +3842,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -4642,7 +3909,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4653,7 +3920,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4786,16 +4053,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,72 +4169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "ssh-cipher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
-dependencies = [
- "cipher",
- "ssh-encoding",
-]
-
-[[package]]
-name = "ssh-encoding"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
-dependencies = [
- "base64ct",
- "pem-rfc7468",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "ssh-key"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
-dependencies = [
- "dsa",
- "ed25519-dalek",
- "num-bigint-dig",
- "p256",
- "p384",
- "p521",
- "rand_core 0.6.4",
- "rsa",
- "sec1",
- "sha1",
- "sha2 0.10.9",
- "signature",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sskr"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef3a90a4a282e53765d6ba384c6f7e1ed7c9efef8373d7a71310a0649e6c795"
-dependencies = [
- "bc-rand 0.5.0",
- "bc-shamir",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,7 +4204,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5021,17 +4212,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -5058,7 +4238,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5124,7 +4304,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5135,7 +4315,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5231,7 +4411,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5434,7 +4614,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5459,7 +4639,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.118",
+ "syn",
  "tempfile",
  "tonic-build",
 ]
@@ -5531,7 +4711,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5719,19 +4899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ur"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010f24a953db5d22d0010969ca3bbf40b3857b89f47c0f7be0da4c2d7ded0760"
-dependencies = [
- "bitcoin_hashes 0.12.0",
- "crc",
- "minicbor",
- "phf 0.11.3",
- "rand_xoshiro 0.6.0",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5792,7 +4959,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5921,7 +5088,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5994,7 +5161,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6005,7 +5172,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6030,15 +5197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6079,21 +5237,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6127,12 +5270,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6145,12 +5282,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6160,12 +5291,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6193,12 +5318,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6208,12 +5327,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6229,12 +5342,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6244,12 +5351,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6351,7 +5452,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -6400,7 +5501,7 @@ dependencies = [
  "nonempty",
  "once_cell",
  "orchard 0.15.0-pre.2",
- "phf 0.12.1",
+ "phf",
  "proptest",
  "quote",
  "rand 0.8.6",
@@ -6413,7 +5514,7 @@ dependencies = [
  "schemars",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "semver",
  "serde",
@@ -6421,7 +5522,7 @@ dependencies = [
  "sha2 0.10.9",
  "shadow-rs",
  "shardtree",
- "syn 2.0.118",
+ "syn",
  "tempfile",
  "time",
  "tokio",
@@ -6505,7 +5606,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "shardtree",
  "subtle",
@@ -6555,7 +5656,7 @@ dependencies = [
  "sapling-crypto",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "shardtree",
  "static_assertions",
@@ -6591,6 +5692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32 0.11.1",
+ "bip0039",
  "bip32",
  "blake2b_simd",
  "bls12_381",
@@ -6602,6 +5704,7 @@ dependencies = [
  "nonempty",
  "orchard 0.14.0",
  "rand_core 0.6.4",
+ "regex",
  "sapling-crypto",
  "secrecy 0.8.0",
  "subtle",
@@ -6634,7 +5737,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "subtle",
  "tracing",
@@ -6710,7 +5813,7 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
@@ -6777,7 +5880,7 @@ dependencies = [
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha1",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -6806,7 +5909,7 @@ dependencies = [
  "hex",
  "nonempty",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
@@ -6830,7 +5933,7 @@ dependencies = [
  "hex",
  "nonempty",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.13.0-pre.0",
@@ -6858,7 +5961,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6878,7 +5981,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -6899,7 +6002,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6933,31 +6036,28 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
 name = "zewif"
 version = "0.1.0"
-source = "git+https://github.com/zcash/zewif.git?rev=0a5a234490a339ca8dda13614146e4769a3cd963#0a5a234490a339ca8dda13614146e4769a3cd963"
+source = "git+https://github.com/zcash/zewif.git?rev=74f1a1694131386515e1733dfb9f414a6284555f#74f1a1694131386515e1733dfb9f414a6284555f"
 dependencies = [
- "bc-components",
- "bc-crypto 0.13.0",
- "bc-envelope",
- "chrono",
- "dcbor",
  "hex",
+ "minicbor",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zewif-zcashd"
 version = "0.1.0"
-source = "git+https://github.com/zcash/zewif-zcashd.git?rev=c640713b91b79d153a7fee2888088931cd7e8326#c640713b91b79d153a7fee2888088931cd7e8326"
+source = "git+https://github.com/zcash/zewif-zcashd.git?rev=fce12991e11bb543f8a9b60a5af92cfb953f699c#fce12991e11bb543f8a9b60a5af92cfb953f699c"
 dependencies = [
- "anyhow",
+ "bech32 0.12.0",
  "bitflags",
  "bridgetree",
+ "bs58",
  "byteorder",
  "chrono",
  "hex",
@@ -6965,8 +6065,10 @@ dependencies = [
  "orchard 0.14.0",
  "ripemd 0.1.3",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
+ "secrecy 0.8.0",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
  "zcash_encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.10"
 
 # Key storage
 age = { version = "0.11", features = ["armor", "cli-common", "plugin"] }
+bech32 = "0.11"
 bip0039 = "0.12"
 
 # Localization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,8 +198,8 @@ orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff9
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 
-zewif = { git = "https://github.com/zcash/zewif.git", rev = "0a5a234490a339ca8dda13614146e4769a3cd963" }
-zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "c640713b91b79d153a7fee2888088931cd7e8326" }
+zewif = { git = "https://github.com/zcash/zewif.git", rev = "74f1a1694131386515e1733dfb9f414a6284555f" }
+zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "fce12991e11bb543f8a9b60a5af92cfb953f699c" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -225,18 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures",
- "password-hash",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,156 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bc-components"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d5d6fc6db90642e4b2b015e2596f2d6a03e518e4fa7d331c4cd9b755b63601"
-dependencies = [
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "bc-tags",
- "bc-ur",
- "dcbor",
- "hex",
- "miniz_oxide",
- "pqcrypto-mldsa",
- "pqcrypto-mlkem",
- "pqcrypto-traits",
- "rand_core 0.9.5",
- "ssh-key",
- "sskr",
- "thiserror 2.0.18",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "bc-crypto"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9644245d48f4ab1bfa8c7eebfbd20d2bea7895e220de766f66876c5a71b14712"
-dependencies = [
- "argon2",
- "bc-rand 0.4.2",
- "chacha20poly1305",
- "crc32fast",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.8.6",
- "scrypt",
- "secp256k1 0.30.0",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
-]
-
-[[package]]
-name = "bc-crypto"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e74e8d1d886ad04ed17badc8856d7303168cabe9201bba100a621171aa41bd7"
-dependencies = [
- "argon2",
- "bc-rand 0.5.0",
- "chacha20poly1305",
- "crc32fast",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.9.4",
- "scrypt",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
-]
-
-[[package]]
-name = "bc-envelope"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354dbf4de7d815ca449fda9ec7a8273715e4d0330af28b2bcb9b7b78f0ea6e11"
-dependencies = [
- "bc-components",
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "bc-ur",
- "bytes",
- "dcbor",
- "hex",
- "itertools 0.14.0",
- "known-values",
- "paste",
- "ssh-key",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bc-rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdade83e92b8dfb9acbccd68e09f9e9555dbaf64c7bc2e5fbb894fcc9b53b413"
-dependencies = [
- "getrandom 0.2.17",
- "lazy_static",
- "num-traits",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_xoshiro 0.6.0",
-]
-
-[[package]]
-name = "bc-rand"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc4ad6720290bd702e6a559a02d643f5f07b0c20bfedfd23798e5da5fc4ff06"
-dependencies = [
- "getrandom 0.3.4",
- "lazy_static",
- "num-traits",
- "rand 0.9.4",
- "rand_core 0.9.5",
- "rand_xoshiro 0.7.0",
-]
-
-[[package]]
-name = "bc-shamir"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d283bf658d34e351bf65dd105a01d2a4e480750b58a218e768cd641a2d0eceb4"
-dependencies = [
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bc-tags"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a274cd8f4a11b1b6f6b31518cc8861d2f882ea8e19ad2e79507f91842803264"
-dependencies = [
- "dcbor",
- "paste",
-]
-
-[[package]]
-name = "bc-ur"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d8f86a33812525e0e66754cfdb8f340125d71488392c6345f2a052a0112504"
-dependencies = [
- "dcbor",
- "thiserror 2.0.18",
- "ur",
-]
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +393,12 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bellman"
@@ -648,62 +492,10 @@ dependencies = [
  "hmac 0.13.0-pre.4",
  "rand_core 0.6.4",
  "ripemd 0.2.0-pre.4",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "bitcoin-consensus-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
-dependencies = [
- "bitcoin-internals",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
-dependencies = [
- "bitcoin-consensus-encoding",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
-dependencies = [
- "bitcoin-io",
- "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -1255,21 +1047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,25 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1440,20 +1204,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "dcbor"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf662b6347d10dd5ab7370287b76923eb88818d46434de8c424b091523f5e54"
-dependencies = [
- "chrono",
- "half",
- "hex",
- "paste",
- "thiserror 2.0.18",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1568,7 +1318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1586,32 +1335,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.6",
- "windows-sys 0.48.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1622,7 +1350,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.59.0",
 ]
 
@@ -1653,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6b3e31251e87acd1b74911aed84071c8364fc9087972748ade2f1094ccce34"
 dependencies = [
  "documented-macros",
- "phf 0.12.1",
+ "phf",
  "thiserror 2.0.18",
 ]
 
@@ -1673,22 +1401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dsa"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
-dependencies = [
- "digest 0.10.7",
- "num-bigint-dig",
- "num-traits",
- "pkcs8",
- "rfc6979",
- "sha2 0.10.9",
- "signature",
- "zeroize",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,20 +1413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,21 +1421,6 @@ dependencies = [
  "pkcs8",
  "serde",
  "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1762,25 +1445,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "embedded-io"
@@ -2198,7 +1862,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2315,17 +1978,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -2485,24 +2137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "hex-conservative"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "hex-conservative"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -3262,20 +2896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "known-values"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987eb566c2bd304ace0df103a86fd4a79035bc39acad2353571bdaab325f154d"
-dependencies = [
- "bc-components",
- "dcbor",
- "dirs 5.0.1",
- "paste",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,22 +3151,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "0.19.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3663,22 +3283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,17 +3294,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -3904,44 +3497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p521"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
-dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "rand_core 0.6.4",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4028,12 +3583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4082,33 +3631,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_macros 0.12.1",
- "phf_shared 0.12.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -4118,20 +3647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
  "fastrand",
- "phf_shared 0.12.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4140,20 +3656,11 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
 dependencies = [
- "phf_generator 0.12.1",
- "phf_shared 0.12.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4204,17 +3711,6 @@ dependencies = [
  "wait-timeout",
  "which 4.4.2",
  "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -4288,51 +3784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pqcrypto-internals"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a326caf27cbf2ac291ca7fd56300497ba9e76a8cc6a7d95b7a18b57f22b61d"
-dependencies = [
- "cc",
- "dunce",
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
-name = "pqcrypto-mldsa"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f812cd126a2582599478a434fea75937b4b05d234c64a49e0cea129e130528"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "paste",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-mlkem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb14d207f3749e8a59a026c22ceaa72d70fff931cfbf4c8d9b08f3fc56dc6e60"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-traits"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,15 +3791,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -4718,24 +4160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,17 +4227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4952,16 +4365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,27 +4436,6 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5417,49 +4799,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
-dependencies = [
- "bitcoin_hashes 0.14.101",
- "rand 0.8.6",
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes 0.14.101",
- "rand 0.9.4",
- "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -5467,15 +4813,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -5768,7 +5105,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5856,62 +5192,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "ssh-cipher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
-dependencies = [
- "cipher",
- "ssh-encoding",
-]
-
-[[package]]
-name = "ssh-encoding"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
-dependencies = [
- "base64ct",
- "pem-rfc7468",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "ssh-key"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
-dependencies = [
- "dsa",
- "ed25519-dalek",
- "num-bigint-dig",
- "p256",
- "p384",
- "p521",
- "rand_core 0.6.4",
- "rsa",
- "sec1",
- "sha1",
- "sha2 0.10.9",
- "signature",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sskr"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef3a90a4a282e53765d6ba384c6f7e1ed7c9efef8373d7a71310a0649e6c795"
-dependencies = [
- "bc-rand 0.5.0",
- "bc-shamir",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6748,19 +6028,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ur"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010f24a953db5d22d0010969ca3bbf40b3857b89f47c0f7be0da4c2d7ded0760"
-dependencies = [
- "bitcoin_hashes 0.12.0",
- "crc",
- "minicbor",
- "phf 0.11.3",
- "rand_xoshiro 0.6.0",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7594,7 +6861,7 @@ dependencies = [
  "nix 0.29.0",
  "nonempty 0.11.0",
  "orchard 0.15.0-pre.2",
- "phf 0.12.1",
+ "phf",
  "quote",
  "rand 0.8.6",
  "rpassword",
@@ -7605,7 +6872,7 @@ dependencies = [
  "schemars 1.2.1",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "semver",
  "serde",
@@ -7736,7 +7003,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "shardtree",
  "subtle",
@@ -7786,7 +7053,7 @@ dependencies = [
  "sapling-crypto",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "shardtree",
  "static_assertions",
@@ -7832,6 +7099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32 0.11.1",
+ "bip0039",
  "bip32",
  "blake2b_simd",
  "bls12_381",
@@ -7843,6 +7111,7 @@ dependencies = [
  "nonempty 0.11.0",
  "orchard 0.14.0",
  "rand_core 0.6.4",
+ "regex",
  "sapling-crypto",
  "secrecy 0.8.0",
  "subtle",
@@ -7875,7 +7144,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "subtle",
  "tracing",
@@ -7951,7 +7220,7 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
@@ -8018,7 +7287,7 @@ dependencies = [
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha1",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -8047,7 +7316,7 @@ dependencies = [
  "hex",
  "nonempty 0.11.0",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
@@ -8071,7 +7340,7 @@ dependencies = [
  "hex",
  "nonempty 0.11.0",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.13.0-pre.0",
@@ -8099,7 +7368,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "derive-getters",
- "dirs 6.0.0",
+ "dirs",
  "ed25519-zebra",
  "equihash",
  "futures",
@@ -8121,7 +7390,7 @@ dependencies = [
  "ripemd 0.1.3",
  "sapling-crypto",
  "schemars 1.2.1",
- "secp256k1 0.29.1",
+ "secp256k1",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -8199,7 +7468,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "dirs 6.0.0",
+ "dirs",
  "futures",
  "hex",
  "humantime-serde",
@@ -8267,7 +7536,7 @@ dependencies = [
  "nix 0.30.1",
  "openrpsee",
  "orchard 0.15.0-pre.2",
- "phf 0.12.1",
+ "phf",
  "prost",
  "rand 0.8.6",
  "sapling-crypto",
@@ -8329,7 +7598,7 @@ dependencies = [
  "crossbeam-channel",
  "derive-getters",
  "derive-new",
- "dirs 6.0.0",
+ "dirs",
  "futures",
  "hex",
  "hex-literal",
@@ -8455,25 +7724,22 @@ dependencies = [
 [[package]]
 name = "zewif"
 version = "0.1.0"
-source = "git+https://github.com/zcash/zewif.git?rev=0a5a234490a339ca8dda13614146e4769a3cd963#0a5a234490a339ca8dda13614146e4769a3cd963"
+source = "git+https://github.com/zcash/zewif.git?rev=74f1a1694131386515e1733dfb9f414a6284555f#74f1a1694131386515e1733dfb9f414a6284555f"
 dependencies = [
- "bc-components",
- "bc-crypto 0.13.0",
- "bc-envelope",
- "chrono",
- "dcbor",
  "hex",
+ "minicbor",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zewif-zcashd"
 version = "0.1.0"
-source = "git+https://github.com/zcash/zewif-zcashd.git?rev=c640713b91b79d153a7fee2888088931cd7e8326#c640713b91b79d153a7fee2888088931cd7e8326"
+source = "git+https://github.com/zcash/zewif-zcashd.git?rev=fce12991e11bb543f8a9b60a5af92cfb953f699c#fce12991e11bb543f8a9b60a5af92cfb953f699c"
 dependencies = [
- "anyhow",
+ "bech32 0.12.0",
  "bitflags 2.13.0",
  "bridgetree",
+ "bs58",
  "byteorder",
  "chrono",
  "hex",
@@ -8481,8 +7747,10 @@ dependencies = [
  "orchard 0.14.0",
  "ripemd 0.1.3",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
+ "secrecy 0.8.0",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
  "zcash_encoding",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -6835,6 +6835,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64ct",
+ "bech32 0.11.1",
  "bip0039",
  "clap",
  "clap_complete",
@@ -7032,6 +7033,8 @@ name = "zcash_client_sqlite"
 version = "0.21.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
+ "bech32 0.11.1",
+ "bip0039",
  "bip32",
  "bitflags 2.13.0",
  "bs58",
@@ -7069,6 +7072,7 @@ dependencies = [
  "zcash_protocol 0.10.0-pre.0",
  "zcash_script",
  "zcash_transparent 0.9.0-pre.0",
+ "zewif",
  "zip32",
 ]
 

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -110,8 +110,8 @@ orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff9
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 
-zewif = { git = "https://github.com/zcash/zewif.git", rev = "0a5a234490a339ca8dda13614146e4769a3cd963" }
-zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "c640713b91b79d153a7fee2888088931cd7e8326" }
+zewif = { git = "https://github.com/zcash/zewif.git", rev = "74f1a1694131386515e1733dfb9f414a6284555f" }
+zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "fce12991e11bb543f8a9b60a5af92cfb953f699c" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
 # which surfaces the Ironwood (NU6.3) note commitment treestate from

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -6411,6 +6411,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64ct",
+ "bech32 0.11.1",
  "bip0039",
  "clap",
  "clap_complete",
@@ -6612,6 +6613,8 @@ name = "zcash_client_sqlite"
 version = "0.21.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
+ "bech32 0.11.1",
+ "bip0039",
  "bip32",
  "bitflags",
  "bs58",
@@ -6649,6 +6652,7 @@ dependencies = [
  "zcash_protocol 0.10.0-pre.0",
  "zcash_script",
  "zcash_transparent 0.9.0-pre.0",
+ "zewif",
  "zip32",
 ]
 

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -249,18 +249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures",
- "password-hash",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,156 +395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bc-components"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d5d6fc6db90642e4b2b015e2596f2d6a03e518e4fa7d331c4cd9b755b63601"
-dependencies = [
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "bc-tags",
- "bc-ur",
- "dcbor",
- "hex",
- "miniz_oxide",
- "pqcrypto-mldsa",
- "pqcrypto-mlkem",
- "pqcrypto-traits",
- "rand_core 0.9.5",
- "ssh-key",
- "sskr",
- "thiserror 2.0.18",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "bc-crypto"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9644245d48f4ab1bfa8c7eebfbd20d2bea7895e220de766f66876c5a71b14712"
-dependencies = [
- "argon2",
- "bc-rand 0.4.2",
- "chacha20poly1305",
- "crc32fast",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.8.6",
- "scrypt",
- "secp256k1 0.30.0",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
-]
-
-[[package]]
-name = "bc-crypto"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e74e8d1d886ad04ed17badc8856d7303168cabe9201bba100a621171aa41bd7"
-dependencies = [
- "argon2",
- "bc-rand 0.5.0",
- "chacha20poly1305",
- "crc32fast",
- "ed25519-dalek",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.9.4",
- "scrypt",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "x25519-dalek",
-]
-
-[[package]]
-name = "bc-envelope"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354dbf4de7d815ca449fda9ec7a8273715e4d0330af28b2bcb9b7b78f0ea6e11"
-dependencies = [
- "bc-components",
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "bc-ur",
- "bytes",
- "dcbor",
- "hex",
- "itertools 0.14.0",
- "known-values",
- "paste",
- "ssh-key",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bc-rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdade83e92b8dfb9acbccd68e09f9e9555dbaf64c7bc2e5fbb894fcc9b53b413"
-dependencies = [
- "getrandom 0.2.17",
- "lazy_static",
- "num-traits",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_xoshiro 0.6.0",
-]
-
-[[package]]
-name = "bc-rand"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc4ad6720290bd702e6a559a02d643f5f07b0c20bfedfd23798e5da5fc4ff06"
-dependencies = [
- "getrandom 0.3.4",
- "lazy_static",
- "num-traits",
- "rand 0.9.4",
- "rand_core 0.9.5",
- "rand_xoshiro 0.7.0",
-]
-
-[[package]]
-name = "bc-shamir"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d283bf658d34e351bf65dd105a01d2a4e480750b58a218e768cd641a2d0eceb4"
-dependencies = [
- "bc-crypto 0.14.0",
- "bc-rand 0.5.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bc-tags"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a274cd8f4a11b1b6f6b31518cc8861d2f882ea8e19ad2e79507f91842803264"
-dependencies = [
- "dcbor",
- "paste",
-]
-
-[[package]]
-name = "bc-ur"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d8f86a33812525e0e66754cfdb8f340125d71488392c6345f2a052a0112504"
-dependencies = [
- "dcbor",
- "thiserror 2.0.18",
- "ur",
-]
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +405,12 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bellman"
@@ -660,62 +504,10 @@ dependencies = [
  "hmac 0.13.0-pre.4",
  "rand_core 0.6.4",
  "ripemd 0.2.0-pre.4",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "bitcoin-consensus-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
-dependencies = [
- "bitcoin-internals",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
-dependencies = [
- "bitcoin-consensus-encoding",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
-dependencies = [
- "bitcoin-io",
- "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -744,15 +536,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1206,21 +989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,25 +1044,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1377,20 +1132,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "dcbor"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf662b6347d10dd5ab7370287b76923eb88818d46434de8c424b091523f5e54"
-dependencies = [
- "chrono",
- "half",
- "hex",
- "paste",
- "thiserror 2.0.18",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1484,7 +1225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1502,32 +1242,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.6",
- "windows-sys 0.48.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1538,7 +1257,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.59.0",
 ]
 
@@ -1569,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6b3e31251e87acd1b74911aed84071c8364fc9087972748ade2f1094ccce34"
 dependencies = [
  "documented-macros",
- "phf 0.12.1",
+ "phf",
  "thiserror 2.0.18",
 ]
 
@@ -1589,22 +1308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dsa"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
-dependencies = [
- "digest 0.10.7",
- "num-bigint-dig",
- "num-traits",
- "pkcs8",
- "rfc6979",
- "sha2 0.10.9",
- "signature",
- "zeroize",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,20 +1320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,21 +1328,6 @@ dependencies = [
  "pkcs8",
  "serde",
  "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1678,25 +1352,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "embedded-io"
@@ -2118,7 +1773,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2235,17 +1889,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -2399,24 +2042,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "hex-conservative"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "hex-conservative"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -3123,20 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "known-values"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987eb566c2bd304ace0df103a86fd4a79035bc39acad2353571bdaab325f154d"
-dependencies = [
- "bc-components",
- "dcbor",
- "dirs 5.0.1",
- "paste",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,22 +2981,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "0.19.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3502,22 +3113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,17 +3124,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -3729,44 +3313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p521"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
-dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "rand_core 0.6.4",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,12 +3399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,33 +3447,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_macros 0.12.1",
- "phf_shared 0.12.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -3943,20 +3463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
  "fastrand",
- "phf_shared 0.12.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3965,20 +3472,11 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
 dependencies = [
- "phf_generator 0.12.1",
- "phf_shared 0.12.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4029,17 +3527,6 @@ dependencies = [
  "wait-timeout",
  "which 4.4.2",
  "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -4113,51 +3600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pqcrypto-internals"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a326caf27cbf2ac291ca7fd56300497ba9e76a8cc6a7d95b7a18b57f22b61d"
-dependencies = [
- "cc",
- "dunce",
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
-name = "pqcrypto-mldsa"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f812cd126a2582599478a434fea75937b4b05d234c64a49e0cea129e130528"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "paste",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-mlkem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb14d207f3749e8a59a026c22ceaa72d70fff931cfbf4c8d9b08f3fc56dc6e60"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-traits"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,15 +3607,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -4516,24 +3949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4601,17 +4016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4713,16 +4117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4794,27 +4188,6 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5128,49 +4501,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
-dependencies = [
- "bitcoin_hashes 0.14.101",
- "rand 0.8.6",
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes 0.14.101",
- "rand 0.9.4",
- "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -5178,15 +4515,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -5455,7 +4783,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5574,62 +4901,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "ssh-cipher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
-dependencies = [
- "cipher",
- "ssh-encoding",
-]
-
-[[package]]
-name = "ssh-encoding"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
-dependencies = [
- "base64ct",
- "pem-rfc7468",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "ssh-key"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
-dependencies = [
- "dsa",
- "ed25519-dalek",
- "num-bigint-dig",
- "p256",
- "p384",
- "p521",
- "rand_core 0.6.4",
- "rsa",
- "sec1",
- "sha1",
- "sha2 0.10.9",
- "signature",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sskr"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef3a90a4a282e53765d6ba384c6f7e1ed7c9efef8373d7a71310a0649e6c795"
-dependencies = [
- "bc-rand 0.5.0",
- "bc-shamir",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6471,19 +5742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ur"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010f24a953db5d22d0010969ca3bbf40b3857b89f47c0f7be0da4c2d7ded0760"
-dependencies = [
- "bitcoin_hashes 0.12.0",
- "crc",
- "minicbor",
- "phf 0.11.3",
- "rand_xoshiro 0.6.0",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7179,7 +6437,7 @@ dependencies = [
  "nix 0.29.0",
  "nonempty",
  "orchard 0.15.0-pre.2",
- "phf 0.12.1",
+ "phf",
  "quote",
  "rand 0.8.6",
  "rpassword",
@@ -7190,7 +6448,7 @@ dependencies = [
  "schemars 1.2.1",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "semver",
  "serde",
@@ -7325,7 +6583,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "shardtree",
  "subtle",
@@ -7375,7 +6633,7 @@ dependencies = [
  "sapling-crypto",
  "schemerz",
  "schemerz-rusqlite",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "shardtree",
  "static_assertions",
@@ -7421,6 +6679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32 0.11.1",
+ "bip0039",
  "bip32",
  "blake2b_simd",
  "bls12_381",
@@ -7432,6 +6691,7 @@ dependencies = [
  "nonempty",
  "orchard 0.14.0",
  "rand_core 0.6.4",
+ "regex",
  "sapling-crypto",
  "secrecy 0.8.0",
  "subtle",
@@ -7464,7 +6724,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "secrecy 0.8.0",
  "subtle",
  "tracing",
@@ -7540,7 +6800,7 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
@@ -7607,7 +6867,7 @@ dependencies = [
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha1",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -7636,7 +6896,7 @@ dependencies = [
  "hex",
  "nonempty",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
@@ -7660,7 +6920,7 @@ dependencies = [
  "hex",
  "nonempty",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.13.0-pre.0",
@@ -7688,7 +6948,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "derive-getters",
- "dirs 6.0.0",
+ "dirs",
  "ed25519-zebra",
  "equihash",
  "futures",
@@ -7710,7 +6970,7 @@ dependencies = [
  "ripemd 0.1.3",
  "sapling-crypto",
  "schemars 1.2.1",
- "secp256k1 0.29.1",
+ "secp256k1",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -7788,7 +7048,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "dirs 6.0.0",
+ "dirs",
  "futures",
  "hex",
  "humantime-serde",
@@ -7856,7 +7116,7 @@ dependencies = [
  "nix 0.30.1",
  "openrpsee",
  "orchard 0.15.0-pre.2",
- "phf 0.12.1",
+ "phf",
  "prost",
  "rand 0.8.6",
  "sapling-crypto",
@@ -7918,7 +7178,7 @@ dependencies = [
  "crossbeam-channel",
  "derive-getters",
  "derive-new",
- "dirs 6.0.0",
+ "dirs",
  "futures",
  "hex",
  "hex-literal",
@@ -8044,25 +7304,22 @@ dependencies = [
 [[package]]
 name = "zewif"
 version = "0.1.0"
-source = "git+https://github.com/zcash/zewif.git?rev=0a5a234490a339ca8dda13614146e4769a3cd963#0a5a234490a339ca8dda13614146e4769a3cd963"
+source = "git+https://github.com/zcash/zewif.git?rev=74f1a1694131386515e1733dfb9f414a6284555f#74f1a1694131386515e1733dfb9f414a6284555f"
 dependencies = [
- "bc-components",
- "bc-crypto 0.13.0",
- "bc-envelope",
- "chrono",
- "dcbor",
  "hex",
+ "minicbor",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zewif-zcashd"
 version = "0.1.0"
-source = "git+https://github.com/zcash/zewif-zcashd.git?rev=c640713b91b79d153a7fee2888088931cd7e8326#c640713b91b79d153a7fee2888088931cd7e8326"
+source = "git+https://github.com/zcash/zewif-zcashd.git?rev=fce12991e11bb543f8a9b60a5af92cfb953f699c#fce12991e11bb543f8a9b60a5af92cfb953f699c"
 dependencies = [
- "anyhow",
+ "bech32 0.12.0",
  "bitflags",
  "bridgetree",
+ "bs58",
  "byteorder",
  "chrono",
  "hex",
@@ -8070,8 +7327,10 @@ dependencies = [
  "orchard 0.14.0",
  "ripemd 0.1.3",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
+ "secrecy 0.8.0",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
  "zcash_encoding",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -114,8 +114,8 @@ orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff9
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 
-zewif = { git = "https://github.com/zcash/zewif.git", rev = "0a5a234490a339ca8dda13614146e4769a3cd963" }
-zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "c640713b91b79d153a7fee2888088931cd7e8326" }
+zewif = { git = "https://github.com/zcash/zewif.git", rev = "74f1a1694131386515e1733dfb9f414a6284555f" }
+zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "fce12991e11bb543f8a9b60a5af92cfb953f699c" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -44,14 +44,26 @@ Additional CLI arguments:
 > For the Zallet alpha releases, the command also currently takes another required flag
 > `--this-is-alpha-code-and-you-will-need-to-redo-the-migration-later`.
 
-When run, Zallet will parse the `zcashd` wallet file, connect to the backing
-full node (to obtain necessary chain information for setting up wallet
-birthdays), create Zallet accounts corresponding to the structure of the
-`zcashd` wallet, and store the key material in the Zallet wallet. Parsing is
-performed using the `db_dump` command-line utility. By default Zallet uses the
-copy it vendors and builds, which is the recommended choice; a `zcashd`-provided
-`db_dump` from the `zcutil/bin` directory of a source installation (via
-`--zcashd-install-dir`), or one on the system `$PATH`, are used otherwise.
+When run, Zallet will parse the `zcashd` wallet file, export its contents to an
+in-memory [ZeWIF] (Zcash Wallet Interchange Format) document, connect to the
+backing full node (to obtain necessary chain information for setting up wallet
+birthdays), and import the document: Zallet accounts are created corresponding
+to the structure of the `zcashd` wallet, spending key material is stored in the
+Zallet keystore, and the account birthdays carry the note commitment tree state
+needed for recovery. Parsing is performed using the `db_dump` command-line
+utility. By default Zallet uses the copy it vendors and builds, which is the
+recommended choice; a `zcashd`-provided `db_dump` from the `zcutil/bin`
+directory of a source installation (via `--zcashd-install-dir`), or one on the
+system `$PATH`, are used otherwise.
+
+Some `zcashd` wallet contents cannot be represented in a Zallet wallet, and are
+reported (with counts) rather than migrated: Sprout spending keys (move any
+Sprout funds using `zcashd` before migrating), address book entries, watch-only
+entries recorded without their public keys or redeem scripts, and entries with
+uncompressed public keys. Migration of regtest wallets is not currently
+supported.
+
+[ZeWIF]: https://github.com/zcash/zewif
 
 [`zcashd`]: https://github.com/zcash/zcash
 [`zallet init-wallet-encryption`]: init-wallet-encryption.md

--- a/crates/zebra-read-state/Cargo.lock
+++ b/crates/zebra-read-state/Cargo.lock
@@ -3,55 +3,6 @@
 version = 4
 
 [[package]]
-name = "abscissa_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd87587023faadfc7f6e93b1ad45074b72f1f6d22c1e0f19333a952446ab1c1"
-dependencies = [
- "abscissa_derive",
- "arc-swap",
- "backtrace",
- "canonical-path",
- "clap",
- "color-eyre",
- "fs-err",
- "once_cell",
- "regex",
- "secrecy 0.10.3",
- "semver",
- "serde",
- "termcolor",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
- "wait-timeout",
-]
-
-[[package]]
-name = "abscissa_derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da54f552dccbdec19736d713720dd88af932a82eb02ca0f22410de5d31ad726"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "abscissa_tokio"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06466251d77b85dae0e3012ca60bc0e2d856b2aa03446f264e9ab9fe838e891b"
-dependencies = [
- "abscissa_core",
- "tokio",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,55 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "age"
-version = "0.11.1"
-source = "git+https://github.com/str4d/rage.git?rev=92f437bc2a061312fa6633bb70c91eef91142fd4#92f437bc2a061312fa6633bb70c91eef91142fd4"
-dependencies = [
- "age-core",
- "base64 0.21.7",
- "bech32 0.9.1",
- "chacha20poly1305",
- "console",
- "cookie-factory",
- "hmac 0.12.1",
- "i18n-embed",
- "i18n-embed-fl",
- "is-terminal",
- "lazy_static",
- "nom",
- "pin-project",
- "pinentry",
- "rand 0.8.6",
- "rpassword",
- "rust-embed",
- "scrypt",
- "sha2 0.10.9",
- "subtle",
- "which 4.4.2",
- "wsl",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "age-core"
-version = "0.11.0"
-source = "git+https://github.com/str4d/rage.git?rev=92f437bc2a061312fa6633bb70c91eef91142fd4#92f437bc2a061312fa6633bb70c91eef91142fd4"
-dependencies = [
- "base64 0.21.7",
- "chacha20poly1305",
- "cookie-factory",
- "hkdf",
- "io_tee",
- "nom",
- "rand 0.8.6",
- "secrecy 0.10.3",
- "sha2 0.10.9",
- "tempfile",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -145,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,93 +63,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse 1.0.0",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
-
-[[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "arrayref"
@@ -262,7 +88,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -285,17 +111,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "automod"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a273e731a7fb8c2268fd2932c9e9a3469f4fd171d85d070d2687190229653bd3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "axum"
@@ -363,12 +178,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -380,31 +189,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
-name = "bech32"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bellman"
@@ -428,17 +216,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip0039"
-version = "0.12.0"
+name = "bincode"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "hmac 0.12.1",
- "pbkdf2",
- "rand 0.8.6",
- "sha2 0.10.9",
- "unicode-normalization",
- "zeroize",
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -448,7 +269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143f5327f23168716be068f8e1014ba2ea16a6c91e8777bc8927da7b51e1df1f"
 dependencies = [
  "bs58",
- "hmac 0.13.0-pre.4",
+ "hmac",
  "rand_core 0.6.4",
  "ripemd 0.2.0-pre.4",
  "secp256k1",
@@ -458,25 +279,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bitflags-serde-legacy"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
+dependencies = [
+ "bitflags",
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -549,16 +365,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
+ "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bridgetree"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d74f010107ed76a581e5c348f27bdf47b8e6286c667d3ae5be473bd07bfc22f"
-dependencies = [
- "incrementalmerkletree",
 ]
 
 [[package]]
@@ -578,6 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,46 +399,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
-name = "camino"
-version = "1.2.4"
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "canonical-path"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -638,14 +424,23 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -668,7 +463,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -678,7 +484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -691,9 +497,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
+ "serde",
  "windows-link",
 ]
 
@@ -709,62 +514,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.1"
+name = "clang-sys"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream 1.0.0",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_complete"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
-dependencies = [
- "clap",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clap_mangen"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
-dependencies = [
- "clap",
- "roff",
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -790,68 +547,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console-api"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
-dependencies = [
- "futures-core",
- "prost",
- "prost-types",
- "tonic",
- "tonic-prost",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "hyper-util",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "const-crc32-nostd"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
@@ -881,30 +586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "content_inspector"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie-factory"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
-dependencies = [
- "futures",
 ]
 
 [[package]]
@@ -929,12 +616,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -945,18 +632,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -964,18 +651,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1003,22 +690,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "current_platform"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -1031,66 +714,61 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "daggy"
-version = "0.8.1"
+name = "darling"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "petgraph 0.7.1",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
-name = "deadpool"
-version = "0.12.3"
+name = "darling_core"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
+name = "darling_macro"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "tokio",
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "deadpool-sqlite"
-version = "0.12.1"
+name = "der"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8510000b26f632483a35120c2ce280c29e1e14c2dcb27b5055dbdac276f63f58"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "deadpool",
- "deadpool-sync",
- "rusqlite",
-]
-
-[[package]]
-name = "deadpool-sync"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
-dependencies = [
- "deadpool-runtime",
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1101,7 +779,18 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1112,7 +801,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1127,6 +815,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,7 +843,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1164,19 +873,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1149cf7462e5e79e17a3c05fd5b1f9055092bbfa95e04c319395c3beacc9370f"
 dependencies = [
  "convert_case",
- "itertools",
+ "itertools 0.14.0",
  "optfield",
  "proc-macro2",
  "quote",
  "strum",
- "syn",
+ "syn 2.0.118",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1185,23 +888,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "hashbrown 0.16.1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "embed-licensing-core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93af86b1ab9c24dcbf99a3e2bc7d65fd7bfef5238240ba8436e85caf752cc66f"
-dependencies = [
- "cargo-platform",
- "cargo_metadata",
- "current_platform",
- "spdx",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "embedded-io"
@@ -1216,18 +934,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
+name = "env_logger"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
+ "document-features",
 ]
 
 [[package]]
@@ -1259,22 +983,11 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1300,112 +1013,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "find-crate"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fluent"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
-dependencies = [
- "fluent-bundle",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-bundle"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
-dependencies = [
- "fluent-langneg",
- "fluent-syntax",
- "intl-memoizer",
- "intl_pluralrules",
- "rustc-hash",
- "self_cell",
- "smallvec",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-langneg"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
-dependencies = [
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-syntax"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
-dependencies = [
- "memchr",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
-name = "fmutex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd990c8a95704647aeb7cc51b0ea54c5072c824894977cc8ba679459f00bc9a"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fnv"
@@ -1418,6 +1047,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1453,7 +1088,7 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "postcard",
  "rand_core 0.6.4",
  "serde",
@@ -1475,15 +1110,6 @@ dependencies = [
  "frost-core",
  "hex",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1548,7 +1174,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1562,12 +1188,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1587,15 +1207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gen-copyright"
-version = "0.1.0"
-dependencies = [
- "cargo_metadata",
- "embed-licensing-core",
- "spdx",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1218,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -1614,20 +1236,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
 ]
 
 [[package]]
@@ -1637,8 +1247,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1649,7 +1262,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1657,19 +1270,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "git2"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -1725,7 +1325,7 @@ dependencies = [
  "rand 0.8.6",
  "sinsemilla",
  "subtle",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -1784,7 +1384,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1792,28 +1403,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "base64 0.21.7",
- "byteorder",
- "flate2",
- "nom",
- "num-traits",
-]
 
 [[package]]
 name = "heapless"
@@ -1846,24 +1435,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
+ "serde",
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
+name = "hex-literal"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -1929,6 +1509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1562,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,85 +1596,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "i18n-config"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
-dependencies = [
- "basic-toml",
- "log",
- "serde",
- "serde_derive",
- "thiserror 1.0.69",
- "unic-langid",
-]
-
-[[package]]
-name = "i18n-embed"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
-dependencies = [
- "arc-swap",
- "fluent",
- "fluent-langneg",
- "fluent-syntax",
- "i18n-embed-impl",
- "intl-memoizer",
- "log",
- "parking_lot",
- "rust-embed",
- "sys-locale",
- "thiserror 1.0.69",
- "unic-langid",
- "walkdir",
-]
-
-[[package]]
-name = "i18n-embed-fl"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e598ed73b67db92f61e04672e599eef2991a262a40e1666735b8a86d2e7e9f30"
-dependencies = [
- "find-crate",
- "fluent",
- "fluent-syntax",
- "i18n-config",
- "i18n-embed",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
- "unic-langid",
-]
-
-[[package]]
-name = "i18n-embed-impl"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
-dependencies = [
- "find-crate",
- "i18n-config",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2209,9 +1747,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
 ]
@@ -2230,6 +1789,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2240,6 +1800,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2252,52 +1814,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "intl-memoizer"
-version = "0.5.3"
+name = "ipnet"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
- "type-map",
- "unic-langid",
+ "either",
 ]
 
 [[package]]
-name = "intl_pluralrules"
-version = "7.0.2"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
- "unic-langid",
+ "either",
 ]
-
-[[package]]
-name = "io_tee"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "is_debug"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -2316,11 +1854,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2342,11 +1880,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
 dependencies = [
  "jsonrpsee-core",
- "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2357,44 +1893,19 @@ checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
 dependencies = [
  "async-trait",
  "bytes",
- "futures-timer",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
- "pin-project",
  "rand 0.8.6",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.24.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c215647e43482d478a6c21f021a013b50d64cf63431c1176eda9ef925dc54ec8"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "http-body",
- "hyper",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -2407,7 +1918,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2497,21 +2008,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -2521,14 +2036,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.35.0"
+name = "libredox"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+dependencies = [
+ "bindgen 0.69.5",
+ "bzip2-sys",
  "cc",
- "pkg-config",
- "vcpkg",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
 ]
 
 [[package]]
@@ -2538,16 +2066,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "libzcash_script"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f8ce05b56f3cbc65ec7d0908adb308ed91281e022f61c8c3a0c9388b5380b17"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "thiserror 2.0.18",
+ "tracing",
+ "zcash_script",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2583,12 +2117,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
- "regex-automata",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2609,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memuse"
@@ -2620,30 +2161,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minicbor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
-dependencies = [
- "minicbor-derive",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2658,7 +2189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2668,9 +2198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4d16a3d2b0e89ec6e7d509cf791545fcb48cbc8fc2fb2e96a492defda9140"
 
 [[package]]
 name = "multimap"
@@ -2679,19 +2215,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2716,25 +2243,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2742,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2762,7 +2274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2772,15 +2283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
  "libc",
 ]
 
@@ -2800,16 +2302,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openrpsee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faeb689cfe5fad5e7285f87b00c903366b307d97f41de53e894ec608968ca3a1"
+dependencies = [
+ "documented",
+ "jsonrpsee",
+ "quote",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "optfield"
@@ -2819,49 +2330,20 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "orchard"
-version = "0.14.0"
+name = "option-ext"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
-dependencies = [
- "aes",
- "bitvec",
- "blake2b_simd",
- "corez",
- "ff",
- "fpe",
- "getset",
- "group",
- "halo2_gadgets",
- "halo2_poseidon",
- "halo2_proofs",
- "hex",
- "incrementalmerkletree",
- "lazy_static",
- "memuse",
- "nonempty",
- "pasta_curves",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "reddsa",
- "serde",
- "sinsemilla",
- "subtle",
- "tracing",
- "visibility",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
-]
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
 dependencies = [
  "aes",
  "bitvec",
@@ -2894,13 +2376,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.3"
+name = "ordered-map"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+checksum = "6ac8f4a4a06c811aa24b151dbb3fe19f687cb52e0d5cca0493671ed88f973970"
 dependencies = [
- "libc",
- "windows-sys 0.61.2",
+ "quickcheck",
+ "quickcheck_macros",
 ]
 
 [[package]]
@@ -2916,6 +2398,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2942,17 +2452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,14 +2467,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
+name = "pem-rfc7468"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash",
+ "base64ct",
 ]
 
 [[package]]
@@ -2983,16 +2480,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap 2.14.0",
-]
 
 [[package]]
 name = "petgraph"
@@ -3036,7 +2523,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3065,7 +2552,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3075,18 +2562,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pinentry"
-version = "0.6.2"
+name = "pkcs8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a108bb5e4e654a3d20c834e5676b4b20f7cd2cc73b22f849d93e028b259340ec"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "log",
- "nom",
- "percent-encoding",
- "secrecy 0.10.3",
- "wait-timeout",
- "which 4.4.2",
- "zeroize",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3101,10 +2583,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"
@@ -3150,7 +2638,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3159,29 +2658,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3191,25 +2668,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
 ]
 
 [[package]]
@@ -3229,15 +2687,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -3248,10 +2708,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3264,10 +2724,103 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
+name = "pulldown-cmark"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
+]
+
+[[package]]
+name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "quote"
@@ -3277,12 +2830,6 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -3298,6 +2845,19 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -3309,12 +2869,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3328,13 +2899,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
+name = "rand_core"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -3348,30 +2918,35 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "num-traits",
- "rand 0.8.6",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.4.0"
+name = "rapidhash"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
- "rand_core 0.9.5",
+ "rustversion",
 ]
 
 [[package]]
@@ -3421,6 +2996,7 @@ checksum = "89b0ac1bc6bb3696d2c6f52cff8fba57238b81da8c0214ee6cd146eb8fde364e"
 dependencies = [
  "rand_core 0.6.4",
  "reddsa",
+ "serde",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -3432,6 +3008,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3451,14 +3038,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3468,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3482,6 +3069,44 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "ring"
@@ -3516,10 +3141,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "roff"
-version = "1.1.1"
+name = "rlimit"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
 
 [[package]]
 name = "route-recognizer"
@@ -3528,101 +3166,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
-name = "rpassword"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
- "time",
- "uuid",
-]
-
-[[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2 0.10.9",
- "walkdir",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
-dependencies = [
- "arrayvec",
- "num-traits",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "zmij",
-]
-
-[[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -3635,19 +3200,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3655,7 +3207,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3665,8 +3217,8 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3679,6 +3231,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3695,39 +3248,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "rusty-fork"
-version = "0.3.1"
+name = "ryu"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sapling-crypto"
@@ -3764,6 +3293,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
@@ -3784,31 +3325,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
-]
-
-[[package]]
-name = "schemerz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e82960ac11ccabd77d53c933532612079e01205b5873ec5095f4b3426493434"
-dependencies = [
- "daggy",
- "indexmap 1.9.3",
- "log",
- "thiserror 1.0.69",
- "uuid",
-]
-
-[[package]]
-name = "schemerz-rusqlite"
-version = "0.370.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6df8a13fb3b7914f94ac6579bd5e76b9292f135886e6becc3525f9e5116827"
-dependencies = [
- "rusqlite",
- "schemerz",
- "uuid",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3818,23 +3335,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -3852,35 +3359,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
- "serde",
  "zeroize",
 ]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -3890,6 +3376,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3909,7 +3404,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3920,7 +3415,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3937,21 +3432,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
+name = "serde_with"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
  "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3971,7 +3492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3982,7 +3503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3993,21 +3514,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-pre.9",
-]
-
-[[package]]
-name = "shadow-rs"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9967e7c3cd89d19cd533d8fceb3e5dcee28cf97fe76441481abe1d32723039"
-dependencies = [
- "const_format",
- "git2",
- "is_debug",
- "time",
- "tzdb",
 ]
 
 [[package]]
@@ -4017,17 +3525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shardtree"
-version = "0.6.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
-dependencies = [
- "bitflags",
- "either",
- "incrementalmerkletree",
- "tracing",
 ]
 
 [[package]]
@@ -4043,26 +3540,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
+name = "signature"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "errno",
- "libc",
+ "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sinsemilla"
@@ -4094,37 +3578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "snapbox"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1abc378119f77310836665f8523018532cf7e3faeb3b10b01da5a7321bf8e1"
-dependencies = [
- "anstream 0.6.21",
- "anstyle",
- "content_inspector",
- "dunce",
- "filetime",
- "libc",
- "normalize-line-endings",
- "os_pipe",
- "similar",
- "snapbox-macros",
- "tempfile",
- "wait-timeout",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "snapbox-macros"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b750c344002d7cc69afb9da00ebd9b5c0f8ac2eb7d115d9d45d5b5f47718d74"
-dependencies = [
- "anstream 0.6.21",
-]
-
-[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,7 +3593,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures",
  "http",
@@ -4151,21 +3604,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "spdx"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4204,7 +3658,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4212,6 +3666,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -4229,6 +3694,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4238,16 +3706,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "sys-locale"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
-dependencies = [
- "libc",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4265,17 +3724,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -4304,7 +3754,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4315,7 +3765,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4329,32 +3779,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4367,7 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -4396,7 +3842,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -4411,7 +3856,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4451,59 +3896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,43 +3906,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -4559,20 +3922,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -4582,7 +3933,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -4596,13 +3947,11 @@ dependencies = [
  "socket2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4614,7 +3963,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4639,9 +3988,23 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -4655,6 +4018,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4677,6 +4041,53 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-batch-control"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6cf52578f98b4da47335c26c4f883f7993b1a9b9d2f5420eb8dbfd5dd19a28"
+dependencies = [
+ "futures",
+ "futures-core",
+ "pin-project",
+ "rayon",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tower-fallback"
+version = "0.2.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434e19ee996ee5c6aa42f11463a355138452592e5c5b5b73b6f0f19534556af"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4711,7 +4122,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4721,18 +4132,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
+name = "tracing-error"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
- "log",
- "once_cell",
- "tracing-core",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -4741,16 +4160,9 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -4760,63 +4172,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "trycmd"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81ea3136ddc88e19c2cc2eb3176b72abee4e831367cd8949f2a88ac5497e64e"
-dependencies = [
- "anstream 0.6.21",
- "automod",
- "glob",
- "humantime",
- "humantime-serde",
- "rayon",
- "serde",
- "shlex 1.3.0",
- "snapbox",
- "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "type-map"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
-dependencies = [
- "rustc-hash",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "tz-rs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6c929ffa10fb34f4a3c7e9a73620a83ef2e85e47f9ec3381b8289e6762f42"
-
-[[package]]
-name = "tzdb"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d4e985b6dda743ae7fd4140c28105316ffd75bc58258ee6cc12934e3eb7a0c"
-dependencies = [
- "iana-time-zone",
- "tz-rs",
- "tzdb_data",
-]
-
-[[package]]
-name = "tzdb_data"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febaa995f6852367564e16c3369988b99d471d43ed12b1255b8d294661797f1c"
-dependencies = [
- "tz-rs",
-]
 
 [[package]]
 name = "uint"
@@ -4831,44 +4190,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
+name = "uint"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unic-langid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
- "unic-langid-impl",
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
 ]
 
 [[package]]
-name = "unic-langid-impl"
-version = "0.9.6"
+name = "unicase"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
-dependencies = [
- "serde",
- "tinystr",
-]
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4917,29 +4260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,7 +4279,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5013,25 +4333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b6d5a78adc3e8f198e9cd730f219a695431467f7ec29dcfc63ade885feebe1"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5042,18 +4343,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5064,9 +4362,18 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5088,7 +4395,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -5102,6 +4409,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5112,32 +4439,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "which"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5161,7 +4467,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5172,7 +4478,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5205,25 +4511,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5241,31 +4529,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5275,22 +4546,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5299,22 +4558,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5323,22 +4570,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5347,31 +4582,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -5383,22 +4597,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wsl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "wyz"
@@ -5420,12 +4622,6 @@ dependencies = [
  "serde",
  "zeroize",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xdg"
@@ -5452,237 +4648,41 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
-name = "zallet"
+name = "zallet-zebra-read-state"
 version = "0.1.0-alpha.4"
 dependencies = [
- "home",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "zallet-core"
-version = "0.1.0-alpha.4"
-dependencies = [
- "abscissa_core",
- "abscissa_tokio",
- "age",
- "anyhow",
- "async-trait",
- "base64ct",
- "bech32 0.11.1",
- "bip0039",
- "clap",
- "clap_complete",
- "clap_mangen",
- "console-subscriber",
- "deadpool",
- "deadpool-sqlite",
- "deadpool-sync",
- "documented",
- "flate2",
- "fmutex",
- "futures",
- "hex",
- "hmac 0.12.1",
- "home",
- "http-body-util",
- "hyper",
- "i18n-embed",
- "i18n-embed-fl",
- "incrementalmerkletree",
- "jsonrpsee",
- "jsonrpsee-http-client",
- "known-folders",
- "nix",
- "nonempty",
- "once_cell",
- "orchard 0.15.0-pre.2",
- "phf",
- "proptest",
- "quote",
- "rand 0.8.6",
- "regex",
- "rpassword",
- "rusqlite",
- "rust-embed",
- "rust_decimal",
- "sapling-crypto",
- "schemars",
- "schemerz",
- "schemerz-rusqlite",
- "secp256k1",
- "secrecy 0.8.0",
- "semver",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "shadow-rs",
- "shardtree",
- "syn",
- "tempfile",
- "time",
  "tokio",
- "toml 0.8.23",
- "tonic",
- "tower 0.4.13",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
- "trycmd",
- "uuid",
- "which 8.0.4",
- "xdg 2.5.2",
- "zcash_address 0.13.0-pre.0",
- "zcash_client_backend",
- "zcash_client_sqlite",
- "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
- "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
- "zewif",
- "zewif-zcashd",
- "zip32",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
-dependencies = [
- "bech32 0.11.1",
- "bs58",
- "corez",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
+ "zebra-chain",
+ "zebra-rpc",
+ "zebra-state",
 ]
 
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2918e73eff76388cda87695a6e7398f96a2e3383a0de7b77729a204ec00a0"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
-]
-
-[[package]]
-name = "zcash_client_backend"
-version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
-dependencies = [
- "base64 0.22.1",
- "bech32 0.11.1",
- "bip32",
- "bls12_381",
- "bs58",
- "byteorder",
- "document-features",
- "flume",
- "getset",
- "group",
- "hex",
- "hyper-util",
- "incrementalmerkletree",
- "memuse",
- "nonempty",
- "orchard 0.15.0-pre.2",
- "pasta_curves",
- "percent-encoding",
- "prost",
- "rand_core 0.6.4",
- "rayon",
- "sapling-crypto",
- "secp256k1",
- "secrecy 0.8.0",
- "shardtree",
- "subtle",
- "time",
- "time-core",
- "tokio",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tracing",
- "which 8.0.4",
- "zcash_address 0.13.0-pre.0",
- "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
- "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
- "zip32",
- "zip321",
-]
-
-[[package]]
-name = "zcash_client_sqlite"
-version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
-dependencies = [
- "bech32 0.11.1",
- "bip0039",
- "bip32",
- "bitflags",
- "bs58",
- "byteorder",
- "document-features",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "maybe-rayon",
- "nonempty",
- "orchard 0.15.0-pre.2",
- "prost",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_distr",
- "regex",
- "rusqlite",
- "sapling-crypto",
- "schemerz",
- "schemerz-rusqlite",
- "secp256k1",
- "secrecy 0.8.0",
- "shardtree",
- "static_assertions",
- "subtle",
- "time",
- "tracing",
- "uuid",
- "zcash_address 0.13.0-pre.0",
- "zcash_client_backend",
- "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
- "zewif",
- "zip32",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -5690,66 +4690,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_keys"
-version = "0.14.0"
+name = "zcash_history"
+version = "0.5.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+checksum = "82e8634d011026cb181cb67b2a412e601dc344a2827b9c576fe3a727fdebf441"
 dependencies = [
- "bech32 0.11.1",
- "bip0039",
- "bip32",
  "blake2b_simd",
- "bls12_381",
- "bs58",
- "corez",
- "document-features",
- "group",
- "memuse",
- "nonempty",
- "orchard 0.14.0",
- "rand_core 0.6.4",
- "regex",
- "sapling-crypto",
- "secrecy 0.8.0",
- "subtle",
- "tracing",
- "zcash_address 0.12.0",
- "zcash_encoding",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
- "zip32",
+ "byteorder",
+ "primitive-types",
 ]
 
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0bac3a9e5b0d954684ba1f07386d55b5ae4588b3ba2d93cad05ee09f3e0947"
 dependencies = [
- "bech32 0.11.1",
- "bip0039",
- "bip32",
+ "bech32",
  "blake2b_simd",
  "bls12_381",
  "bs58",
- "byteorder",
  "corez",
  "document-features",
  "group",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard",
  "rand_core 0.6.4",
- "regex",
  "sapling-crypto",
- "secp256k1",
- "secrecy 0.8.0",
+ "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
- "zeroize",
+ "zcash_protocol",
+ "zcash_transparent",
  "zip32",
 ]
 
@@ -5759,7 +4734,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "cipher",
  "rand_core 0.6.4",
@@ -5768,38 +4743,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "document-features",
- "equihash",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard 0.14.0",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2 0.10.9",
- "zcash_encoding",
- "zcash_note_encryption",
- "zcash_protocol 0.9.0",
- "zcash_script",
- "zcash_transparent 0.8.0",
-]
-
-[[package]]
-name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7bfe66975658f44dba87d535f9ebb9fb4c9c0c4fecca3f5c40cbe1583dece6"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5813,7 +4759,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -5821,15 +4767,16 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39b90964ffe6bdc314368c7b849aaa6dcc2b495249a3bf1b9bfbdc92ba4e4f6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5844,27 +4791,15 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "wagyu-zcash-parameters",
- "xdg 3.0.0",
- "zcash_primitives 0.29.0-pre.0",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
-dependencies = [
- "corez",
- "document-features",
- "hex",
- "memuse",
- "zcash_encoding",
+ "xdg",
+ "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f339a9801c7f70295732a5cf822346f194202cea6425fc2fc14a5af679b004"
 dependencies = [
  "corez",
  "document-features",
@@ -5901,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
+version = "0.9.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+checksum = "4e941230f67056aad41c8fa9b926f9cc4d9d1a321f32e95c39c0b0e38e85f79b"
 dependencies = [
  "bip32",
  "bs58",
@@ -5916,56 +4851,307 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.12.0",
+ "zcash_address",
  "zcash_encoding",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
  "zcash_script",
  "zcash_spec",
  "zip32",
 ]
 
 [[package]]
-name = "zcash_transparent"
-version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+name = "zebra-chain"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600a4c35ee81350384226f8178fab2b088e38d5e0a9f6cb0b1051caba30702d7"
 dependencies = [
- "bip32",
+ "bech32",
+ "bitflags",
+ "bitflags-serde-legacy",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bounded-vec",
  "bs58",
- "corez",
- "document-features",
- "getset",
+ "byteorder",
+ "chrono",
+ "derive-getters",
+ "dirs",
+ "ed25519-zebra",
+ "equihash",
+ "futures",
+ "group",
+ "halo2_proofs",
  "hex",
- "nonempty",
+ "humantime",
+ "incrementalmerkletree",
+ "itertools 0.14.0",
+ "jubjub",
+ "lazy_static",
+ "num-integer",
+ "orchard",
+ "primitive-types",
+ "rand_core 0.6.4",
+ "rayon",
+ "reddsa",
+ "redjubjub",
  "ripemd 0.1.3",
+ "sapling-crypto",
+ "schemars 1.2.1",
  "secp256k1",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "serde_with",
  "sha2 0.10.9",
- "subtle",
- "zcash_address 0.13.0-pre.0",
+ "sinsemilla",
+ "static_assertions",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uint 0.10.0",
+ "x25519-dalek",
+ "zcash_address",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_history",
+ "zcash_note_encryption",
+ "zcash_primitives",
+ "zcash_protocol",
  "zcash_script",
- "zcash_spec",
- "zip32",
+ "zcash_transparent",
+]
+
+[[package]]
+name = "zebra-consensus"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa2b2678c4ce6d18172bad73a9b72b24a4b3a65af4c2a5e9120a1470c3fc402"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "bls12_381",
+ "chrono",
+ "derive-getters",
+ "futures",
+ "futures-util",
+ "halo2_proofs",
+ "jubjub",
+ "lazy_static",
+ "libzcash_script",
+ "metrics",
+ "mset",
+ "once_cell",
+ "orchard",
+ "rand 0.8.6",
+ "rayon",
+ "sapling-crypto",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.4.13",
+ "tower-batch-control",
+ "tower-fallback",
+ "tracing",
+ "tracing-futures",
+ "zcash_primitives",
+ "zcash_proofs",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+ "zebra-chain",
+ "zebra-node-services",
+ "zebra-script",
+ "zebra-state",
+]
+
+[[package]]
+name = "zebra-network"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b1e6ca4687bc8d128553ca04bb82cc38701c4dac7107f3e56717b39d4b18da"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "dirs",
+ "futures",
+ "hex",
+ "humantime-serde",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "lazy_static",
+ "metrics",
+ "num-integer",
+ "ordered-map",
+ "pin-project",
+ "rand 0.8.6",
+ "rayon",
+ "regex",
+ "schemars 1.2.1",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-error",
+ "tracing-futures",
+ "zebra-chain",
+]
+
+[[package]]
+name = "zebra-node-services"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4446db9b576c0de14ff91c7fd7b38a59d340c1969a1604787185a52b8b7f53a6"
+dependencies = [
+ "color-eyre",
+ "jsonrpsee-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.4.13",
+ "zebra-chain",
+]
+
+[[package]]
+name = "zebra-rpc"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb180542f1ffc0f66c20e1cd66c7741662053ccda588e3847a8ed2df8c83dae7"
+dependencies = [
+ "base64",
+ "chrono",
+ "color-eyre",
+ "derive-getters",
+ "derive-new",
+ "futures",
+ "hex",
+ "http-body-util",
+ "hyper",
+ "indexmap 2.14.0",
+ "jsonrpsee",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "lazy_static",
+ "metrics",
+ "nix",
+ "openrpsee",
+ "orchard",
+ "phf",
+ "prost",
+ "rand 0.8.6",
+ "sapling-crypto",
+ "schemars 1.2.1",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "strum_macros",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-reflection",
+ "tower 0.4.13",
+ "tracing",
+ "which",
+ "zcash_address",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_proofs",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+ "zebra-chain",
+ "zebra-consensus",
+ "zebra-network",
+ "zebra-node-services",
+ "zebra-script",
+ "zebra-state",
+]
+
+[[package]]
+name = "zebra-script"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8648c201e3dadb1c95022eb7605d528de4bf94b6c0cebf76537805849aee76c5"
+dependencies = [
+ "libzcash_script",
+ "rand 0.8.6",
+ "thiserror 2.0.18",
+ "zcash_primitives",
+ "zcash_script",
+ "zebra-chain",
+]
+
+[[package]]
+name = "zebra-state"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b95b81181253a46885e3254cc5a20e4d82b5258116c9e43db5c8e9660c6b973"
+dependencies = [
+ "bincode",
+ "chrono",
+ "crossbeam-channel",
+ "derive-getters",
+ "derive-new",
+ "dirs",
+ "futures",
+ "hex",
+ "hex-literal",
+ "human_bytes",
+ "humantime-serde",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "lazy_static",
+ "metrics",
+ "mset",
+ "rayon",
+ "regex",
+ "rlimit",
+ "rocksdb",
+ "sapling-crypto",
+ "semver",
+ "serde",
+ "serde-big-array",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "zebra-chain",
+ "zebra-node-services",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5985,7 +5171,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6006,7 +5192,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6026,7 +5212,6 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -6040,48 +5225,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "zewif"
-version = "0.1.0"
-source = "git+https://github.com/zcash/zewif.git?rev=74f1a1694131386515e1733dfb9f414a6284555f#74f1a1694131386515e1733dfb9f414a6284555f"
-dependencies = [
- "hex",
- "minicbor",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "zewif-zcashd"
-version = "0.1.0"
-source = "git+https://github.com/zcash/zewif-zcashd.git?rev=fce12991e11bb543f8a9b60a5af92cfb953f699c#fce12991e11bb543f8a9b60a5af92cfb953f699c"
-dependencies = [
- "bech32 0.12.0",
- "bitflags",
- "bridgetree",
- "bs58",
- "byteorder",
- "chrono",
- "hex",
- "incrementalmerkletree",
- "orchard 0.14.0",
- "ripemd 0.1.3",
- "sapling-crypto",
- "secp256k1",
- "secrecy 0.8.0",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "uuid",
- "zcash_address 0.12.0",
- "zcash_encoding",
- "zcash_keys 0.14.0",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
- "zewif",
- "zip32",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6090,23 +5234,11 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64bf5186a8916f7a48f2a98ef599bf9c099e2458b36b819e393db1c0e768c4b"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "blake2b_simd",
  "memuse",
  "subtle",
  "zcash_spec",
-]
-
-[[package]]
-name = "zip321"
-version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
-dependencies = [
- "base64 0.22.1",
- "nom",
- "percent-encoding",
- "zcash_address 0.13.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -57,6 +57,7 @@ exceptions = [
     { name = "litemap", allow = ["Unicode-3.0"] },
     { name = "matchit", allow = ["BSD-3-Clause"] },
     { name = "minicbor", allow = ["BlueOak-1.0.0"] },
+    { name = "minicbor-derive", allow = ["BlueOak-1.0.0"] },
     { name = "nanorand", allow = ["Zlib"] },
     { name = "potential_utf", allow = ["Unicode-3.0"] },
     { name = "option-ext", allow = ["MPL-2.0"] },

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1172,8 +1172,16 @@ criteria = "safe-to-deploy"
 version = "0.19.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.minicbor]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.minicbor-derive]]
 version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.minicbor-derive]]
+version = "0.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,6 +34,17 @@ audit-as-crates-io = false
 [policy.f4jumble]
 audit-as-crates-io = false
 
+[policy.incrementalmerkletree]
+audit-as-crates-io = true
+
+[policy."orchard:0.14.0"]
+
+[policy."orchard:0.15.0-pre.2@git:475ef0ff77d45aebff93cb039d639250d82518a3"]
+audit-as-crates-io = true
+
+[policy.shardtree]
+audit-as-crates-io = true
+
 [policy.zcash_address]
 audit-as-crates-io = false
 
@@ -124,16 +135,8 @@ criteria = "safe-to-deploy"
 version = "3.0.11"
 criteria = "safe-to-deploy"
 
-[[exemptions.anyhow]]
-version = "1.0.103"
-criteria = "safe-to-deploy"
-
 [[exemptions.arc-swap]]
 version = "1.9.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.argon2]]
-version = "0.5.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.arrayvec]]
@@ -156,14 +159,6 @@ criteria = "safe-to-deploy"
 version = "1.0.17"
 criteria = "safe-to-run"
 
-[[exemptions.aws-lc-rs]]
-version = "1.17.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.aws-lc-sys]]
-version = "0.42.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.axum]]
 version = "0.8.9"
 criteria = "safe-to-deploy"
@@ -184,42 +179,6 @@ criteria = "safe-to-deploy"
 version = "1.8.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.bc-components]]
-version = "0.31.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-crypto]]
-version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-crypto]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-envelope]]
-version = "0.41.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-rand]]
-version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-rand]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-shamir]]
-version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-tags]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bc-ur]]
-version = "0.19.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.bech32]]
 version = "0.8.1"
 criteria = "safe-to-deploy"
@@ -228,12 +187,12 @@ criteria = "safe-to-deploy"
 version = "0.11.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.bellman]]
-version = "0.14.0"
+[[exemptions.bech32]]
+version = "0.12.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.bincode]]
-version = "1.3.3"
+[[exemptions.bellman]]
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bip0039]]
@@ -244,44 +203,12 @@ criteria = "safe-to-deploy"
 version = "0.6.0-pre.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.bitcoin-consensus-encoding]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitcoin-internals]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitcoin-io]]
-version = "0.1.101"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitcoin-private]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitcoin_hashes]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bitcoin_hashes]]
-version = "0.14.101"
-criteria = "safe-to-deploy"
-
 [[exemptions.bitflags]]
 version = "2.13.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.bitflags-serde-legacy]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.bitvec]]
 version = "1.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.blake2]]
-version = "0.10.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.blake2b_simd]]
@@ -308,16 +235,8 @@ criteria = "safe-to-deploy"
 version = "0.5.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.byte-slice-cast]]
-version = "1.2.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.bytes]]
 version = "1.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bzip2-sys]]
-version = "0.1.13+1.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.camino]]
@@ -340,10 +259,6 @@ criteria = "safe-to-deploy"
 version = "1.2.65"
 criteria = "safe-to-deploy"
 
-[[exemptions.cesu8]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.chacha20]]
 version = "0.9.1"
 criteria = "safe-to-deploy"
@@ -354,10 +269,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
 version = "0.4.45"
-criteria = "safe-to-deploy"
-
-[[exemptions.clang-sys]]
-version = "1.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
@@ -384,20 +295,12 @@ criteria = "safe-to-deploy"
 version = "0.2.33"
 criteria = "safe-to-deploy"
 
-[[exemptions.cmake]]
-version = "0.1.58"
-criteria = "safe-to-deploy"
-
 [[exemptions.color-eyre]]
 version = "0.6.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.colorchoice]]
 version = "1.0.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.combine]]
-version = "4.6.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.console]]
@@ -414,10 +317,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.const-crc32-nostd]]
 version = "1.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.const-oid]]
-version = "0.9.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.const_format]]
@@ -440,20 +339,8 @@ criteria = "safe-to-run"
 version = "0.8.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.cookie]]
-version = "0.18.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.cookie-factory]]
 version = "0.3.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.cookie_store]]
-version = "0.22.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.core-foundation]]
-version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.corez]]
@@ -462,14 +349,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.cpufeatures]]
 version = "0.2.17"
-criteria = "safe-to-deploy"
-
-[[exemptions.crc]]
-version = "3.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.crc-catalog]]
-version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.crc32fast]]
@@ -496,10 +375,6 @@ criteria = "safe-to-deploy"
 version = "0.8.20"
 criteria = "safe-to-deploy"
 
-[[exemptions.crypto-bigint]]
-version = "0.5.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.crypto-common]]
 version = "0.1.7"
 criteria = "safe-to-deploy"
@@ -524,26 +399,6 @@ criteria = "safe-to-deploy"
 version = "0.8.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.darling]]
-version = "0.13.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.darling_core]]
-version = "0.13.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.darling_macro]]
-version = "0.20.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.dashmap]]
-version = "6.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.dcbor]]
-version = "0.25.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.deadpool]]
 version = "0.12.3"
 criteria = "safe-to-deploy"
@@ -564,28 +419,12 @@ criteria = "safe-to-deploy"
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.derive_more]]
-version = "2.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.derive_more-impl]]
-version = "2.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.digest]]
 version = "0.10.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.digest]]
 version = "0.11.0-pre.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.dirs]]
-version = "5.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.dirs-sys]]
-version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.displaydoc]]
@@ -600,52 +439,16 @@ criteria = "safe-to-deploy"
 version = "0.9.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.dsa]]
-version = "0.6.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.dyn-clone]]
 version = "1.0.19"
-criteria = "safe-to-deploy"
-
-[[exemptions.ecdsa]]
-version = "0.16.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.ed25519]]
-version = "2.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ed25519-dalek]]
-version = "2.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ed25519-zebra]]
-version = "4.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.elliptic-curve]]
-version = "0.13.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.embed-licensing]]
-version = "0.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.embed-licensing-core]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.embed-licensing-macros]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.encode_unicode]]
 version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.env_logger]]
-version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.eyre]]
@@ -670,10 +473,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.find-msvc-tools]]
 version = "0.1.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.fixed-hash]]
-version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fixedbitset]]
@@ -706,10 +505,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fs-err]]
 version = "3.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fs_extra]]
-version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.funty]]
@@ -761,10 +556,6 @@ version = "0.14.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
-version = "0.1.16"
-criteria = "safe-to-deploy"
-
-[[exemptions.getrandom]]
 version = "0.2.15"
 criteria = "safe-to-deploy"
 
@@ -790,10 +581,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.h2]]
 version = "0.4.15"
-criteria = "safe-to-deploy"
-
-[[exemptions.half]]
-version = "2.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.halo2_legacy_pdqsort]]
@@ -828,18 +615,6 @@ criteria = "safe-to-deploy"
 version = "0.3.9"
 criteria = "safe-to-deploy"
 
-[[exemptions.hex-conservative]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.hex-conservative]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.hex-literal]]
-version = "0.4.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.hkdf]]
 version = "0.12.4"
 criteria = "safe-to-deploy"
@@ -864,17 +639,13 @@ criteria = "safe-to-deploy"
 version = "1.10.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.human_bytes]]
-version = "0.4.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.humantime]]
 version = "2.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.humantime-serde]]
 version = "1.1.1"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.hybrid-array]]
 version = "0.2.3"
@@ -882,10 +653,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.hyper]]
 version = "1.10.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.hyper-rustls]]
-version = "0.27.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-timeout]]
@@ -948,16 +715,8 @@ criteria = "safe-to-deploy"
 version = "1.2.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.impl-codec]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.impl-codec]]
-version = "0.7.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.impl-trait-for-tuples]]
-version = "0.2.3"
+[[exemptions.incrementalmerkletree]]
+version = "0.8.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
 criteria = "safe-to-deploy"
 
 [[exemptions.indenter]]
@@ -976,10 +735,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.ipnet]]
-version = "2.12.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.is-terminal]]
 version = "0.4.16"
 criteria = "safe-to-deploy"
@@ -996,24 +751,8 @@ criteria = "safe-to-deploy"
 version = "0.10.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.itertools]]
-version = "0.13.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.itoa]]
 version = "1.0.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.jni-sys]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.jni-sys]]
-version = "0.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.jni-sys-macros]]
-version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
@@ -1056,20 +795,12 @@ criteria = "safe-to-deploy"
 version = "1.4.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.known-values]]
-version = "0.15.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.konst]]
 version = "0.2.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.konst_macro_rules]]
 version = "0.2.19"
-criteria = "safe-to-deploy"
-
-[[exemptions.lazycell]]
-version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
@@ -1080,20 +811,8 @@ criteria = "safe-to-deploy"
 version = "0.18.5+1.9.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.libloading]]
-version = "0.8.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.libm]]
 version = "0.2.16"
-criteria = "safe-to-deploy"
-
-[[exemptions.libredox]]
-version = "0.1.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.librocksdb-sys]]
-version = "0.16.0+8.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libsqlite3-sys]]
@@ -1102,10 +821,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.libz-sys]]
 version = "1.1.29"
-criteria = "safe-to-deploy"
-
-[[exemptions.libzcash_script]]
-version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
@@ -1124,28 +839,12 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.lmdb]]
-version = "0.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.lmdb-sys]]
-version = "0.8.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.lock_api]]
 version = "0.4.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.log]]
 version = "0.4.33"
-criteria = "safe-to-deploy"
-
-[[exemptions.lru-slab]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.lz4-sys]]
-version = "1.11.1+lz4-1.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.matchit]]
@@ -1160,24 +859,12 @@ criteria = "safe-to-deploy"
 version = "0.2.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.metrics]]
-version = "0.24.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.mime]]
 version = "0.3.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.minicbor]]
-version = "0.19.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.minicbor]]
 version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.minicbor-derive]]
-version = "0.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.minicbor-derive]]
@@ -1192,10 +879,6 @@ criteria = "safe-to-deploy"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.mset]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.multimap]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
@@ -1208,16 +891,8 @@ criteria = "safe-to-deploy"
 version = "0.15.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.nonempty]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.num-bigint]]
 version = "0.4.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.num-bigint-dig]]
-version = "0.8.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.num_cpus]]
@@ -1226,10 +901,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num_threads]]
 version = "0.1.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.objc2-system-configuration]]
-version = "0.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.object]]
@@ -1244,20 +915,12 @@ criteria = "safe-to-deploy"
 version = "1.70.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.openrpsee]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.openssl-probe]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.optfield]]
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ordered-map]]
-version = "0.4.2"
+[[exemptions.orchard]]
+version = "0.15.0-pre.2@git:475ef0ff77d45aebff93cb039d639250d82518a3"
 criteria = "safe-to-deploy"
 
 [[exemptions.os_pipe]]
@@ -1268,28 +931,8 @@ criteria = "safe-to-run"
 version = "4.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.p256]]
-version = "0.13.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.p384]]
-version = "0.13.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.p521]]
-version = "0.13.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.pairing]]
 version = "0.23.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.parity-scale-codec]]
-version = "3.7.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.parity-scale-codec-derive]]
-version = "3.7.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.parking_lot]]
@@ -1306,10 +949,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pasta_curves]]
 version = "0.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.paste]]
-version = "1.0.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.pbkdf2]]
@@ -1333,10 +972,6 @@ version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.phf_macros]]
-version = "0.11.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.phf_macros]]
 version = "0.12.1"
 criteria = "safe-to-deploy"
 
@@ -1356,24 +991,12 @@ criteria = "safe-to-deploy"
 version = "0.2.17"
 criteria = "safe-to-deploy"
 
-[[exemptions.pkcs1]]
-version = "0.7.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.pkcs8]]
-version = "0.10.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.pkg-config]]
 version = "0.3.33"
 criteria = "safe-to-deploy"
 
 [[exemptions.poly1305]]
 version = "0.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.portable-atomic]]
-version = "1.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.potential_utf]]
@@ -1384,36 +1007,8 @@ criteria = "safe-to-deploy"
 version = "0.2.21"
 criteria = "safe-to-deploy"
 
-[[exemptions.pqcrypto-internals]]
-version = "0.2.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.pqcrypto-mldsa]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.pqcrypto-mlkem]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.pqcrypto-traits]]
-version = "0.3.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.prettyplease]]
 version = "0.2.37"
-criteria = "safe-to-deploy"
-
-[[exemptions.primeorder]]
-version = "0.13.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.primitive-types]]
-version = "0.12.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.primitive-types]]
-version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-macro-crate]]
@@ -1440,38 +1035,6 @@ criteria = "safe-to-deploy"
 version = "0.14.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.psl-types]]
-version = "2.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.publicsuffix]]
-version = "2.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.pulldown-cmark]]
-version = "0.13.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.pulldown-cmark-to-cmark]]
-version = "22.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.quickcheck]]
-version = "0.9.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.quickcheck_macros]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.quinn]]
-version = "0.11.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.quinn-proto]]
-version = "0.11.15"
-criteria = "safe-to-deploy"
-
 [[exemptions.quote]]
 version = "1.0.46"
 criteria = "safe-to-deploy"
@@ -1488,34 +1051,6 @@ criteria = "safe-to-deploy"
 version = "0.7.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rand]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_chacha]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_core]]
-version = "0.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_hc]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_xoshiro]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_xoshiro]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rapidhash]]
-version = "4.5.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rayon]]
 version = "1.12.0"
 criteria = "safe-to-deploy"
@@ -1526,14 +1061,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
 version = "0.5.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.redox_users]]
-version = "0.4.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.redox_users]]
-version = "0.4.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.ref-cast]]
@@ -1556,18 +1083,6 @@ criteria = "safe-to-deploy"
 version = "0.8.11"
 criteria = "safe-to-deploy"
 
-[[exemptions.reqwest]]
-version = "0.12.28"
-criteria = "safe-to-deploy"
-
-[[exemptions.reqwest]]
-version = "0.13.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rfc6979]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.ring]]
 version = "0.17.14"
 criteria = "safe-to-deploy"
@@ -1580,14 +1095,6 @@ criteria = "safe-to-deploy"
 version = "0.2.0-pre.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.rlimit]]
-version = "0.10.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.rocksdb]]
-version = "0.22.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.roff]]
 version = "1.1.1"
 criteria = "safe-to-deploy"
@@ -1598,10 +1105,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rpassword]]
 version = "7.5.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.rsa]]
-version = "0.9.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.rtoolbox]]
@@ -1636,10 +1139,6 @@ criteria = "safe-to-deploy"
 version = "2.1.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustc-hex]]
-version = "2.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustix]]
 version = "0.38.44"
 criteria = "safe-to-deploy"
@@ -1652,20 +1151,8 @@ criteria = "safe-to-deploy"
 version = "0.23.41"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustls-native-certs]]
-version = "0.8.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustls-pki-types]]
 version = "1.15.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-platform-verifier]]
-version = "0.6.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-platform-verifier-android]]
-version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
@@ -1675,10 +1162,6 @@ criteria = "safe-to-deploy"
 [[exemptions.rusty-fork]]
 version = "0.3.1"
 criteria = "safe-to-run"
-
-[[exemptions.ryu]]
-version = "1.0.23"
-criteria = "safe-to-deploy"
 
 [[exemptions.salsa20]]
 version = "0.10.2"
@@ -1690,10 +1173,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.sapling-crypto]]
 version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.schannel]]
-version = "0.1.29"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars]]
@@ -1716,28 +1195,12 @@ criteria = "safe-to-deploy"
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.sec1]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.secp256k1]]
 version = "0.29.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.secp256k1]]
-version = "0.30.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.secp256k1]]
-version = "0.31.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.secp256k1-sys]]
 version = "0.10.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.secp256k1-sys]]
-version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.secrecy]]
@@ -1748,24 +1211,12 @@ criteria = "safe-to-deploy"
 version = "0.10.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.security-framework]]
-version = "3.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.security-framework-sys]]
-version = "2.17.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.self_cell]]
 version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.semver]]
 version = "1.0.28"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde-big-array]]
-version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive_internals]]
@@ -1784,18 +1235,6 @@ criteria = "safe-to-deploy"
 version = "1.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde_urlencoded]]
-version = "0.7.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_with]]
-version = "3.17.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_with_macros]]
-version = "3.17.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.serdect]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
@@ -1808,6 +1247,10 @@ criteria = "safe-to-deploy"
 version = "1.7.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.shardtree]]
+version = "0.6.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+criteria = "safe-to-deploy"
+
 [[exemptions.shlex]]
 version = "2.0.1"
 criteria = "safe-to-deploy"
@@ -1818,10 +1261,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.simd-adler32]]
 version = "0.3.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.simple-mermaid]]
-version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.sinsemilla]]
@@ -1860,32 +1299,8 @@ criteria = "safe-to-deploy"
 version = "0.9.8"
 criteria = "safe-to-deploy"
 
-[[exemptions.spki]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.ssh-cipher]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ssh-encoding]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ssh-key]]
-version = "0.6.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.sskr]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.stable_deref_trait]]
 version = "1.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.syn]]
-version = "1.0.109"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
@@ -2012,28 +1427,12 @@ criteria = "safe-to-deploy"
 version = "0.14.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.tonic-reflection]]
-version = "0.14.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.tower]]
 version = "0.4.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.tower]]
 version = "0.5.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-batch-control]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-fallback]]
-version = "0.2.41"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-http]]
-version = "0.6.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.tower-layer]]
@@ -2056,24 +1455,8 @@ criteria = "safe-to-deploy"
 version = "0.1.36"
 criteria = "safe-to-deploy"
 
-[[exemptions.tracing-error]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tracing-futures]]
-version = "0.2.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.tracing-serde]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.tracing-subscriber]]
 version = "0.3.23"
-criteria = "safe-to-deploy"
-
-[[exemptions.tracing-tree]]
-version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.trycmd]]
@@ -2104,24 +1487,12 @@ criteria = "safe-to-deploy"
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.uint]]
-version = "0.10.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.unicase]]
-version = "2.9.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.unicode-ident]]
 version = "1.0.24"
 criteria = "safe-to-deploy"
 
 [[exemptions.untrusted]]
 version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ur]]
-version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.url]]
@@ -2145,23 +1516,11 @@ version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi]]
-version = "0.9.0+wasi-snapshot-preview1"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasi]]
 version = "0.11.0+wasi-snapshot-preview1"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasite]]
-version = "1.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
 version = "0.2.126"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-futures]]
-version = "0.4.76"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
@@ -2176,18 +1535,6 @@ criteria = "safe-to-deploy"
 version = "0.2.126"
 criteria = "safe-to-deploy"
 
-[[exemptions.web-sys]]
-version = "0.3.103"
-criteria = "safe-to-deploy"
-
-[[exemptions.web-time]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.webpki-root-certs]]
-version = "1.0.8"
-criteria = "safe-to-deploy"
-
 [[exemptions.webpki-roots]]
 version = "1.0.8"
 criteria = "safe-to-deploy"
@@ -2198,10 +1545,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.which]]
 version = "8.0.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.whoami]]
-version = "2.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.winapi-util]]
@@ -2252,34 +1595,6 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.zebra-chain]]
-version = "11.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-consensus]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-network]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-node-services]]
-version = "9.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-rpc]]
-version = "11.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-script]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-state]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.zerocopy]]
 version = "0.8.52"
 criteria = "safe-to-deploy"
@@ -2314,10 +1629,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zerovec-derive]]
 version = "0.11.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.zingo_common_components]]
-version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -22,23 +22,9 @@ user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
 
-[[publisher.incrementalmerkletree]]
-version = "0.8.2"
-when = "2025-02-01"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.orchard]]
 version = "0.14.0"
 when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.orchard]]
-version = "0.15.0-pre.2"
-when = "2026-07-03"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -56,13 +42,6 @@ when = "2025-10-26"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
-
-[[publisher.shardtree]]
-version = "0.6.2"
-when = "2026-02-21"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
 
 [[publisher.unicode-normalization]]
 version = "0.1.25"
@@ -91,13 +70,6 @@ when = "2023-12-01"
 user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
-
-[[publisher.wasi]]
-version = "0.14.7+wasi-0.2.4"
-when = "2025-09-15"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
 
 [[publisher.wasip2]]
 version = "1.0.4+wasi-0.2.12"
@@ -149,20 +121,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows-sys]]
-version = "0.45.0"
-when = "2023-01-21"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-sys]]
-version = "0.48.0"
-when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-sys]]
 version = "0.52.0"
 when = "2023-11-15"
 user-id = 64539
@@ -191,20 +149,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows-targets]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-targets]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-targets]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -219,20 +163,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_aarch64_gnullvm]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_gnullvm]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_gnullvm]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -247,20 +177,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_aarch64_msvc]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_msvc]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -270,20 +186,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_aarch64_msvc]]
 version = "0.53.1"
 when = "2025-10-06"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_gnu]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_gnu]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -317,20 +219,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_i686_msvc]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_msvc]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -340,20 +228,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_i686_msvc]]
 version = "0.53.1"
 when = "2025-10-06"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnu]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnu]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -373,20 +247,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_x86_64_gnullvm]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnullvm]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnullvm]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -396,20 +256,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_x86_64_gnullvm]]
 version = "0.53.1"
 when = "2025-10-06"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_msvc]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -489,16 +335,6 @@ user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2026-08-21"
 
-[[audits.bytecode-alliance.wildcard-audits.wasi]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-user-id = 1 # Alex Crichton (alexcrichton)
-start = "2025-08-10"
-end = "2026-08-21"
-notes = """
-This is a Bytecode Alliance authored crate.
-"""
-
 [[audits.bytecode-alliance.wildcard-audits.wasip2]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -546,14 +382,10 @@ criteria = "safe-to-deploy"
 version = "2.0.0"
 notes = "Fork of the original `adler` crate, zero unsfae code, works in `no_std`, does what it says on th tin."
 
-[[audits.bytecode-alliance.audits.allocator-api2]]
-who = "Chris Fallin <chris@cfallin.org>"
+[[audits.bytecode-alliance.audits.anyhow]]
+who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
-delta = "0.2.18 -> 0.2.20"
-notes = """
-The changes appear to be reasonable updates from Rust's stdlib imported into
-`allocator-api2`'s copy of this code.
-"""
+delta = "1.0.69 -> 1.0.71"
 
 [[audits.bytecode-alliance.audits.arrayref]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -621,12 +453,6 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.3 -> 0.3.0"
 notes = "Nothing out of the ordinary, virtually no unsafe code."
-
-[[audits.bytecode-alliance.audits.der]]
-who = "Chris Fallin <chris@cfallin.org>"
-criteria = "safe-to-deploy"
-version = "0.7.10"
-notes = "No unsafe code aside from transmutes for transparent newtypes."
 
 [[audits.bytecode-alliance.audits.embedded-io]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -851,12 +677,6 @@ criteria = "safe-to-deploy"
 delta = "0.37.1 -> 0.37.3"
 notes = "Lots of new support for new object features, no new unsafe or anything suspicious."
 
-[[audits.bytecode-alliance.audits.pem-rfc7468]]
-who = "Chris Fallin <chris@cfallin.org>"
-criteria = "safe-to-deploy"
-version = "0.7.0"
-notes = "Only `unsafe` around a `from_utf8_unchecked`, and no IO."
-
 [[audits.bytecode-alliance.audits.percent-encoding]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -988,6 +808,11 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
 
+[[audits.embark-studios.audits.anyhow]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.58"
+
 [[audits.embark-studios.audits.cargo_metadata]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -1006,12 +831,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 notes = "No unsafe usage or ambient capabilities"
 
-[[audits.embark-studios.audits.derive-new]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.5.9"
-notes = "Proc macro. No unsafe usage or ambient capabilities"
-
 [[audits.embark-studios.audits.ident_case]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -1023,61 +842,6 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 notes = "No unsafe usage or ambient capabilities"
-
-[[audits.embark-studios.audits.jni]]
-who = "Robert Bragg <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.21.1"
-notes = """
-Aims to provide a safe JNI (Java Native Interface) API over the
-unsafe `jni_sys` crate.
-
-This is a very general FFI abstraction for Java VMs with a lot of unsafe code
-throughout the API. There are almost certainly some edge cases with its design
-that could lead to unsound behaviour but it should still be considerably safer
-than working with JNI directly.
-
-A lot of the unsafe usage relates to quite-simple use of `from_raw` APIs to
-construct or cast wrapper types (around JNI pointers) which are fairly
-straight-forward to verify/trust in context.
-
-Some unsafe code has good `// # Safety` documentation (this has been enforced for
-newer code) but a lot of unsafe code doesn't document invariants that are
-being relied on.
-
-The design depends on non-trivial named lifetimes across many APIs to associate
-Java local references with JNI stack frames.
-
-The crate is not very actively maintained and was practically unmaintained for
-over a year before the 0.20 release.
-
-Robert Bragg who now works at Embark Studios became the maintainer of this
-crate in October 2022.
-
-In the process of working on the `jni` crate since becoming maintainer it's
-worth noting that I came across multiple APIs that I found needed to be
-re-worked to address safety issues, including ensuring that APIs that are not
-implemented safely are correctly declared as `unsafe`.
-
-There has been a focus on improving safety in the last two release.
-
-The jni crate has been used in production with the Signal messaging application
-for over two years:
-https://github.com/signalapp/libsignal/blob/main/rust/bridge/jni/Cargo.toml
-
-# Some Notable Open Issues
-- https://github.com/jni-rs/jni-rs/issues/422 - questions soundness of linking
-  multiple versions of jni crate into an application, considering the use
-  of (separately scoped) thread-local-storage to track thread attachments
-- https://github.com/jni-rs/jni-rs/issues/405 - discusses the ease with which
-  code may expose the JVM to invalid booleans with undefined behaviour
-"""
-
-[[audits.embark-studios.audits.schemars]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.8.12"
-notes = "No unsafe usage (forbidden) or ambient capabilities"
 
 [[audits.embark-studios.audits.similar]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -1133,22 +897,6 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.6.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.bitflags]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.3.2"
-notes = """
-Security review of earlier versions of the crate can be found at
-(Google-internal, sorry): go/image-crate-chromium-security-review
-
-The crate exposes a function marked as `unsafe`, but doesn't use any
-`unsafe` blocks (except for tests of the single `unsafe` function).  I
-think this justifies marking this crate as `ub-risk-1`.
-
-Additional review comments can be found at https://crrev.com/c/4723145/31
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.byteorder]]
 who = "danakj <danakj@chromium.org>"
@@ -1293,12 +1041,6 @@ criteria = "safe-to-deploy"
 version = "0.1.46"
 notes = "Contains no unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.num-iter]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-deploy"
-version = "0.1.43"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.num-traits]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -1957,16 +1699,6 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.12.1"
 
-[[audits.isrg.audits.num-iter]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.43 -> 0.1.44"
-
-[[audits.isrg.audits.num-iter]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.44 -> 0.1.45"
-
 [[audits.isrg.audits.once_cell]]
 who = "J.C. Jones <jc@insufficient.coffee>"
 criteria = "safe-to-deploy"
@@ -2109,15 +1841,6 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.5.0 -> 0.5.1"
 
-[[audits.mozilla.wildcard-audits.cexpr]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-user-id = 3788
-start = "2021-06-21"
-end = "2024-04-21"
-notes = "No unsafe code, rather straight-forward parser."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.wildcard-audits.unicode-normalization]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2160,16 +1883,47 @@ criteria = "safe-to-deploy"
 delta = "2.0.0 -> 2.0.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.allocator-api2]]
-who = "Nicolas Silva <nical@fastmail.com>"
-criteria = "safe-to-deploy"
-version = "0.2.18"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.allocator-api2]]
+[[audits.mozilla.audits.anyhow]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
-delta = "0.2.20 -> 0.2.21"
+delta = "1.0.57 -> 1.0.61"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.58 -> 1.0.57"
+notes = "No functional differences, just CI config and docs."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.61 -> 1.0.62"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.62 -> 1.0.68"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.68 -> 1.0.69"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.71 -> 1.0.95"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.95 -> 1.0.103"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.basic-toml]]
@@ -2184,62 +1938,6 @@ who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.2 -> 0.1.9"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-version = "0.59.2"
-notes = "I'm the primary author and maintainer of the crate."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-delta = "0.59.2 -> 0.63.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.63.0 -> 0.64.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.64.0 -> 0.66.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.66.1 -> 0.68.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Andreas Pehrson <apehrson@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.68.1 -> 0.69.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.69.1 -> 0.69.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-delta = "0.69.2 -> 0.69.4"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bindgen]]
-who = "Emilio Cobos Álvarez <emilio@crisal.io>"
-criteria = "safe-to-deploy"
-delta = "0.69.4 -> 0.72.0"
-notes = "I'm the primary maintainer of this crate."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.bit-set]]
 who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
@@ -2289,54 +1987,6 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-c
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.2.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.13.4 -> 0.14.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.14.2 -> 0.14.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.14.3 -> 0.20.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling]]
-who = "Ben Dean-Kawamura <bdk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.20.1 -> 0.20.10"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling_core]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.13.4 -> 0.14.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling_core]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.14.2 -> 0.14.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling_core]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.14.3 -> 0.20.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.darling_core]]
-who = "Ben Dean-Kawamura <bdk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.20.1 -> 0.20.10"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.deranged]]
@@ -2448,12 +2098,6 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.0.7"
 notes = "Simple hasher implementation with no unsafe code."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.foldhash]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.1.5 -> 0.2.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.form_urlencoded]]
@@ -2691,29 +2335,6 @@ criteria = "safe-to-deploy"
 delta = "0.28.0 -> 0.29.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.nix]]
-who = "Gabriele Svelto <gsvelto@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.29.0 -> 0.30.1"
-notes = "Some new wrappers, support for minor platforms and lots of work around type safety that reduces the unsafe surafce."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.objc2-core-foundation]]
-who = "Andy Leiserson <aleiserson@mozilla.com>"
-criteria = "safe-to-deploy"
-version = "0.3.2"
-notes = """
-Contains substantial unsafe code, as is typical for FFI.
-
-The (non-published) `header-translator` crate that produces generated bindings
-in this crate was also reviewed, in lieu of a full review of the generated
-bindings.
-
-Users of this crate should be aware of the information in
-https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.once_cell]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2725,18 +2346,6 @@ who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "1.20.3 -> 1.21.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.option-ext]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-version = "0.2.0"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.paste]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.10 -> 1.0.15"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.percent-encoding]]
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
@@ -2785,55 +2394,6 @@ who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.94 -> 1.0.106"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-version = "0.5.4"
-notes = "This is a small crate, providing safe wrappers around various low-level networking specific operating system features. Given that the Rust standard library does not provide safe wrappers for these low-level features, safe wrappers need to be build in the crate itself, i.e. `quinn-udp`, thus requiring `unsafe` code."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.4 -> 0.5.6"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.6 -> 0.5.8"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.8 -> 0.5.9"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.9 -> 0.5.10"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.10 -> 0.5.11"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.11 -> 0.5.12"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.12 -> 0.5.13"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rand]]
 who = "Henrik Skupin <mail@hskupin.info>"
@@ -2896,13 +2456,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mark Hammond <mhammond@skippinet.com.au>"
 criteria = "safe-to-deploy"
 delta = "0.33.0 -> 0.37.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.rustc-hash]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "1.1.0"
-notes = "Straightforward crate with no unsafe code, does what it says on the tin."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.serde]]
@@ -3172,16 +2725,6 @@ criteria = "safe-to-deploy"
 delta = "0.8.1 -> 0.9.1"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.bindgen]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.69.4 -> 0.69.5"
-notes = """
-Change to `unsafe` block is to switch from `clang_getSpellingLocation` to
-`clang_getFileLocation`; I confirmed these have the same arguments.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.block-buffer]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3242,37 +2785,6 @@ criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.1"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.darling]]
-who = "Schell Carl Scivally <efsubenovex@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.20.10 -> 0.21.3"
-notes = "Mostly added tests and documentation. The bulk of the changes were made to `darling_core`."
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.darling_core]]
-who = "Schell Carl Scivally <efsubenovex@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.20.10 -> 0.21.3"
-notes = "No unsafe, just helpers for proc-macros."
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.dirs]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "5.0.1 -> 6.0.0"
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.dirs-sys]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.4.1 -> 0.5.0"
-notes = """
-One change to an `unsafe` block, adapting to an API change in `windows_sys`
-(`Win32::Foundation::HANDLE` changed from `isize` to `*mut c_void`). I confirmed
-that the Windows documentation permits an argument of `std::ptr::null_mut()`.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.dunce]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3282,18 +2794,6 @@ Does what it says on the tin. No `unsafe`, and the only IO is `std::fs::canonica
 Path and string handling looks plausibly correct.
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.ed25519]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "2.2.1 -> 2.2.2"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.ed25519]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "2.2.2 -> 2.2.3"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.errno]]
 who = "Jack Grigg <jack@electriccoin.co>"
@@ -3425,32 +2925,6 @@ delta = "0.7.0 -> 0.8.0"
 notes = "This release adds `no-std` compatibility."
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
-[[audits.zcash.audits.redox_users]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.4.3 -> 0.4.4"
-notes = "Switches from `redox_syscall` crate to `libredox` crate for syscalls."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.redox_users]]
-who = "Daira-Emma Hopwood <daira@jacaranda.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.4 -> 0.4.5"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.redox_users]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.4.5 -> 0.5.0"
-notes = """
-Changes `Config` from using scheme prefixes (with a default of `file:`) to root
-FS prefixes (with a default of `/`). The behaviour of `Config::scheme` changed
-correspondingly but without being renamed. The effect on the rest of the crate
-is that the passwd, shadow, and group files now default to UNIX-style paths
-(`/etc/passwd`) instead of scheme syntax (`file:etc/passwd`).
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.rustc_version]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3480,17 +2954,6 @@ delta = "1.0.20 -> 1.0.21"
 notes = "Build script change is to fix building with `-Zfmt-debug=none`."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.schemars]]
-who = "Schell Carl Scivally <efsubenovex@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.8.12 -> 0.9.0"
-notes = """
-The changes are primarily API refactoring and simplification, dependency updates, new type implementations, and feature flag reorganization.
-The crate changed from #![forbid(unsafe_code)] (line 9347) to #![deny(unsafe_code)] (line 9348), to accommodate the ref-cast crate integration which requires #[allow(unsafe_code)] on specific functions.
-The only notable change is the ref-cast usage which is a sound pattern for creating transparent newtype wrappers.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.serde]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3516,22 +2979,6 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.1.4 -> 0.1.7"
 notes = "Only change to an `unsafe` block is to fix a clippy lint."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.signature]]
-who = "Daira Emma Hopwood <daira@jacaranda.org>"
-criteria = "safe-to-deploy"
-version = "2.1.0"
-notes = """
-This crate uses `#![forbid(unsafe_code)]`, has no build script, and only provides traits with some trivial default implementations.
-I did not review whether implementing these APIs would present any undocumented cryptographic hazards.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.signature]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "2.1.0 -> 2.2.0"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.strum]]

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -46,6 +46,7 @@ rust-embed.workspace = true
 
 # Parsing and serialization
 base64ct.workspace = true
+bech32 = { workspace = true, optional = true }
 hex.workspace = true
 semver.workspace = true
 serde.workspace = true
@@ -186,10 +187,12 @@ transparent-key-import = [
 zcashd-import = [
   "transparent-key-import",
   "dep:which",
+  "dep:bech32",
   "dep:zewif",
   "dep:zewif-zcashd",
   "zcash_client_backend/zcashd-compat",
   "zcash_client_sqlite/zcashd-compat",
+  "zcash_client_sqlite/zewif",
 ]
 
 [lints.rust]

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -282,6 +282,14 @@ err-migrate-secret-sapling-key-decoding =
 err-migrate-secret-sapling-key-mismatch =
     A Sapling spending key does not correspond to the viewing key it was
     recorded under; the wallet data may be corrupt.
+err-migrate-wallet-export =
+    An error occurred exporting the {-zcashd} wallet to a ZeWIF document: '{$err}'
+err-migrate-wallet-import =
+    An error occurred importing the ZeWIF document into the wallet database: '{$err}'
+err-migrate-wallet-secret-store =
+    An error occurred storing wallet secrets in the keystore: '{$err}'
+err-migrate-wallet-encrypted-secrets =
+    The ZeWIF document's secret material is encrypted; decrypt it before import.
 
 err-ux-A = Did {-zallet} not do what you expected? Could the error be more useful?
 err-ux-B = Tell us

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -263,6 +263,25 @@ err-migrate-wallet-invalid-account-id =
 err-migrate-wallet-all-unmined =
     All transactions in the wallet are unmined; cannot determine effective
     consensus branch ID for pre-v5 transactions.
+err-migrate-secret-non-english-mnemonic =
+    The wallet contains a mnemonic seed phrase using a wordlist other than
+    English; only English mnemonics can be imported.
+err-migrate-secret-fingerprint-encoding =
+    The wallet records an invalid seed fingerprint '{$fingerprint}'.
+err-migrate-secret-fingerprint-mismatch =
+    A stored seed does not match the fingerprint '{$fingerprint}' it was
+    recorded under; the wallet data may be corrupt.
+err-migrate-secret-transparent-key-decoding =
+    The wallet contains a transparent secret key that is not a valid WIF
+    encoding for this network.
+err-migrate-secret-transparent-key-mismatch =
+    A transparent secret key does not correspond to the public key it was
+    recorded under; the wallet data may be corrupt.
+err-migrate-secret-sapling-key-decoding =
+    An error occurred decoding a Sapling spending key: '{$err}'.
+err-migrate-secret-sapling-key-mismatch =
+    A Sapling spending key does not correspond to the viewing key it was
+    recorded under; the wallet data may be corrupt.
 
 err-ux-A = Did {-zallet} not do what you expected? Could the error be more useful?
 err-ux-B = Tell us

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -148,7 +148,7 @@ impl MigrateZcashdWalletCmd {
         .map_err(|e| MigrateError::Zewif {
             error_type: ZewifError::BdbDump,
             wallet_path: wallet_path.to_path_buf(),
-            error: e,
+            error: e.into(),
         })?;
 
         let zcashd_dump =
@@ -156,7 +156,7 @@ impl MigrateZcashdWalletCmd {
                 MigrateError::Zewif {
                     error_type: ZewifError::ZcashdDump,
                     wallet_path: wallet_path.clone(),
-                    error: e,
+                    error: e.into(),
                 }
             })?;
 
@@ -165,7 +165,7 @@ impl MigrateZcashdWalletCmd {
                 MigrateError::Zewif {
                     error_type: ZewifError::ZcashdDump,
                     wallet_path,
-                    error: e,
+                    error: e.into(),
                 }
             })?;
 
@@ -173,15 +173,15 @@ impl MigrateZcashdWalletCmd {
     }
 
     fn check_network(
-        zewif_network: zewif::Network,
+        zewif_network: &zewif::Network,
         network_type: NetworkType,
     ) -> Result<NetworkType, MigrateError> {
         match (zewif_network, network_type) {
-            (zewif::Network::Main, NetworkType::Main) => Ok(()),
-            (zewif::Network::Test, NetworkType::Test) => Ok(()),
-            (zewif::Network::Regtest, NetworkType::Regtest) => Ok(()),
+            (zewif::Network::Mainnet, NetworkType::Main) => Ok(()),
+            (zewif::Network::Testnet, NetworkType::Test) => Ok(()),
+            (zewif::Network::Regtest(_), NetworkType::Regtest) => Ok(()),
             (wallet_network, db_network) => Err(MigrateError::NetworkMismatch {
-                wallet_network,
+                wallet_network: wallet_network.clone(),
                 db_network,
             }),
         }?;
@@ -335,7 +335,12 @@ impl MigrateZcashdWalletCmd {
             },
         )?;
 
-        let mnemonic_seed_data = match Self::parse_mnemonic(wallet.bip39_mnemonic().mnemonic())? {
+        let mnemonic_seed_data = match wallet
+            .bip39_mnemonic()
+            .map(|bip39| Self::parse_mnemonic(bip39.mnemonic()))
+            .transpose()?
+            .flatten()
+        {
             Some(m) => Some((
                 SecretVec::new(m.to_seed("").to_vec()),
                 keystore.encrypt_and_store_mnemonic(m).await?,
@@ -510,9 +515,9 @@ impl MigrateZcashdWalletCmd {
 
         let legacy_seed_data = match wallet.legacy_hd_seed() {
             Some(d) => Some((
-                SecretVec::new(d.seed_data().to_vec()),
+                SecretVec::new(d.as_bytes().to_vec()),
                 keystore
-                    .encrypt_and_store_legacy_seed(&SecretVec::new(d.seed_data().to_vec()))
+                    .encrypt_and_store_legacy_seed(&SecretVec::new(d.as_bytes().to_vec()))
                     .await?,
             )),
             None => None,
@@ -576,8 +581,8 @@ impl MigrateZcashdWalletCmd {
                 .expect("mnemonic seed should be present");
 
             assert_eq!(
-                SeedFingerprint::from_bytes(*account.seed_fingerprint().as_bytes()),
-                *seed_fp
+                account.seed_fingerprint(),
+                &zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&seed_fp.to_bytes()),
             );
 
             let zip32_account_id = AccountId::try_from(account.zip32_account_id())
@@ -623,7 +628,7 @@ impl MigrateZcashdWalletCmd {
             let key_seed_fp = key
                 .metadata()
                 .seed_fp()
-                .map(|seed_fp_bytes| SeedFingerprint::from_bytes(*seed_fp_bytes.as_bytes()));
+                .map(|seed_fp_bytes| SeedFingerprint::from_bytes(*seed_fp_bytes));
 
             let derivation = key
                 .metadata()
@@ -1018,7 +1023,7 @@ pub(crate) enum MigrateError {
     Zewif {
         error_type: ZewifError,
         wallet_path: PathBuf,
-        error: anyhow::Error,
+        error: Box<dyn std::error::Error + Send + Sync>,
     },
     SeedNotAvailable,
     MnemonicInvalid(bip0039::Error),
@@ -1074,7 +1079,11 @@ impl From<MigrateError> for Error {
                 db_network,
             } => Error::from(ErrorKind::Generic.context(fl!(
                 "err-migrate-wallet-network-mismatch",
-                wallet_network = String::from(wallet_network),
+                wallet_network = match wallet_network {
+                    zewif::Network::Mainnet => "main".to_string(),
+                    zewif::Network::Testnet => "test".to_string(),
+                    zewif::Network::Regtest(_) => "regtest".to_string(),
+                },
                 zallet_network = match db_network {
                     NetworkType::Main => "main",
                     NetworkType::Test => "test",

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -1,41 +1,30 @@
-use std::{
-    collections::{HashMap, HashSet, hash_map::Entry},
-    path::PathBuf,
-};
+use std::collections::{BTreeMap, HashMap, HashSet, hash_map::Entry};
+use std::path::PathBuf;
 
 use abscissa_core::Runnable;
 
-use bip0039::{English, Mnemonic};
 use secp256k1::PublicKey;
-use secrecy::{ExposeSecret, SecretVec};
-use shardtree::error::ShardTreeError;
+use secrecy::SecretVec;
 use transparent::address::TransparentAddress;
-use zcash_client_backend::{
-    data_api::{
-        Account as _, AccountBirthday, AccountPurpose, AccountSource, WalletRead, WalletWrite as _,
-        Zip32Derivation, chain::ChainState,
-    },
-    decrypt_transaction,
+use zcash_client_backend::data_api::{
+    Account as _, AccountSource, WalletRead, WalletWrite as _, chain::ChainState,
 };
 use zcash_client_sqlite::error::SqliteClientError;
-use zcash_keys::keys::{
-    DerivationError, UnifiedFullViewingKey,
-    zcashd::{PathParseError, ZcashdHdDerivation},
-};
-use zcash_primitives::{block::BlockHash, transaction::Transaction};
-use zcash_protocol::consensus::{BlockHeight, BranchId, NetworkType, NetworkUpgrade, Parameters};
-use zcash_script::script::{Code, Redeem};
-use zewif_zcashd::{
-    BDBDump, ZcashdDump, ZcashdParser, ZcashdWallet, zcashd_wallet::transparent::WatchScriptKind,
-};
-use zip32::{AccountId, fingerprint::SeedFingerprint};
+use zcash_client_sqlite::zewif::{DiscardSecrets, SecretSink, ZewifImportError, ZewifImportReport};
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
+use zewif_zcashd::{BDBDump, ZcashdDump, ZcashdParser, ZcashdWallet};
+use zip32::fingerprint::SeedFingerprint;
 
 use crate::{
     cli::MigrateZcashdWalletCmd,
     components::{
         chain::{Chain, ChainError, ChainFactory, ChainView},
         database::Database,
-        keystore::KeyStore,
+        keystore::{
+            KeyStore,
+            zewif::{KeyStoreSecretSink, SecretSinkError, decode_seed_fingerprint},
+        },
     },
     error::{Error, ErrorKind},
     fl,
@@ -44,15 +33,16 @@ use crate::{
 
 use super::{AsyncRunnable, migrate_zcash_conf};
 
-/// The ZIP 32 account identifier of the zcashd account used for maintaining legacy `getnewaddress`
-/// and `z_getnewaddress` semantics after the zcashd v4.7.0 upgrade to support using
-/// mnemonic-sourced HD derivation for all addresses in the wallet.
-pub const ZCASHD_LEGACY_ACCOUNT: AccountId = AccountId::const_from_u32(0x7FFFFFFF);
-/// A source string to identify an account as being derived from the randomly generated binary HD
-/// seed used for Sapling key generation prior to the zcashd v4.7.0 upgrade.
+/// The ZIP 32 account identifier of the zcashd account used for maintaining legacy
+/// `getnewaddress` and `z_getnewaddress` semantics after the zcashd v4.7.0 upgrade to
+/// support using mnemonic-sourced HD derivation for all addresses in the wallet.
+pub const ZCASHD_LEGACY_ACCOUNT_INDEX: u32 = 0x7FFFFFFF;
+/// The key-source string with which `zewif-zcashd` labels the synthesized legacy
+/// account, and with which the previous migration implementation labeled accounts
+/// containing imported key material.
 pub const ZCASHD_LEGACY_SOURCE: &str = "zcashd_legacy";
-/// A source string to identify an account as being derived from the mnemonic HD seed used for
-/// key derivation after the zcashd v4.7.0 upgrade.
+/// The key-source string with which `zewif-zcashd` labels accounts derived from the
+/// mnemonic HD seed used for key derivation after the zcashd v4.7.0 upgrade.
 pub const ZCASHD_MNEMONIC_SOURCE: &str = "zcashd_mnemonic";
 
 impl MigrateZcashdWalletCmd {
@@ -86,7 +76,6 @@ impl MigrateZcashdWalletCmd {
             wallet,
             self.buffer_wallet_transactions,
             self.allow_multiple_wallet_imports,
-            self.no_scan,
         )
         .await?;
 
@@ -175,24 +164,20 @@ impl MigrateZcashdWalletCmd {
     fn check_network(
         zewif_network: &zewif::Network,
         network_type: NetworkType,
-    ) -> Result<NetworkType, MigrateError> {
+    ) -> Result<(), MigrateError> {
         match (zewif_network, network_type) {
             (zewif::Network::Mainnet, NetworkType::Main) => Ok(()),
             (zewif::Network::Testnet, NetworkType::Test) => Ok(()),
-            (zewif::Network::Regtest(_), NetworkType::Regtest) => Ok(()),
+            // The ZeWIF importer cannot verify the equivalence of regtest activation
+            // schedules, so regtest migrations are not currently supported.
+            (zewif::Network::Regtest(_), NetworkType::Regtest) => {
+                Err(MigrateError::NetworkNotSupported)
+            }
             (wallet_network, db_network) => Err(MigrateError::NetworkMismatch {
                 wallet_network: wallet_network.clone(),
                 db_network,
             }),
-        }?;
-
-        Ok(network_type)
-    }
-
-    fn parse_mnemonic(mnemonic: &str) -> Result<Option<Mnemonic>, bip0039::Error> {
-        (!mnemonic.is_empty())
-            .then(|| Mnemonic::<English>::from_phrase(mnemonic))
-            .transpose()
+        }
     }
 
     async fn migrate_zcashd_wallet<C: Chain>(
@@ -202,168 +187,13 @@ impl MigrateZcashdWalletCmd {
         wallet: ZcashdWallet,
         buffer_wallet_transactions: bool,
         allow_multiple_wallet_imports: bool,
-        no_scan: bool,
     ) -> Result<(), MigrateError> {
         let mut db_data = db.handle().await?;
         let network_params = *db_data.params();
         Self::check_network(wallet.network(), network_params.network_type())?;
 
-        // Collect transparent material imported via `zcashd`'s `importpubkey` (P2PK
-        // entries in `watch_scripts()`) and `importaddress <redeemScript> "" true`
-        // (entries in `cscripts()`). Address-only entries (raw P2PKH / P2SH hashes with
-        // no associated pubkey or redeem script) cannot be represented in the Zallet
-        // wallet schema; count and warn-log them so users see what was dropped. P2SH
-        // entries with a matching `cscripts()` record are imported via that path below.
-        let mut skipped_p2pkh_address_only = 0usize;
-        let mut skipped_p2sh_address_only = 0usize;
-        let mut skipped_nonstandard = 0usize;
-        let mut skipped_malformed_pubkeys = 0usize;
-        let mut skipped_uncompressed_pubkeys = 0usize;
-        let watchonly_pubkeys = wallet
-            .watch_scripts()
-            .iter()
-            .filter_map(|w| match w.kind() {
-                // `import_standalone_transparent_pubkey` always derives the stored
-                // P2PKH from `PublicKey::serialize()` (the 33-byte compressed form),
-                // so an uncompressed (65-byte) pubkey would be tracked under a
-                // different address than `zcashd` had on-chain. Skip with a warn
-                // rather than silently migrating to the wrong address.
-                WatchScriptKind::P2PK(pubkey) if !pubkey.is_compressed() => {
-                    skipped_uncompressed_pubkeys += 1;
-                    None
-                }
-                WatchScriptKind::P2PK(pubkey) => match PublicKey::from_slice(pubkey.as_slice()) {
-                    Ok(pk) => Some(pk),
-                    Err(_) => {
-                        skipped_malformed_pubkeys += 1;
-                        None
-                    }
-                },
-                WatchScriptKind::P2PKH(_) => {
-                    skipped_p2pkh_address_only += 1;
-                    None
-                }
-                WatchScriptKind::P2SH(_) => {
-                    skipped_p2sh_address_only += 1;
-                    None
-                }
-                WatchScriptKind::Other(_) => {
-                    skipped_nonstandard += 1;
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        if skipped_uncompressed_pubkeys > 0 {
-            warn!(
-                "Skipped {} watch-only P2PK entries with uncompressed public keys; \
-                 the Zallet wallet schema only supports compressed-form pubkey \
-                 imports, so these would be tracked under a different address than \
-                 `zcashd` had on-chain.",
-                skipped_uncompressed_pubkeys,
-            );
-        }
-        if skipped_malformed_pubkeys > 0 {
-            warn!(
-                "Skipped {} watch-only P2PK entries with malformed public keys.",
-                skipped_malformed_pubkeys,
-            );
-        }
-        if skipped_p2pkh_address_only > 0 {
-            warn!(
-                "Skipped {} watch-only P2PKH address-only entries (from `zcashd`'s \
-                 `importaddress <p2pkhaddress>`); these cannot be migrated without the \
-                 corresponding pubkey.",
-                skipped_p2pkh_address_only,
-            );
-        }
-        if skipped_p2sh_address_only > 0 {
-            warn!(
-                "Skipped {} watch-only P2SH address-only entries (`watchs` records with \
-                 no matching `cscript`). P2SH entries with a matching redeem script are \
-                 imported via the `cscript` path.",
-                skipped_p2sh_address_only,
-            );
-        }
-        if skipped_nonstandard > 0 {
-            warn!(
-                "Skipped {} watch-only entries with non-standard script kinds.",
-                skipped_nonstandard,
-            );
-        }
-        let mut skipped_unparseable_scripts = 0usize;
-        let watchonly_scripts = wallet
-            .cscripts()
-            .values()
-            .filter_map(|s| match Redeem::parse(&Code(s.as_ref().to_vec())) {
-                Ok(redeem) => Some(redeem),
-                Err(e) => {
-                    skipped_unparseable_scripts += 1;
-                    warn!(
-                        "Failed to parse watch-only redeem script (hex: {}): {}",
-                        hex::encode(s.as_ref()),
-                        e,
-                    );
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        if skipped_unparseable_scripts > 0 {
-            warn!(
-                "Skipped {} watch-only redeem scripts that failed to parse in total.",
-                skipped_unparseable_scripts,
-            );
-        }
-
-        let existing_zcash_sourced_accounts = db_data.get_account_ids()?.into_iter().try_fold(
-            HashSet::new(),
-            |mut found, account_id| {
-                let account = db_data
-                    .get_account(account_id)?
-                    .expect("account exists for just-retrieved id");
-
-                match account.source() {
-                    AccountSource::Derived {
-                        derivation,
-                        key_source,
-                    } if key_source.as_ref() == Some(&ZCASHD_MNEMONIC_SOURCE.to_string()) => {
-                        found.insert(*derivation.seed_fingerprint());
-                    }
-                    _ => {}
-                }
-
-                Ok::<_, SqliteClientError>(found)
-            },
-        )?;
-
-        let mnemonic_seed_data = match wallet
-            .bip39_mnemonic()
-            .map(|bip39| Self::parse_mnemonic(bip39.mnemonic()))
-            .transpose()?
-            .flatten()
-        {
-            Some(m) => Some((
-                SecretVec::new(m.to_seed("").to_vec()),
-                keystore.encrypt_and_store_mnemonic(m).await?,
-            )),
-            None => None,
-        };
-
-        if !existing_zcash_sourced_accounts.is_empty() {
-            if allow_multiple_wallet_imports {
-                if let Some((seed, _)) = mnemonic_seed_data.as_ref() {
-                    let seed_fp =
-                        SeedFingerprint::from_seed(seed.expose_secret()).expect("valid length");
-                    if existing_zcash_sourced_accounts.contains(&seed_fp) {
-                        return Err(MigrateError::DuplicateImport(seed_fp));
-                    }
-                }
-            } else {
-                return Err(MigrateError::MultiImportDisabled);
-            }
-        }
-
-        // Obtain information about the current state of the chain, so that we can set the recovery
-        // height properly.
+        // Obtain information about the current state of the chain, so that we can set
+        // the recovery height properly.
         let (chain_view, chain_tip) = if let Some(chain) = &chain {
             let chain_view = chain.snapshot().await?;
             let tip = chain_view.tip().await?;
@@ -379,66 +209,157 @@ impl MigrateZcashdWalletCmd {
             .activation_height(NetworkUpgrade::Sapling)
             .expect("Sapling activation height is defined.");
 
-        // Collect an index from block hash to block height for all transactions known to the
-        // wallet that appear in the main chain. This only runs when we have a chain subscriber;
-        // without one, all transactions are stored as unmined and a later scan will assign
-        // accurate heights. Address exposure is handled separately via
-        // `mark_transparent_addresses_exposed` below.
+        // The export height records the chain tip at export time. Without a chain
+        // backend, approximate it with the wallet's maximum transaction expiry height
+        // (expiry heights are near the height at which a transaction was created).
+        let export_height = chain_tip
+            .or_else(|| {
+                wallet
+                    .transactions()
+                    .values()
+                    .map(|tx| u32::from(tx.transaction().expiry_height()))
+                    .filter(|&h| h > 0)
+                    .max()
+                    .map(BlockHeight::from_u32)
+            })
+            .unwrap_or(sapling_activation);
+
+        // Export the parsed wallet to a ZeWIF document. Everything below operates on
+        // the document alone.
+        info!("Exporting the zcashd wallet to a ZeWIF document");
+        let document = zewif_zcashd::migrate_to_zewif(
+            &wallet,
+            zewif::BlockHeight::from_u32(u32::from(export_height)),
+        )
+        .map_err(MigrateError::Export)?;
+        drop(wallet);
+
         info!(
-            "Wallet contains {} transactions",
-            wallet.transactions().len(),
+            "Wallet document contains {} transactions",
+            document.transactions().len(),
         );
-        let mut main_chain_block_heights = HashMap::new();
-        if let Some(chain_view) = chain_view.as_ref() {
-            for wallet_tx in wallet.transactions().values() {
-                let block_hash = BlockHash(*wallet_tx.hash_block().as_ref());
-                // Skip transactions that were unmined when the zcashd wallet was last written.
-                if block_hash.0 != [0; 32]
-                    && let Entry::Vacant(entry) = main_chain_block_heights.entry(block_hash)
+
+        // Normalize the secret store and the legacy account's derivation to zcashd's
+        // post-v4.7.0 semantics: zcashd derives legacy-account (0x7FFFFFFF) keys from
+        // the seed of its BIP 39 mnemonic, deriving that mnemonic from the pre-v4.7.0
+        // legacy seed where one exists. A pre-v4.7.0 wallet's document carries only the
+        // raw legacy seed, so reconstruct the mnemonic exactly as zcashd would have on
+        // upgrade, and re-point the legacy account's key source at it.
+        let secret_store = match document.secrets() {
+            Some(zewif::Secrets::Plain(store)) => Some(store.clone()),
+            Some(zewif::Secrets::Encrypted(_)) => return Err(MigrateError::EncryptedSecrets),
+            None => None,
+        };
+        let (secret_store, mnemonic_fp) = match secret_store {
+            Some(mut store) => {
+                let mnemonic_fp = store.seeds().iter().find_map(|entry| {
+                    matches!(entry.material(), zewif::SeedMaterial::Bip39Mnemonic(_))
+                        .then(|| entry.fingerprint().clone())
+                });
+                let legacy_seed = store
+                    .seeds()
+                    .iter()
+                    .find_map(|entry| match entry.material() {
+                        zewif::SeedMaterial::LegacySeed(seed) => Some(*seed.as_bytes()),
+                        _ => None,
+                    });
+                let mnemonic_fp = match (mnemonic_fp, legacy_seed) {
+                    (Some(fp), _) => Some(fp),
+                    (None, Some(seed_bytes)) => {
+                        let seed = SecretVec::new(seed_bytes.to_vec());
+                        let mnemonic = zcash_keys::keys::zcashd::derive_mnemonic(&seed).ok_or(
+                            ErrorKind::Generic.context(fl!("err-failed-seed-fingerprinting")),
+                        )?;
+                        let fp = SeedFingerprint::from_seed(&mnemonic.to_seed(""))
+                            .expect("BIP 39 seeds have a valid length");
+                        let fp =
+                            zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&fp.to_bytes());
+                        store.add_seed(zewif::SeedEntry::new(
+                            fp.clone(),
+                            zewif::SeedMaterial::Bip39Mnemonic(zewif::Bip39Mnemonic::new(
+                                mnemonic.phrase(),
+                                Some(zewif::MnemonicLanguage::English),
+                            )),
+                        ));
+                        Some(fp)
+                    }
+                    (None, None) => None,
+                };
+                (Some(store), mnemonic_fp)
+            }
+            None => (None, None),
+        };
+
+        // Check whether this wallet (identified by its mnemonic seed fingerprint) has
+        // already been imported, and whether additional wallet imports are permitted.
+        let existing_zcashd_sourced_accounts = db_data.get_account_ids()?.into_iter().try_fold(
+            HashSet::new(),
+            |mut found, account_id| {
+                let account = db_data
+                    .get_account(account_id)?
+                    .expect("account exists for just-retrieved id");
+
+                if let AccountSource::Derived {
+                    derivation,
+                    key_source,
+                } = account.source()
+                    && matches!(
+                        key_source.as_deref(),
+                        Some(ZCASHD_MNEMONIC_SOURCE) | Some(ZCASHD_LEGACY_SOURCE)
+                    )
                 {
-                    // Ignore any blocks that are not in the main chain.
-                    if let Some(height) = chain_view.block_height(&block_hash).await? {
-                        entry.insert(height);
+                    found.insert(*derivation.seed_fingerprint());
+                }
+
+                Ok::<_, SqliteClientError>(found)
+            },
+        )?;
+        if !existing_zcashd_sourced_accounts.is_empty() {
+            if allow_multiple_wallet_imports {
+                if let Some(fp) = mnemonic_fp.as_ref().and_then(decode_seed_fingerprint)
+                    && existing_zcashd_sourced_accounts.contains(&fp)
+                {
+                    return Err(MigrateError::DuplicateImport(fp));
+                }
+            } else {
+                return Err(MigrateError::MultiImportDisabled);
+            }
+        }
+
+        // Determine the wallet's birthday. With a chain backend, resolve the block
+        // hashes recorded on the document's transactions to main-chain heights, take
+        // the earliest as the birthday, and fetch the chain state (including the note
+        // commitment tree frontiers) as of the prior block; the importer then
+        // constructs precise account birthdays with no further chain access. In
+        // no-scan mode, estimate a conservative birthday from transaction expiry
+        // heights; the importer will schedule a rescan from there.
+        let (birthday_chain_state, recover_until) = if let Some(chain_view) = chain_view.as_ref() {
+            let mut block_heights = HashMap::new();
+            for tx in document.transactions().values() {
+                if let Some(position) = tx.block_position() {
+                    let block_hash = BlockHash(*position.block_hash().as_bytes());
+                    if let Entry::Vacant(entry) = block_heights.entry(block_hash) {
+                        // Ignore any blocks that are not in the main chain.
+                        if let Some(height) = chain_view.block_height(&block_hash).await? {
+                            entry.insert(height);
+                        }
                     }
                 }
             }
-        }
-        let mut tx_heights = HashMap::new();
-        for (txid, wallet_tx) in wallet.transactions().iter() {
-            let block_hash = BlockHash(*wallet_tx.hash_block().as_ref());
-            tx_heights.insert(
-                txid,
-                (
-                    main_chain_block_heights.get(&block_hash).cloned(),
-                    buffer_wallet_transactions.then_some(wallet_tx),
-                ),
+            info!(
+                "Wallet document references {} mined main-chain blocks",
+                block_heights.len(),
             );
-        }
-        info!(
-            "Wallet contains {} mined transactions",
-            tx_heights.values().filter(|(h, _)| h.is_some()).count(),
-        );
 
-        // Since zcashd scans in linear order, we can reliably choose the earliest wallet
-        // transaction's mined height as the birthday height, so long as it is in the "stable"
-        // range. We don't have a good source of individual per-account birthday information at
-        // this point; once we've imported all of the transaction data into the wallet then we'll
-        // be able to choose per-account birthdays without difficulty.
-        let wallet_birthday = if let Some(chain_view) = chain_view.as_ref() {
-            // Fall back to the chain tip height, and then Sapling activation as a last resort.
-            // If we have a birthday height, max() that with sapling activation; that will be
-            // the minimum possible wallet birthday that is relevant to future recovery
-            // scenarios.
-            let birthday_height = tx_heights
+            let birthday_height = block_heights
                 .values()
-                .flat_map(|(h, _)| h)
                 .min()
                 .copied()
                 .or(chain_tip)
                 .map_or(sapling_activation, |h| std::cmp::max(h, sapling_activation));
 
-            // Fetch the tree state corresponding to the last block prior to the wallet's
-            // birthday height.
+            // Fetch the tree state corresponding to the last block prior to the
+            // wallet's birthday height.
             let treestate_height = birthday_height.saturating_sub(1);
             let chain_state = chain_view.tree_state_as_of(treestate_height).await?.ok_or(
                 ErrorKind::Generic.context(fl!(
@@ -446,561 +367,350 @@ impl MigrateZcashdWalletCmd {
                     err = format!("missing tree state for height {treestate_height}")
                 )),
             )?;
+            info!("Setting the wallet birthday to height {}", birthday_height);
 
-            AccountBirthday::from_parts(chain_state, chain_tip)
+            (Some(to_zewif_chain_state(&chain_state)), chain_tip)
         } else {
-            // In no-scan mode, no chain is available, and we cannot determine actual transaction
-            // mined heights. Instead, we estimate the wallet's birthday, and then conservatively
-            // mark each address with a mined transaction as exposed at that birthday height.
-            //
-            // We approximate the wallet birthday from transaction expiry heights. Expiry heights
-            // are typically creation_height + 40 (the default TX_EXPIRY_DELTA in zcashd).
-            // Subtracting 1000 gives a conservative lower bound on the earliest mined height.
-            let birthday_height = wallet
-                .transactions()
-                .values()
-                .map(|tx| u32::from(tx.transaction().expiry_height()))
-                .filter(|&h| h > 0)
-                .min()
-                .map(|h| BlockHeight::from_u32(h.saturating_sub(1000)))
-                .map(|h| std::cmp::max(h, sapling_activation))
-                .unwrap_or(sapling_activation);
-
-            AccountBirthday::from_parts(
-                ChainState::empty(birthday_height, BlockHash([0; 32])),
-                None,
-            )
+            (None, None)
         };
-        info!(
-            "Setting the wallet birthday to height {}",
-            wallet_birthday.height(),
-        );
-
-        let mnemonic_seed_fp = mnemonic_seed_data.as_ref().map(|(_, fp)| *fp);
-        let legacy_transparent_account_uuid = if let Some((seed, _)) = mnemonic_seed_data.as_ref() {
-            // Create the legacy account if there are any legacy transparent keys or any
-            // imported watch-only transparent pubkeys / redeem scripts to store.
-            if !wallet.keys().is_empty()
-                || !watchonly_pubkeys.is_empty()
-                || !watchonly_scripts.is_empty()
-            {
-                let (account, _) = db_data.import_account_hd(
-                    &format!(
-                        "zcashd post-v4.7.0 legacy transparent account {}",
-                        u32::from(ZCASHD_LEGACY_ACCOUNT),
-                    ),
-                    seed,
-                    ZCASHD_LEGACY_ACCOUNT,
-                    &wallet_birthday,
-                    Some(ZCASHD_MNEMONIC_SOURCE),
-                )?;
-
-                println!(
-                    "{}",
-                    fl!(
-                        "migrate-wallet-legacy-seed-fp",
-                        seed_fp = mnemonic_seed_fp
-                            .expect("present for mnemonic seed")
-                            .to_string()
-                    )
-                );
-
-                Some(account.id())
-            } else {
-                None
-            }
+        let no_scan_birthday_estimate = if chain_view.is_none() {
+            // Expiry heights are typically creation_height + 40 (the default
+            // TX_EXPIRY_DELTA in zcashd). Subtracting 1000 gives a conservative lower
+            // bound on the earliest mined height.
+            Some(
+                document
+                    .transactions()
+                    .values()
+                    .filter_map(|tx| tx.expiry_height())
+                    .map(u32::from)
+                    .filter(|&h| h > 0)
+                    .min()
+                    .map(|h| BlockHeight::from_u32(h.saturating_sub(1000)))
+                    .map(|h| std::cmp::max(h, sapling_activation))
+                    .unwrap_or(sapling_activation),
+            )
         } else {
             None
         };
 
-        let legacy_seed_data = match wallet.legacy_hd_seed() {
-            Some(d) => Some((
-                SecretVec::new(d.as_bytes().to_vec()),
-                keystore
-                    .encrypt_and_store_legacy_seed(&SecretVec::new(d.as_bytes().to_vec()))
-                    .await?,
-            )),
-            None => None,
-        };
-        let legacy_transparent_account_uuid =
-            match (legacy_transparent_account_uuid, legacy_seed_data.as_ref()) {
-                (Some(uuid), _) => {
-                    // We already had a mnemonic seed and have created the mnemonic-based legacy
-                    // account, so we don't need to do anything.
-                    Some(uuid)
-                }
-                (None, Some((seed, _)))
-                    if !wallet.keys().is_empty()
-                        || !watchonly_pubkeys.is_empty()
-                        || !watchonly_scripts.is_empty() =>
-                {
-                    // In this case, we have the legacy seed, but no mnemonic seed was ever derived
-                    // from it, so this is a pre-v4.7.0 wallet. We construct the mnemonic in the same
-                    // fashion as zcashd, by using the legacy seed as entropy in the generation of the
-                    // mnemonic seed, and then import that seed and the associated legacy account so
-                    // that we have an account to act as the "bucket of funds" for the transparent keys
-                    // derived from system randomness.
-                    let mnemonic = zcash_keys::keys::zcashd::derive_mnemonic(seed)
-                        .ok_or(ErrorKind::Generic.context(fl!("err-failed-seed-fingerprinting")))?;
-
-                    let seed = SecretVec::new(mnemonic.to_seed("").to_vec());
-                    keystore.encrypt_and_store_mnemonic(mnemonic).await?;
-                    let (account, _) = db_data.import_account_hd(
-                        &format!(
-                            "zcashd post-v4.7.0 legacy transparent account {}",
-                            u32::from(ZCASHD_LEGACY_ACCOUNT),
-                        ),
-                        &seed,
-                        ZCASHD_LEGACY_ACCOUNT,
-                        &wallet_birthday,
-                        Some(ZCASHD_MNEMONIC_SOURCE),
-                    )?;
-
-                    Some(account.id())
-                }
-                _ => None,
-            };
-
-        let legacy_seed_fp = legacy_seed_data.map(|(_, fp)| fp);
-
-        // Add unified accounts. The only source of unified accounts in zcashd is derivation from
-        // the mnemonic seed.
-        if wallet.unified_accounts().account_metadata.is_empty() {
-            info!("Wallet contains no unified accounts (z_getnewaccount was never used)");
-        } else {
-            info!(
-                "Importing {} unified accounts (created with z_getnewaccount)",
-                wallet.unified_accounts().account_metadata.len()
-            );
-        }
-        for account in wallet.unified_accounts().account_metadata.values() {
-            // The only way that a unified account could be created in zcashd was
-            // to be derived from the mnemonic seed, so we can safely unwrap here.
-            let (seed, seed_fp) = mnemonic_seed_data
-                .as_ref()
-                .expect("mnemonic seed should be present");
-
-            assert_eq!(
-                account.seed_fingerprint(),
-                &zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&seed_fp.to_bytes()),
-            );
-
-            let zip32_account_id = AccountId::try_from(account.zip32_account_id())
-                .map_err(|_| MigrateError::AccountIdInvalid(account.zip32_account_id()))?;
-
-            if db_data
-                .get_derived_account(&Zip32Derivation::new(*seed_fp, zip32_account_id, None))?
-                .is_none()
-            {
-                db_data.import_account_hd(
-                    &format!(
-                        "zcashd imported unified account {}",
-                        account.zip32_account_id()
-                    ),
-                    seed,
-                    zip32_account_id,
-                    &wallet_birthday,
-                    Some(ZCASHD_MNEMONIC_SOURCE),
-                )?;
-            }
-        }
-
-        // Sapling keys may originate from:
-        // * The legacy HD seed, under a standard ZIP 32 key path
-        // * The mnemonic HD seed, under a standard ZIP 32 key path
-        // * The mnemonic HD seed, under the "legacy" account with an additional hardened path element
-        // * Zcashd Sapling spending key import
-        info!("Importing legacy Sapling keys"); // TODO: Expose how many there are in zewif-zcashd.
-        for (idx, key) in wallet.sapling_keys().keypairs().enumerate() {
-            if idx % 100 == 0 && idx > 0 {
-                info!("Processed {} legacy Sapling keys", idx);
-            }
-            // `zewif_zcashd` parses to an earlier version of the `sapling` types, so we
-            // must roundtrip through the byte representation into the version we need.
-            let extsk = sapling::zip32::ExtendedSpendingKey::from_bytes(&key.extsk().to_bytes())
-                .map_err(|_| ()) //work around missing Debug impl
-                .expect("Sapling extsk encoding is stable across sapling-crypto versions");
-            #[allow(deprecated)]
-            let extfvk = extsk.to_extended_full_viewing_key();
-            let ufvk =
-                UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(extfvk.clone())?;
-
-            let key_seed_fp = key
-                .metadata()
-                .seed_fp()
-                .map(|seed_fp_bytes| SeedFingerprint::from_bytes(*seed_fp_bytes));
-
-            let derivation = key
-                .metadata()
-                .hd_keypath()
-                .map(|keypath| ZcashdHdDerivation::parse_hd_path(&network_params, keypath))
-                .transpose()?
-                .zip(key_seed_fp)
-                .map(|(derivation, key_seed_fp)| match derivation {
-                    ZcashdHdDerivation::Zip32 { account_id } => {
-                        Zip32Derivation::new(key_seed_fp, account_id, None)
-                    }
-                    ZcashdHdDerivation::Post470LegacySapling { address_index } => {
-                        Zip32Derivation::new(
-                            key_seed_fp,
-                            ZCASHD_LEGACY_ACCOUNT,
-                            Some(address_index),
-                        )
-                    }
-                });
-
-            // If the key is not associated with either of the seeds, treat it as a standalone
-            // imported key
-            if key_seed_fp != mnemonic_seed_fp && key_seed_fp != legacy_seed_fp {
-                keystore
-                    .encrypt_and_store_standalone_sapling_key(&extsk)
-                    .await?;
-            }
-
-            let account_exists = match key_seed_fp.as_ref() {
-                Some(fp) => db_data
-                    .get_derived_account(&Zip32Derivation::new(
-                        *fp,
-                        ZCASHD_LEGACY_ACCOUNT,
-                        derivation.as_ref().and_then(|d| d.legacy_address_index()),
-                    ))?
-                    .is_some(),
-                None => db_data.get_account_for_ufvk(&ufvk)?.is_some(),
-            };
-
-            if !account_exists {
-                db_data.import_account_ufvk(
-                    &format!("zcashd legacy sapling {idx}"),
-                    &ufvk,
-                    &wallet_birthday,
-                    AccountPurpose::Spending { derivation },
-                    Some(ZCASHD_LEGACY_SOURCE),
-                )?;
-            }
-        }
-
-        // Import view-only Sapling keys added via `z_importviewingkey`. zcashd stores these as
-        // `sapextfvk` BDB records; each extended FVK becomes its own view-only account, matching
-        // how each spending-key entry becomes its own account above. If both `z_importkey` and
-        // `z_importviewingkey` were called for the same key, the spending-key path already created
-        // the account, so the `get_account_for_ufvk` check below skips the duplicate.
-        let viewing_keys = wallet.sapling_extended_full_viewing_keys();
-        info!("Importing {} view-only Sapling keys", viewing_keys.len());
-        for (idx, zewif_extfvk) in viewing_keys.values().enumerate() {
-            if idx % 100 == 0 && idx > 0 {
-                info!("Processed {} view-only Sapling keys", idx);
-            }
-            // `zewif-zcashd` parses Sapling types against an older `sapling-crypto`. The ZIP 32
-            // extended FVK encoding is 169 bytes and stable across versions, so round-trip through
-            // bytes to get the version this crate uses.
-            let mut bytes = [0u8; 169];
-            zewif_extfvk
-                .write(&mut bytes[..])
-                .expect("Sapling extended FVK fits in 169 bytes");
-            let extfvk = sapling::zip32::ExtendedFullViewingKey::read(&bytes[..])
-                .expect("Sapling extended FVK encoding is stable across sapling-crypto versions");
-            let ufvk = UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(extfvk)?;
-
-            if db_data.get_account_for_ufvk(&ufvk)?.is_none() {
-                db_data.import_account_ufvk(
-                    &format!("zcashd imported view-only sapling {idx}"),
-                    &ufvk,
-                    &wallet_birthday,
-                    AccountPurpose::ViewOnly,
-                    Some(ZCASHD_LEGACY_SOURCE),
-                )?;
-            }
-        }
-
-        // TODO: Move this into zewif-zcashd once we're out of dependency version hell.
-        fn convert_key(
-            key: &zewif_zcashd::zcashd_wallet::transparent::KeyPair,
-        ) -> Result<zcash_keys::keys::transparent::Key, MigrateError> {
-            // Check the encoding of the pubkey
-            let _ = PublicKey::from_slice(key.pubkey().as_slice())?;
-            let compressed = key.pubkey().is_compressed();
-
-            let key = zcash_keys::keys::transparent::Key::der_decode(
-                &SecretVec::new(key.privkey().data().to_vec()),
-                compressed,
-            )
-            .map_err(|_| {
-                ErrorKind::Generic.context(fl!(
-                    "err-migrate-wallet-key-decoding",
-                    err = "failed DER decoding"
-                ))
-            })?;
-
-            Ok(key)
-        }
-
-        // Collect transparent addresses that need to be explicitly marked as exposed at the
-        // wallet birthday; `mark_transparent_addresses_exposed` consumes this set below.
-        // Otherwise `listaddresses` (which filters on `exposed_at_height IS NOT NULL`) would
-        // never surface them. Two sources feed this set:
-        //   * Every address imported standalone (privkey, pubkey, or P2SH redeem script) or
-        //     watch-only (from `importaddress` / `importpubkey`), accumulated below as each
-        //     import succeeds, since these have no on-chain derivation history that a chain
-        //     scan would discover.
-        //   * In no-scan mode, every address observed in the wallet's transaction set, since
-        //     the chain will not be scanned to detect exposure heights.
-        let mut to_expose: HashSet<TransparentAddress> = HashSet::new();
-
-        let encryptor = keystore.encryptor().await?;
-        let transparent_keypairs = wallet.keys().keypairs().collect::<Vec<_>>();
-        info!(
-            "Importing {} legacy standalone transparent keys",
-            transparent_keypairs.len(),
-        ); // TODO: Expose how many there are in zewif-zcashd.
-        let encrypted_transparent_keys = transparent_keypairs
-            .into_iter()
-            .map(|key| {
-                let key = convert_key(key)?;
-                encryptor.encrypt_standalone_transparent_key(&key)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        keystore
-            .store_encrypted_standalone_transparent_keys(&encrypted_transparent_keys)
-            .await?;
-        let standalone_pubkeys: Vec<PublicKey> = encrypted_transparent_keys
-            .iter()
-            .map(|key| *key.pubkey())
-            .collect();
-        to_expose.extend(
-            standalone_pubkeys
-                .iter()
-                .map(TransparentAddress::from_pubkey),
+        let document = enriched_document(
+            &document,
+            secret_store,
+            mnemonic_fp.as_ref(),
+            birthday_chain_state.as_ref(),
+            recover_until,
+            no_scan_birthday_estimate,
+            buffer_wallet_transactions,
         );
-        db_data.import_standalone_transparent_pubkeys(
-            legacy_transparent_account_uuid.ok_or(MigrateError::SeedNotAvailable)?,
-            standalone_pubkeys.into_iter(),
-        )?;
 
-        // Import transparent addresses that were added to the `zcashd` wallet via
-        // `importaddress` / `importpubkey` (i.e. watch-only imports). These are stored as
-        // `watchs` and `cscript` records in `wallet.dat`, and `zewif-zcashd` does not
-        // currently surface them through its parsed `ZcashdWallet` type.
-        if !watchonly_pubkeys.is_empty() || !watchonly_scripts.is_empty() {
-            let target_account =
-                legacy_transparent_account_uuid.ok_or(MigrateError::SeedNotAvailable)?;
-
+        // Persist all spending material in the keystore before any wallet-database
+        // write occurs. This runs outside the wallet database's write lock: the
+        // keystore shares that lock, so diverting secrets from within `import_wallet`
+        // (which holds the write lock for its whole run) would deadlock.
+        let mut sink = KeyStoreSecretSink::new(&keystore, network_params).await?;
+        if let Some(zewif::Secrets::Plain(store)) = document.secrets() {
             info!(
-                "Importing {} watch-only transparent pubkeys",
-                watchonly_pubkeys.len(),
+                "Storing {} seeds, {} transparent keys, and {} Sapling keys in the keystore",
+                store.seeds().len(),
+                store.transparent_keys().len(),
+                store.sapling_keys().len(),
             );
-            to_expose.extend(
-                watchonly_pubkeys
-                    .iter()
-                    .map(TransparentAddress::from_pubkey),
+            for entry in store.seeds() {
+                sink.store_seed(entry).map_err(MigrateError::SecretSink)?;
+            }
+            for entry in store.transparent_keys() {
+                sink.store_transparent_key(entry)
+                    .map_err(MigrateError::SecretSink)?;
+            }
+            for entry in store.sapling_keys() {
+                sink.store_sapling_key(entry)
+                    .map_err(MigrateError::SecretSink)?;
+            }
+            for entry in store.sprout_keys() {
+                sink.store_sprout_key(entry)
+                    .map_err(MigrateError::SecretSink)?;
+            }
+            for entry in store.unified_keys() {
+                sink.store_unified_key(entry)
+                    .map_err(MigrateError::SecretSink)?;
+            }
+            if sink.sprout_keys_ignored() > 0 {
+                warn!(
+                    "The wallet contains {} Sprout spending keys, which Zallet does not \
+                     support; move any Sprout funds using zcashd before migrating.",
+                    sink.sprout_keys_ignored(),
+                );
+            }
+            if sink.unified_keys_ignored() > 0 {
+                warn!(
+                    "The wallet contains {} extracted unified spending keys, which \
+                     Zallet does not support storing.",
+                    sink.unified_keys_ignored(),
+                );
+            }
+        }
+        if let Some(fp) = mnemonic_fp.as_ref() {
+            println!(
+                "{}",
+                fl!("migrate-wallet-legacy-seed-fp", seed_fp = fp.encoding())
             );
-            db_data.import_standalone_transparent_pubkeys(
-                target_account,
-                watchonly_pubkeys.into_iter(),
-            )?;
+        }
 
-            info!(
-                "Importing {} watch-only transparent redeem scripts",
-                watchonly_scripts.len(),
-            );
-            let mut skipped_unsupported_scripts = 0usize;
-            for script in watchonly_scripts {
-                let script_addr =
-                    TransparentAddress::from_script_pubkey(&zcash_script::descriptor::sh(&script));
-                // A P2SH descriptor should always produce a valid scriptPubKey from which
-                // `TransparentAddress` can be parsed; if not, our exposure-marking step
-                // below will silently miss this address, so log it.
-                if script_addr.is_none() {
-                    warn!(
-                        "P2SH descriptor unexpectedly produced no `TransparentAddress`; \
-                         the imported script will not be marked as exposed.",
+        // Import the document. All secret material was persisted above, so the
+        // importer's sink discards its (repeated) deliveries.
+        info!("Importing the ZeWIF document into the wallet database");
+        let report = db_data
+            .with_mut(|mut wdb| {
+                zcash_client_sqlite::zewif::import_wallet(&mut wdb, &document, &mut DiscardSecrets)
+            })
+            .map_err(MigrateError::Import)?;
+
+        log_import_report(&report);
+
+        // Register watch-only transparent pubkeys (from zcashd's `importpubkey`) with
+        // the accounts whose address lists carry them. The ZeWIF importer registers
+        // spendable transparent keys from the secret store and P2SH redeem scripts,
+        // but has no path for pubkey-only (watch) addresses.
+        let accounts_by_name: HashMap<&str, zcash_client_sqlite::AccountUuid> = report
+            .imported_accounts
+            .iter()
+            .map(|a| (a.name.as_str(), a.account_uuid))
+            .collect();
+        let exposure_height = birthday_chain_state
+            .as_ref()
+            .map(|cs| BlockHeight::from_u32(u32::from(cs.height()) + 1))
+            .or(no_scan_birthday_estimate)
+            .unwrap_or(sapling_activation);
+        let mut skipped_uncompressed_watch_pubkeys = 0usize;
+        for wallet in document.wallets() {
+            for account in wallet.accounts() {
+                let Some(account_uuid) = accounts_by_name.get(account.name()) else {
+                    continue;
+                };
+                let mut watch_pubkeys = Vec::new();
+                for address in account.addresses() {
+                    if let zewif::ProtocolAddress::Transparent(t) = address.address()
+                        && t.spend_authority().is_none()
+                        && let Some(pubkey) = t.pubkey()
+                    {
+                        // `import_standalone_transparent_pubkeys` derives the stored
+                        // P2PKH address from the compressed pubkey serialization, so an
+                        // uncompressed pubkey would be tracked under a different
+                        // address than zcashd had on-chain.
+                        match PublicKey::from_slice(pubkey.as_slice()) {
+                            Ok(pk) if pubkey.as_slice().len() == 33 => watch_pubkeys.push(pk),
+                            _ => skipped_uncompressed_watch_pubkeys += 1,
+                        }
+                    }
+                }
+                if !watch_pubkeys.is_empty() {
+                    info!(
+                        "Registering {} watch-only transparent pubkeys with account '{}'",
+                        watch_pubkeys.len(),
+                        account.name(),
                     );
-                    debug_assert!(false, "sh() descriptor should always yield an address");
-                }
-                // `import_standalone_transparent_script` currently only accepts multisig
-                // redeem scripts within the P2SH size limit; treat those rejections
-                // (`SqliteClientError::BadAccountData`) as warn-and-skip so a single
-                // unsupported script does not abort the migration. Any other error
-                // (corrupted data, DB failure, conflict, ...) is propagated.
-                match db_data.import_standalone_transparent_script(target_account, script) {
-                    Ok(()) => {
-                        if let Some(addr) = script_addr {
-                            to_expose.insert(addr);
-                        }
-                    }
-                    Err(SqliteClientError::BadAccountData(msg)) => {
-                        skipped_unsupported_scripts += 1;
-                        warn!("Skipping unsupported watch-only redeem script: {}", msg);
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-            if skipped_unsupported_scripts > 0 {
-                warn!(
-                    "Skipped {} unsupported watch-only redeem scripts in total.",
-                    skipped_unsupported_scripts,
-                );
-            }
-        }
-
-        // In no-scan mode, also mark every address observed in the wallet's transaction set,
-        // since the chain will not be scanned to detect exposure heights.
-        if no_scan {
-            let mut buf = vec![];
-            for wallet_tx in wallet.transactions().values() {
-                buf.clear();
-                wallet_tx.transaction().write(&mut buf)?;
-                // We only read the transparent bundle here, so the branch id chosen here
-                // is irrelevant: for v5+ txs the embedded branch id overrides this value,
-                // and for earlier versions the branch id is only stored as metadata and
-                // does not affect parsing of the transparent bundle. Any value works.
-                //
-                // The buffer-path below uses `BranchId::for_height` instead because it
-                // re-parses the transaction for full decryption, where the branch id
-                // does affect the result for earlier-version txs.
-                let tx = Transaction::read(buf.as_slice(), BranchId::Sprout)?;
-                if let Some(bundle) = tx.transparent_bundle() {
-                    for vout in &bundle.vout {
-                        if let Some(addr) = vout
-                            .script_kind()
-                            .as_ref()
-                            .and_then(TransparentAddress::from_script_kind)
-                        {
-                            to_expose.insert(addr);
-                        }
-                    }
-                }
-            }
-        }
-
-        if !to_expose.is_empty() {
-            // The upstream API rolls back the whole batch if any address is not tracked,
-            // so filter to just the wallet's known receivers (external counterparties drop
-            // out here).
-            let mut known: HashSet<TransparentAddress> = HashSet::new();
-            for account_id in db_data.get_account_ids()? {
-                known.extend(
+                    let to_expose: Vec<(TransparentAddress, BlockHeight)> = watch_pubkeys
+                        .iter()
+                        .map(|pk| (TransparentAddress::from_pubkey(pk), exposure_height))
+                        .collect();
                     db_data
-                        .get_transparent_receivers(
-                            account_id, true, // include_change
-                            true, // include_standalone
-                        )?
-                        .into_keys(),
-                );
-            }
-
-            let birthday_height = wallet_birthday.height();
-            let to_mark: Vec<(TransparentAddress, BlockHeight)> = to_expose
-                .intersection(&known)
-                .map(|addr| (*addr, birthday_height))
-                .collect();
-            // Surface any address we queued for exposure marking but that does not
-            // appear in `known`. This should be empty in steady state; a non-zero
-            // count signals that an import-path above produced a different address
-            // than what was stored in the wallet (e.g. encoding mismatches), which
-            // would otherwise be invisible.
-            let dropped = to_expose.difference(&known).count();
-            if dropped > 0 {
-                warn!(
-                    "{} transparent addresses queued for exposure marking were not \
-                     tracked by any account and were skipped; an import path may \
-                     have stored them under a different address.",
-                    dropped,
-                );
-            }
-            if !to_mark.is_empty() {
-                db_data.mark_transparent_addresses_exposed(&to_mark)?;
-                info!(
-                    "Marked {} transparent addresses as exposed at birthday height {}",
-                    to_mark.len(),
-                    birthday_height,
-                );
+                        .import_standalone_transparent_pubkeys(
+                            *account_uuid,
+                            watch_pubkeys.into_iter(),
+                        )
+                        .map_err(MigrateError::Database)?;
+                    db_data
+                        .mark_transparent_addresses_exposed(&to_expose)
+                        .map_err(MigrateError::Database)?;
+                }
             }
         }
-
-        // Since we've retrieved the raw transaction data anyway, preemptively store it for faster
-        // access to balance & to set priorities in the scan queue.
-        if buffer_wallet_transactions {
-            info!("Importing transactions");
-
-            // Fetch the UnifiedFullViewingKeys we are tracking
-            let ufvks = db_data.get_unified_full_viewing_keys()?;
-
-            let chain_tip_height = db_data.chain_height()?;
-
-            // Assume that the zcashd wallet was shut down immediately after its last
-            // transaction was mined. This will be accurate except in the following case:
-            // - User mines a transaction in any older epoch.
-            // - A network upgrade activates.
-            // - User creates a transaction.
-            // - User shuts down the wallet before the transaction is mined.
-            let assumed_mempool_height = tx_heights
-                .values()
-                .flat_map(|(h, _)| h)
-                .max()
-                .map(|h| *h + 1);
-
-            let mut buf = vec![];
-            let decoded_txs = tx_heights
-                .values()
-                .flat_map(|(h, wallet_tx)| {
-                    wallet_tx.map(|wallet_tx| {
-                        let consensus_height = match h {
-                            Some(h) => *h,
-                            None => {
-                                let expiry_height =
-                                    u32::from(wallet_tx.transaction().expiry_height());
-                                if expiry_height == 0 {
-                                    // Transaction is unmined and unexpired, use fallback.
-                                    assumed_mempool_height.ok_or_else(|| {
-                                        ErrorKind::Generic
-                                            .context(fl!("err-migrate-wallet-all-unmined"))
-                                    })?
-                                } else {
-                                    // A transaction's expiry height is always in same epoch
-                                    // as its eventual mined height.
-                                    BlockHeight::from_u32(expiry_height)
-                                }
-                            }
-                        };
-                        let consensus_branch_id =
-                            BranchId::for_height(&network_params, consensus_height);
-                        // TODO: Use the same zcash_primitives version in zewif-zcashd
-                        let tx = {
-                            buf.clear();
-                            wallet_tx.transaction().write(&mut buf)?;
-                            Transaction::read(buf.as_slice(), consensus_branch_id)?
-                        };
-                        Ok((tx, *h))
-                    })
-                })
-                .collect::<Result<Vec<_>, MigrateError>>()?;
-
-            info!("Decrypting {} transactions", decoded_txs.len());
-            let decrypted_txs = decoded_txs
-                .iter()
-                .enumerate()
-                .map(|(i, (tx, mined_height))| {
-                    if i % 1000 == 0 && i > 0 {
-                        tracing::info!("Decrypted {i}/{} transactions", decoded_txs.len());
-                    }
-                    decrypt_transaction(
-                        &network_params,
-                        *mined_height,
-                        chain_tip_height,
-                        tx,
-                        &ufvks,
-                    )
-                })
-                .collect::<Vec<_>>();
-
-            info!("Storing {} decrypted transactions", decrypted_txs.len());
-            // TODO: Use chunking here if we add support for resuming migrations.
-            db_data.store_decrypted_txs(decrypted_txs)?;
-        } else {
-            info!("Not importing transactions (--buffer-wallet-transactions not set)");
+        if skipped_uncompressed_watch_pubkeys > 0 {
+            warn!(
+                "Skipped {} watch-only entries with uncompressed or malformed public \
+                 keys; Zallet only supports compressed-form pubkey imports.",
+                skipped_uncompressed_watch_pubkeys,
+            );
         }
 
         Ok(())
+    }
+}
+
+/// Converts a chain-backend `ChainState` into its ZeWIF representation, preserving
+/// the note commitment tree frontiers of every shielded pool.
+fn to_zewif_chain_state(chain_state: &ChainState) -> zewif::ChainState {
+    let mut out = zewif::ChainState::new(zewif::BlockHeight::from_u32(u32::from(
+        chain_state.block_height(),
+    )));
+    out.set_block_hash(zewif::BlockHash::from_bytes(chain_state.block_hash().0));
+    out.set_sapling_tree(to_zewif_frontier(
+        chain_state.final_sapling_tree(),
+        |node| node.to_bytes(),
+    ));
+    out.set_orchard_tree(to_zewif_frontier(
+        chain_state.final_orchard_tree(),
+        |node| node.to_bytes(),
+    ));
+    out.set_ironwood_tree(to_zewif_frontier(
+        chain_state.final_ironwood_tree(),
+        |node| node.to_bytes(),
+    ));
+    out
+}
+
+/// Converts an `incrementalmerkletree` frontier into its ZeWIF representation.
+fn to_zewif_frontier<H, const DEPTH: u8>(
+    frontier: &incrementalmerkletree::frontier::Frontier<H, DEPTH>,
+    node_bytes: impl Fn(&H) -> [u8; 32],
+) -> zewif::Frontier {
+    match frontier.value() {
+        None => zewif::Frontier::Empty,
+        Some(frontier) => zewif::Frontier::NonEmpty(zewif::FrontierData::from_parts(
+            u64::from(frontier.position()),
+            zewif::MerkleNode::new(node_bytes(frontier.leaf())),
+            frontier
+                .ommers()
+                .iter()
+                .map(|ommer| zewif::MerkleNode::new(node_bytes(ommer)))
+                .collect(),
+        )),
+    }
+}
+
+/// Rebuilds `document` with Zallet's enrichments applied.
+///
+/// The ZeWIF document model does not expose mutable access to the accounts of an
+/// assembled document, so enrichment reassembles it:
+///
+/// * the (possibly normalized) secret store replaces the original;
+/// * the legacy account's key source is re-pointed at the mnemonic seed, matching
+///   zcashd's post-v4.7.0 derivation semantics;
+/// * account birthdays are replaced with the chain-derived birthday state where one
+///   was computed, and defaulted to the no-scan estimate where the document records
+///   nothing; and
+/// * transactions are dropped unless `--buffer-wallet-transactions` was given.
+fn enriched_document(
+    document: &zewif::Zewif,
+    secret_store: Option<zewif::SecretStore>,
+    mnemonic_fp: Option<&zewif::SeedFingerprint>,
+    birthday_chain_state: Option<&zewif::ChainState>,
+    recover_until: Option<BlockHeight>,
+    no_scan_birthday_estimate: Option<BlockHeight>,
+    buffer_wallet_transactions: bool,
+) -> zewif::Zewif {
+    let mut out = zewif::Zewif::new(
+        document.export_height(),
+        document.export_height_block_hash(),
+    );
+
+    for wallet in document.wallets() {
+        let mut out_wallet = zewif::ZewifWallet::new(wallet.network().clone());
+        for account in wallet.accounts() {
+            let mut account = account.clone();
+
+            // Normalize the legacy account's derivation to the mnemonic seed.
+            if let (Some(mnemonic_fp), Some(zewif::KeySource::Derived(derived))) =
+                (mnemonic_fp, account.key_source())
+                && derived.account_index() == ZCASHD_LEGACY_ACCOUNT_INDEX
+                && derived.seed_fingerprint() != mnemonic_fp
+            {
+                let legacy_address_index = derived.legacy_address_index();
+                account.set_key_source(zewif::KeySource::Derived(zewif::DerivedKeySource::new(
+                    mnemonic_fp.clone(),
+                    ZCASHD_LEGACY_ACCOUNT_INDEX,
+                    legacy_address_index,
+                )));
+            }
+
+            if let Some(chain_state) = birthday_chain_state {
+                account.set_birthday_chain_state(chain_state.clone());
+                if let Some(height) = recover_until {
+                    account
+                        .set_recover_until_height(zewif::BlockHeight::from_u32(u32::from(height)));
+                }
+            } else if account.birthday_height().is_none()
+                && account.birthday_chain_state().is_none()
+                && let Some(estimate) = no_scan_birthday_estimate
+            {
+                account.set_birthday_height(zewif::BlockHeight::from_u32(u32::from(estimate)));
+            }
+
+            out_wallet.add_account(account);
+        }
+        for entry in wallet.address_book() {
+            out_wallet.add_address_book_entry(entry.clone());
+        }
+        *out_wallet.extensions_mut() = wallet.extensions().clone();
+        out.add_wallet(out_wallet);
+    }
+
+    if buffer_wallet_transactions {
+        out.set_transactions(document.transactions().clone());
+    } else {
+        out.set_transactions(BTreeMap::new());
+    }
+
+    if let Some(store) = secret_store {
+        out.set_secrets(zewif::Secrets::Plain(store));
+    }
+
+    *out.extensions_mut() = document.extensions().clone();
+    out
+}
+
+/// Logs the outcome of a ZeWIF document import.
+fn log_import_report(report: &ZewifImportReport) {
+    for account in &report.imported_accounts {
+        info!(
+            "Imported account '{}' as {:?} (birthday basis: {:?})",
+            account.name, account.account_uuid, account.birthday_basis,
+        );
+    }
+    for skipped in &report.skipped_accounts {
+        warn!(
+            "Account '{}' was not imported: {:?}",
+            skipped.name, skipped.reason,
+        );
+    }
+    info!(
+        "Registered {} standalone transparent keys and {} P2SH redeem scripts",
+        report.transparent_keys_registered, report.redeem_scripts_registered,
+    );
+    if !report.skipped_transparent_keys.is_empty() {
+        warn!(
+            "{} transparent spending keys could not be registered with any account",
+            report.skipped_transparent_keys.len(),
+        );
+    }
+    if report.redeem_scripts_not_representable > 0 {
+        warn!(
+            "Skipped {} watch-only redeem scripts that the wallet cannot represent",
+            report.redeem_scripts_not_representable,
+        );
+    }
+    info!(
+        "Marked {} transparent addresses as exposed",
+        report.addresses_marked_exposed,
+    );
+    if report.transactions_stored > 0 || report.transactions_without_wallet_relevance > 0 {
+        info!(
+            "Stored {} wallet transactions ({} were not relevant to any imported account)",
+            report.transactions_stored, report.transactions_without_wallet_relevance,
+        );
+    }
+    if report.transactions_without_raw_data > 0 {
+        warn!(
+            "{} transactions carried no raw data and were not stored",
+            report.transactions_without_raw_data,
+        );
+    }
+    if report.address_book_entries_not_imported > 0 {
+        warn!(
+            "The wallet's address book ({} entries) was not migrated; Zallet does not \
+             yet store address book entries.",
+            report.address_book_entries_not_imported,
+        );
     }
 }
 
@@ -1017,7 +727,6 @@ pub(crate) enum ZewifError {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum MigrateError {
     Wrapped(Error),
     Zewif {
@@ -1025,20 +734,16 @@ pub(crate) enum MigrateError {
         wallet_path: PathBuf,
         error: Box<dyn std::error::Error + Send + Sync>,
     },
-    SeedNotAvailable,
-    MnemonicInvalid(bip0039::Error),
-    KeyError(secp256k1::Error),
+    Export(zewif_zcashd::migrate::MigrateError),
+    Import(ZewifImportError<std::convert::Infallible>),
+    SecretSink(SecretSinkError),
+    EncryptedSecrets,
     NetworkMismatch {
         wallet_network: zewif::Network,
         db_network: NetworkType,
     },
-    NetworkNotSupported(NetworkType),
+    NetworkNotSupported,
     Database(SqliteClientError),
-    Tree(ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>),
-    Io(std::io::Error),
-    KeyDerivation(DerivationError),
-    HdPath(PathParseError),
-    AccountIdInvalid(u32),
     MultiImportDisabled,
     DuplicateImport(SeedFingerprint),
 }
@@ -1063,17 +768,19 @@ impl From<MigrateError> for Error {
                     err = error.to_string()
                 )),
             }),
-            MigrateError::SeedNotAvailable => {
-                Error::from(ErrorKind::Generic.context(fl!("err-migrate-wallet-seed-absent")))
+            MigrateError::Export(e) => Error::from(
+                ErrorKind::Generic.context(fl!("err-migrate-wallet-export", err = e.to_string())),
+            ),
+            MigrateError::Import(e) => Error::from(
+                ErrorKind::Generic.context(fl!("err-migrate-wallet-import", err = e.to_string())),
+            ),
+            MigrateError::SecretSink(e) => Error::from(
+                ErrorKind::Generic
+                    .context(fl!("err-migrate-wallet-secret-store", err = e.to_string())),
+            ),
+            MigrateError::EncryptedSecrets => {
+                Error::from(ErrorKind::Generic.context(fl!("err-migrate-wallet-encrypted-secrets")))
             }
-            MigrateError::MnemonicInvalid(error) => Error::from(ErrorKind::Generic.context(fl!(
-                "err-migrate-wallet-invalid-mnemonic",
-                err = error.to_string()
-            ))),
-            MigrateError::KeyError(error) => Error::from(ErrorKind::Generic.context(fl!(
-                "err-migrate-wallet-key-decoding",
-                err = error.to_string()
-            ))),
             MigrateError::NetworkMismatch {
                 wallet_network,
                 db_network,
@@ -1090,7 +797,7 @@ impl From<MigrateError> for Error {
                     NetworkType::Regtest => "regtest",
                 }
             ))),
-            MigrateError::NetworkNotSupported(_) => {
+            MigrateError::NetworkNotSupported => {
                 Error::from(ErrorKind::Generic.context(fl!("err-migrate-wallet-regtest")))
             }
             MigrateError::Database(sqlite_client_error) => {
@@ -1099,25 +806,6 @@ impl From<MigrateError> for Error {
                     err = sqlite_client_error.to_string()
                 )))
             }
-            MigrateError::Tree(e) => Error::from(
-                ErrorKind::Generic
-                    .context(fl!("err-migrate-wallet-data-parse", err = e.to_string())),
-            ),
-            MigrateError::Io(e) => Error::from(
-                ErrorKind::Generic
-                    .context(fl!("err-migrate-wallet-data-parse", err = e.to_string())),
-            ),
-            MigrateError::KeyDerivation(e) => Error::from(
-                ErrorKind::Generic.context(fl!("err-migrate-wallet-key-data", err = e.to_string())),
-            ),
-            MigrateError::HdPath(err) => Error::from(ErrorKind::Generic.context(fl!(
-                "err-migrate-wallet-data-parse",
-                err = format!("{:?}", err)
-            ))),
-            MigrateError::AccountIdInvalid(id) => Error::from(ErrorKind::Generic.context(fl!(
-                "err-migrate-wallet-invalid-account-id",
-                account_id = id
-            ))),
             MigrateError::MultiImportDisabled => Error::from(
                 ErrorKind::Generic.context(fl!("err-migrate-wallet-multi-import-disabled")),
             ),
@@ -1131,21 +819,9 @@ impl From<MigrateError> for Error {
     }
 }
 
-impl From<ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>> for MigrateError {
-    fn from(e: ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>) -> Self {
-        Self::Tree(e)
-    }
-}
-
 impl From<SqliteClientError> for MigrateError {
     fn from(e: SqliteClientError) -> Self {
         Self::Database(e)
-    }
-}
-
-impl From<bip0039::Error> for MigrateError {
-    fn from(value: bip0039::Error) -> Self {
-        Self::MnemonicInvalid(value)
     }
 }
 
@@ -1164,29 +840,5 @@ impl From<abscissa_core::error::Context<ErrorKind>> for MigrateError {
 impl From<ChainError> for MigrateError {
     fn from(value: ChainError) -> Self {
         MigrateError::Wrapped(value.into())
-    }
-}
-
-impl From<std::io::Error> for MigrateError {
-    fn from(value: std::io::Error) -> Self {
-        MigrateError::Io(value)
-    }
-}
-
-impl From<DerivationError> for MigrateError {
-    fn from(value: DerivationError) -> Self {
-        MigrateError::KeyDerivation(value)
-    }
-}
-
-impl From<PathParseError> for MigrateError {
-    fn from(value: PathParseError) -> Self {
-        MigrateError::HdPath(value)
-    }
-}
-
-impl From<secp256k1::Error> for MigrateError {
-    fn from(value: secp256k1::Error) -> Self {
-        MigrateError::KeyError(value)
     }
 }

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -842,3 +842,164 @@ impl From<ChainError> for MigrateError {
         MigrateError::Wrapped(value.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use incrementalmerkletree::{Position, frontier::Frontier};
+    use orchard::tree::MerkleHashOrchard;
+    use zcash_protocol::consensus::{BlockHeight, NetworkType};
+
+    use super::{
+        MigrateError, MigrateZcashdWalletCmd, ZCASHD_LEGACY_ACCOUNT_INDEX, enriched_document,
+        to_zewif_frontier,
+    };
+
+    fn node(byte: u8) -> MerkleHashOrchard {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        MerkleHashOrchard::from_bytes(&bytes).expect("valid field element")
+    }
+
+    #[test]
+    fn check_network_accepts_matching_networks() {
+        assert!(
+            MigrateZcashdWalletCmd::check_network(&zewif::Network::Mainnet, NetworkType::Main)
+                .is_ok()
+        );
+        assert!(
+            MigrateZcashdWalletCmd::check_network(&zewif::Network::Testnet, NetworkType::Test)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn check_network_rejects_mismatch_and_regtest() {
+        assert!(matches!(
+            MigrateZcashdWalletCmd::check_network(&zewif::Network::Testnet, NetworkType::Main),
+            Err(MigrateError::NetworkMismatch { .. })
+        ));
+        assert!(matches!(
+            MigrateZcashdWalletCmd::check_network(
+                &zewif::Network::Regtest(zewif::RegtestParams::default()),
+                NetworkType::Regtest,
+            ),
+            Err(MigrateError::NetworkNotSupported)
+        ));
+    }
+
+    #[test]
+    fn frontier_conversion_preserves_structure() {
+        let empty: Frontier<MerkleHashOrchard, 32> = Frontier::empty();
+        assert!(matches!(
+            to_zewif_frontier(&empty, |n| n.to_bytes()),
+            zewif::Frontier::Empty
+        ));
+
+        let frontier: Frontier<MerkleHashOrchard, 32> =
+            Frontier::from_parts(Position::from(1), node(2), vec![node(3)])
+                .expect("valid frontier");
+        match to_zewif_frontier(&frontier, |n| n.to_bytes()) {
+            zewif::Frontier::NonEmpty(data) => {
+                assert_eq!(data.position(), 1);
+                assert_eq!(data.leaf().as_bytes(), &node(2).to_bytes());
+                assert_eq!(data.ommers().len(), 1);
+                assert_eq!(data.ommers()[0].as_bytes(), &node(3).to_bytes());
+            }
+            zewif::Frontier::Empty => panic!("frontier should be non-empty"),
+        }
+    }
+
+    fn test_document() -> (zewif::Zewif, zewif::SeedFingerprint, zewif::SeedFingerprint) {
+        let legacy_fp = zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&[1u8; 32]);
+        let mnemonic_fp = zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&[2u8; 32]);
+
+        let mut document = zewif::Zewif::new(
+            zewif::BlockHeight::from_u32(2_000_000),
+            zewif::BlockHash::from_bytes([9u8; 32]),
+        );
+        let mut wallet = zewif::ZewifWallet::new(zewif::Network::Testnet);
+
+        let mut legacy = zewif::Account::new(zewif::AccountViewingKey::TransparentAddressSet);
+        legacy.set_name("Legacy");
+        legacy.set_key_source(zewif::KeySource::Derived(zewif::DerivedKeySource::new(
+            legacy_fp.clone(),
+            ZCASHD_LEGACY_ACCOUNT_INDEX,
+            None,
+        )));
+        wallet.add_account(legacy);
+        document.add_wallet(wallet);
+
+        let txid = zewif::TxId::from_bytes([4u8; 32]);
+        document.add_transaction(txid, zewif::Transaction::new(txid));
+
+        (document, legacy_fp, mnemonic_fp)
+    }
+
+    #[test]
+    fn enrichment_normalizes_legacy_derivation_and_strips_transactions() {
+        let (document, _legacy_fp, mnemonic_fp) = test_document();
+
+        let enriched = enriched_document(
+            &document,
+            None,
+            Some(&mnemonic_fp),
+            None,
+            None,
+            Some(BlockHeight::from_u32(1_900_000)),
+            false,
+        );
+
+        let account = &enriched.wallets()[0].accounts()[0];
+        match account.key_source() {
+            Some(zewif::KeySource::Derived(derived)) => {
+                assert_eq!(derived.seed_fingerprint(), &mnemonic_fp);
+                assert_eq!(derived.account_index(), ZCASHD_LEGACY_ACCOUNT_INDEX);
+            }
+            other => panic!("unexpected key source: {other:?}"),
+        }
+        // The no-scan estimate fills in the missing birthday.
+        assert_eq!(
+            account.birthday_height(),
+            Some(zewif::BlockHeight::from_u32(1_900_000))
+        );
+        assert!(enriched.transactions().is_empty());
+    }
+
+    #[test]
+    fn enrichment_applies_chain_state_and_retains_transactions() {
+        let (document, legacy_fp, _mnemonic_fp) = test_document();
+
+        let mut chain_state = zewif::ChainState::new(zewif::BlockHeight::from_u32(1_500_000));
+        chain_state.set_block_hash(zewif::BlockHash::from_bytes([8u8; 32]));
+
+        let enriched = enriched_document(
+            &document,
+            None,
+            None,
+            Some(&chain_state),
+            Some(BlockHeight::from_u32(2_000_000)),
+            None,
+            true,
+        );
+
+        let account = &enriched.wallets()[0].accounts()[0];
+        // Without a mnemonic fingerprint the legacy derivation is untouched.
+        match account.key_source() {
+            Some(zewif::KeySource::Derived(derived)) => {
+                assert_eq!(derived.seed_fingerprint(), &legacy_fp);
+            }
+            other => panic!("unexpected key source: {other:?}"),
+        }
+        assert_eq!(
+            account
+                .birthday_chain_state()
+                .map(|cs| u32::from(cs.height())),
+            Some(1_500_000)
+        );
+        assert_eq!(
+            account.recover_until_height(),
+            Some(zewif::BlockHeight::from_u32(2_000_000))
+        );
+        assert_eq!(enriched.transactions().len(), 1);
+    }
+}

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -188,32 +188,6 @@ impl DbConnection {
             })
         })
     }
-
-    /// Caches decrypted transactions in the persistent wallet store.
-    ///
-    /// This creates a single database transaction for all inserts, significantly reducing
-    /// overhead for large migrated wallets.
-    #[cfg(feature = "zcashd-import")]
-    pub(crate) fn store_decrypted_txs(
-        &mut self,
-        received_txs: Vec<DecryptedTransaction<'_, Transaction, AccountUuid>>,
-    ) -> Result<
-        (),
-        <WalletDb<rusqlite::Connection, Network, SystemClock, OsRng> as WalletRead>::Error,
-    > {
-        self.with_mut(|mut db_data| {
-            db_data.transactionally(|wdb| {
-                let total = received_txs.len();
-                for (i, received_tx) in received_txs.into_iter().enumerate() {
-                    if i % 100 == 0 && i > 0 {
-                        tracing::info!("Stored {i}/{total} transactions");
-                    }
-                    wdb.store_decrypted_tx(received_tx)?;
-                }
-                Ok(())
-            })
-        })
-    }
 }
 
 impl WalletRead for DbConnection {

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -145,6 +145,11 @@ pub(super) mod db;
 mod error;
 pub(crate) use error::KeystoreError;
 
+#[cfg(feature = "zcashd-import")]
+// TODO: remove the dead-code allowance once the migrate command consumes the sink.
+#[allow(dead_code)]
+pub(crate) mod zewif;
+
 type RelockTask = (SystemTime, JoinHandle<()>);
 
 #[derive(Clone)]

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -146,8 +146,6 @@ mod error;
 pub(crate) use error::KeystoreError;
 
 #[cfg(feature = "zcashd-import")]
-// TODO: remove the dead-code allowance once the migrate command consumes the sink.
-#[allow(dead_code)]
 pub(crate) mod zewif;
 
 type RelockTask = (SystemTime, JoinHandle<()>);
@@ -920,13 +918,6 @@ impl Encryptor {
 pub(crate) struct EncryptedStandaloneTransparentKey {
     pubkey: secp256k1::PublicKey,
     encrypted_key_bytes: Vec<u8>,
-}
-
-#[cfg(feature = "transparent-key-import")]
-impl EncryptedStandaloneTransparentKey {
-    pub(crate) fn pubkey(&self) -> &secp256k1::PublicKey {
-        &self.pubkey
-    }
 }
 
 fn encrypt_string(

--- a/zallet-core/src/components/keystore/zewif.rs
+++ b/zallet-core/src/components/keystore/zewif.rs
@@ -47,6 +47,18 @@ macro_rules! wfl {
 /// The Human-Readable Part of the canonical ZIP 32 seed fingerprint encoding.
 const SEED_FINGERPRINT_HRP: &str = "zip32seedfp";
 
+/// Decodes a seed fingerprint from its canonical `zip32seedfp` Bech32m
+/// encoding, returning `None` if the encoding is not a valid fingerprint.
+pub(crate) fn decode_seed_fingerprint(
+    fingerprint: &zewif::SeedFingerprint,
+) -> Option<SeedFingerprint> {
+    let checked = CheckedHrpstring::new::<Bech32m>(fingerprint.encoding()).ok()?;
+    (checked.hrp().as_str() == SEED_FINGERPRINT_HRP)
+        .then(|| checked.byte_iter().collect::<Vec<_>>())
+        .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok())
+        .map(SeedFingerprint::from_bytes)
+}
+
 /// A [`SecretSink`] that persists ZeWIF secret material in the Zallet
 /// keystore.
 pub(crate) struct KeyStoreSecretSink<'a, N> {
@@ -99,16 +111,10 @@ impl<'a, N: NetworkConstants> KeyStoreSecretSink<'a, N> {
         recorded: &zewif::SeedFingerprint,
         computed: &SeedFingerprint,
     ) -> Result<(), SecretSinkError> {
-        let checked = CheckedHrpstring::new::<Bech32m>(recorded.encoding()).map_err(|_| {
+        let decoded = decode_seed_fingerprint(recorded).ok_or_else(|| {
             SecretSinkError::SeedFingerprintEncoding(recorded.encoding().to_string())
         })?;
-        if checked.hrp().as_str() != SEED_FINGERPRINT_HRP {
-            return Err(SecretSinkError::SeedFingerprintEncoding(
-                recorded.encoding().to_string(),
-            ));
-        }
-        let bytes = checked.byte_iter().collect::<Vec<_>>();
-        if bytes == computed.to_bytes() {
+        if decoded.to_bytes() == computed.to_bytes() {
             Ok(())
         } else {
             Err(SecretSinkError::SeedFingerprintMismatch {

--- a/zallet-core/src/components/keystore/zewif.rs
+++ b/zallet-core/src/components/keystore/zewif.rs
@@ -1,0 +1,287 @@
+//! A [`SecretSink`] adapter that persists ZeWIF secret material in the Zallet
+//! keystore.
+//!
+//! [`zcash_client_sqlite::zewif::import_wallet`] delivers every entry of a
+//! ZeWIF document's secret store to a [`SecretSink`] before it imports any
+//! account, so that no account can be created whose spending material has not
+//! already been persisted. [`KeyStoreSecretSink`] implements that sink on top
+//! of the Zallet keystore: each entry is decoded from its canonical ZeWIF
+//! string encoding, verified against the public material recorded alongside
+//! it, age-encrypted, and stored.
+//!
+//! The sink is synchronous (as required by the `SecretSink` trait) while the
+//! keystore is asynchronous; the adapter bridges the two with
+//! [`tokio::task::block_in_place`], and therefore requires the multi-threaded
+//! Tokio runtime that Zallet always runs on.
+//!
+//! Sprout spending keys and extracted unified spending keys have no backing
+//! store in Zallet; they are counted (for reporting by the caller) and
+//! otherwise ignored, which matches the behavior of the previous zcashd
+//! migration code.
+
+use std::fmt;
+
+use bech32::{Bech32m, primitives::decode::CheckedHrpstring};
+use bip0039::{English, Mnemonic};
+use secrecy::{SecretString, SecretVec};
+use tokio::runtime::Handle;
+use zcash_client_sqlite::zewif::SecretSink;
+use zcash_keys::encoding::{decode_extended_spending_key, encode_extended_full_viewing_key};
+use zcash_protocol::consensus::NetworkConstants;
+use zip32::fingerprint::SeedFingerprint;
+
+use crate::error::Error;
+
+use super::{Encryptor, KeyStore};
+
+macro_rules! wfl {
+    ($f:ident, $message_id:literal) => {
+        write!($f, "{}", $crate::fl!($message_id))
+    };
+
+    ($f:ident, $message_id:literal, $($args:expr),* $(,)?) => {
+        write!($f, "{}", $crate::fl!($message_id, $($args), *))
+    };
+}
+
+/// The Human-Readable Part of the canonical ZIP 32 seed fingerprint encoding.
+const SEED_FINGERPRINT_HRP: &str = "zip32seedfp";
+
+/// A [`SecretSink`] that persists ZeWIF secret material in the Zallet
+/// keystore.
+pub(crate) struct KeyStoreSecretSink<'a, N> {
+    keystore: &'a KeyStore,
+    network: N,
+    runtime: Handle,
+    encryptor: Encryptor,
+    sprout_keys_ignored: usize,
+    unified_keys_ignored: usize,
+}
+
+impl<'a, N: NetworkConstants> KeyStoreSecretSink<'a, N> {
+    /// Constructs a sink that persists secrets with `keystore`, decoding
+    /// network-dependent key encodings for `network`.
+    pub(crate) async fn new(keystore: &'a KeyStore, network: N) -> Result<Self, Error> {
+        let encryptor = keystore.encryptor().await?;
+        Ok(Self {
+            keystore,
+            network,
+            runtime: Handle::current(),
+            encryptor,
+            sprout_keys_ignored: 0,
+            unified_keys_ignored: 0,
+        })
+    }
+
+    /// The number of Sprout spending keys that were delivered to the sink;
+    /// Zallet has no store for Sprout key material, so these were not
+    /// persisted.
+    pub(crate) fn sprout_keys_ignored(&self) -> usize {
+        self.sprout_keys_ignored
+    }
+
+    /// The number of extracted unified spending keys that were delivered to
+    /// the sink; Zallet has no store for extracted unified key material, so
+    /// these were not persisted.
+    pub(crate) fn unified_keys_ignored(&self) -> usize {
+        self.unified_keys_ignored
+    }
+
+    /// Runs a keystore future to completion from the synchronous sink context.
+    fn block_on<F: Future>(&self, fut: F) -> F::Output {
+        tokio::task::block_in_place(|| self.runtime.block_on(fut))
+    }
+
+    /// Verifies that a keystore-computed seed fingerprint matches the
+    /// fingerprint recorded in the document (in its canonical `zip32seedfp`
+    /// Bech32m encoding).
+    fn check_fingerprint(
+        recorded: &zewif::SeedFingerprint,
+        computed: &SeedFingerprint,
+    ) -> Result<(), SecretSinkError> {
+        let checked = CheckedHrpstring::new::<Bech32m>(recorded.encoding()).map_err(|_| {
+            SecretSinkError::SeedFingerprintEncoding(recorded.encoding().to_string())
+        })?;
+        if checked.hrp().as_str() != SEED_FINGERPRINT_HRP {
+            return Err(SecretSinkError::SeedFingerprintEncoding(
+                recorded.encoding().to_string(),
+            ));
+        }
+        let bytes = checked.byte_iter().collect::<Vec<_>>();
+        if bytes == computed.to_bytes() {
+            Ok(())
+        } else {
+            Err(SecretSinkError::SeedFingerprintMismatch {
+                recorded: recorded.encoding().to_string(),
+            })
+        }
+    }
+}
+
+impl<N: NetworkConstants> SecretSink for KeyStoreSecretSink<'_, N> {
+    type Error = SecretSinkError;
+
+    fn store_seed(&mut self, entry: &zewif::SeedEntry) -> Result<(), Self::Error> {
+        let computed = match entry.material() {
+            zewif::SeedMaterial::Bip39Mnemonic(mnemonic) => {
+                // zcashd only ever generated English mnemonics, and the Zallet
+                // keystore stores mnemonic phrases without a language tag, so
+                // restrict imports to the English wordlist.
+                if mnemonic
+                    .language()
+                    .is_some_and(|l| *l != zewif::MnemonicLanguage::English)
+                {
+                    return Err(SecretSinkError::UnsupportedMnemonicLanguage);
+                }
+                let mnemonic = Mnemonic::<English>::from_phrase(mnemonic.mnemonic())
+                    .map_err(SecretSinkError::InvalidMnemonic)?;
+                self.block_on(self.keystore.encrypt_and_store_mnemonic(mnemonic))
+                    .map_err(SecretSinkError::Keystore)?
+            }
+            zewif::SeedMaterial::LegacySeed(seed) => {
+                let seed_bytes = SecretVec::new(seed.as_bytes().to_vec());
+                self.block_on(self.keystore.encrypt_and_store_legacy_seed(&seed_bytes))
+                    .map_err(SecretSinkError::Keystore)?
+            }
+        };
+        Self::check_fingerprint(entry.fingerprint(), &computed)
+    }
+
+    fn store_transparent_key(
+        &mut self,
+        entry: &zewif::TransparentKeyEntry,
+    ) -> Result<(), Self::Error> {
+        let encoded = SecretString::new(entry.spending_key().encoding().to_string());
+        let key = zcash_keys::keys::transparent::Key::decode_base58(&self.network, &encoded)
+            .map_err(|_| SecretSinkError::TransparentKeyDecoding)?;
+
+        // Verify the decoded key against the public key it is stored under.
+        let pubkey = key.pubkey();
+        let matches = if key.compressed() {
+            pubkey.serialize()[..] == *entry.pubkey().as_slice()
+        } else {
+            pubkey.serialize_uncompressed()[..] == *entry.pubkey().as_slice()
+        };
+        if !matches {
+            return Err(SecretSinkError::TransparentKeyMismatch);
+        }
+
+        let encrypted = self
+            .encryptor
+            .encrypt_standalone_transparent_key(&key)
+            .map_err(SecretSinkError::Keystore)?;
+        self.block_on(
+            self.keystore
+                .store_encrypted_standalone_transparent_keys(&[encrypted]),
+        )
+        .map_err(SecretSinkError::Keystore)
+    }
+
+    fn store_sapling_key(&mut self, entry: &zewif::SaplingKeyEntry) -> Result<(), Self::Error> {
+        let extsk = decode_extended_spending_key(
+            self.network.hrp_sapling_extended_spending_key(),
+            entry.spending_key().encoding(),
+        )
+        .map_err(|e| SecretSinkError::SaplingKeyDecoding(e.to_string()))?;
+
+        // Verify the decoded key against the viewing key it is stored under.
+        #[allow(deprecated)]
+        let extfvk = extsk.to_extended_full_viewing_key();
+        let encoded_fvk = encode_extended_full_viewing_key(
+            self.network.hrp_sapling_extended_full_viewing_key(),
+            &extfvk,
+        );
+        if encoded_fvk != entry.fvk().encoding() {
+            return Err(SecretSinkError::SaplingKeyMismatch);
+        }
+
+        self.block_on(
+            self.keystore
+                .encrypt_and_store_standalone_sapling_key(&extsk),
+        )
+        .map(|_dfvk| ())
+        .map_err(SecretSinkError::Keystore)
+    }
+
+    fn store_sprout_key(&mut self, _entry: &zewif::SproutKeyEntry) -> Result<(), Self::Error> {
+        self.sprout_keys_ignored += 1;
+        Ok(())
+    }
+
+    fn store_unified_key(&mut self, _entry: &zewif::UnifiedKeyEntry) -> Result<(), Self::Error> {
+        self.unified_keys_ignored += 1;
+        Ok(())
+    }
+}
+
+/// The reasons persisting an entry of a ZeWIF document's secret store in the
+/// Zallet keystore can fail.
+#[derive(Debug)]
+pub(crate) enum SecretSinkError {
+    /// A mnemonic seed phrase uses a wordlist other than English.
+    UnsupportedMnemonicLanguage,
+    /// A mnemonic seed phrase is not a valid BIP 39 mnemonic.
+    InvalidMnemonic(bip0039::Error),
+    /// A recorded seed fingerprint is not a valid `zip32seedfp` Bech32m
+    /// string.
+    SeedFingerprintEncoding(String),
+    /// The fingerprint of a stored seed does not match the fingerprint it was
+    /// recorded under in the document.
+    SeedFingerprintMismatch { recorded: String },
+    /// A transparent spending key is not a valid WIF encoding for the wallet's
+    /// network.
+    TransparentKeyDecoding,
+    /// A transparent spending key does not correspond to the public key it was
+    /// recorded under in the document.
+    TransparentKeyMismatch,
+    /// A Sapling extended spending key could not be decoded from its canonical
+    /// encoding.
+    SaplingKeyDecoding(String),
+    /// A Sapling extended spending key does not correspond to the extended
+    /// full viewing key it was recorded under in the document.
+    SaplingKeyMismatch,
+    /// The keystore failed to persist an entry.
+    Keystore(Error),
+}
+
+impl fmt::Display for SecretSinkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedMnemonicLanguage => {
+                wfl!(f, "err-migrate-secret-non-english-mnemonic")
+            }
+            Self::InvalidMnemonic(e) => {
+                wfl!(
+                    f,
+                    "err-migrate-wallet-invalid-mnemonic",
+                    err = e.to_string()
+                )
+            }
+            Self::SeedFingerprintEncoding(encoding) => wfl!(
+                f,
+                "err-migrate-secret-fingerprint-encoding",
+                fingerprint = encoding.as_str()
+            ),
+            Self::SeedFingerprintMismatch { recorded } => wfl!(
+                f,
+                "err-migrate-secret-fingerprint-mismatch",
+                fingerprint = recorded.as_str()
+            ),
+            Self::TransparentKeyDecoding => {
+                wfl!(f, "err-migrate-secret-transparent-key-decoding")
+            }
+            Self::TransparentKeyMismatch => {
+                wfl!(f, "err-migrate-secret-transparent-key-mismatch")
+            }
+            Self::SaplingKeyDecoding(e) => wfl!(
+                f,
+                "err-migrate-secret-sapling-key-decoding",
+                err = e.as_str()
+            ),
+            Self::SaplingKeyMismatch => wfl!(f, "err-migrate-secret-sapling-key-mismatch"),
+            Self::Keystore(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for SecretSinkError {}

--- a/zallet-core/src/components/keystore/zewif.rs
+++ b/zallet-core/src/components/keystore/zewif.rs
@@ -291,3 +291,42 @@ impl fmt::Display for SecretSinkError {
 }
 
 impl std::error::Error for SecretSinkError {}
+
+#[cfg(test)]
+mod tests {
+    use zip32::fingerprint::SeedFingerprint;
+
+    use super::decode_seed_fingerprint;
+
+    #[test]
+    fn seed_fingerprint_roundtrip() {
+        let fp_bytes = [7u8; 32];
+        let encoded = zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&fp_bytes);
+        let decoded = decode_seed_fingerprint(&encoded).expect("valid encoding decodes");
+        assert_eq!(
+            decoded.to_bytes(),
+            SeedFingerprint::from_bytes(fp_bytes).to_bytes()
+        );
+    }
+
+    #[test]
+    fn seed_fingerprint_rejects_wrong_hrp() {
+        // A valid Bech32m string whose HRP is not "zip32seedfp".
+        let wrong_hrp = bech32::encode::<bech32::Bech32m>(
+            bech32::Hrp::parse("notseedfp").expect("valid HRP"),
+            &[7u8; 32],
+        )
+        .expect("32 bytes fit in Bech32m");
+        assert!(decode_seed_fingerprint(&zewif::SeedFingerprint::new(wrong_hrp)).is_none());
+    }
+
+    #[test]
+    fn seed_fingerprint_rejects_invalid_checksum() {
+        let encoded = zewif_zcashd::zcashd_wallet::encode_seed_fingerprint(&[7u8; 32]);
+        let mut corrupted = encoded.encoding().to_string();
+        // Flip the final checksum character.
+        let last = corrupted.pop().expect("nonempty");
+        corrupted.push(if last == 'q' { 'p' } else { 'q' });
+        assert!(decode_seed_fingerprint(&zewif::SeedFingerprint::new(corrupted)).is_none());
+    }
+}


### PR DESCRIPTION
Replaces `migrate-zcashd-wallet`'s hand-rolled account/transaction/transparent import logic with the composition **zewif-zcashd export → `zcash_client_sqlite` ZeWIF import** (zcash/librustzcash#2547), making the ZeWIF document the single interchange point between wallet.dat parsing and wallet-database population. Net −577 lines.

## Pipeline

1. `wallet.dat` dump and parse (unchanged), network reconciliation, and the multi-wallet-import pre-check — now sourced from the document's secret store fingerprints.
2. `zewif_zcashd::migrate_to_zewif` produces the interchange document.
3. Zallet enriches the document with what only it knows: chain-derived account birthdays written in as full tree states (Sapling, Orchard, and Ironwood frontiers) with `recover_until` at the chain tip; under `--no-scan`, the expiry-based birthday estimate. Pre-4.7.0 legacy seeds are normalized to their zcashd-style derived mnemonic, with the legacy account's key source re-pointed at the mnemonic fingerprint.
4. Secret material is decoded from its canonical ZeWIF encodings (BIP-39 phrase, WIF, Sapling Bech32), verified against the recorded public halves, and age-encrypted into the keystore via a new `SecretSink` adapter — before any account is created. Because the keystore and wallet DB share a database-wide lock, zallet drives the sink itself and hands `import_wallet` a `DiscardSecrets`; keystore inserts are idempotent, so the pattern is safe.
5. `zcash_client_sqlite::zewif::import_wallet` populates the wallet, and the returned report is logged through the usual warning conventions — including the address-book entry count, which the previous implementation dropped silently.
6. Watch-only (pubkey-only) transparent addresses are supplemented post-import (see gaps below).

## Behavior changes

- Regtest wallets are now rejected up front (activation-schedule equivalence cannot be verified).
- Under `--no-scan`, address exposure derives from the document's recorded addresses rather than transaction-output scraping.
- The address book size is now reported instead of silently discarded.
- `--buffer-wallet-transactions` retains its semantics: when unset, the document's transaction set is stripped before import.

## Dependencies

The librustzcash `[patch.crates-io]` pins move to the head of zcash/librustzcash#2547 (transiently on a fork; will be re-pointed when that merges), and zewif/zewif-zcashd to their current mains. This is a stacked draft until #2547 lands and zewif has a crates.io release. The pin bump also brings in the Ironwood scan-model work, so the chain backends gained Ironwood tree handling here.

## Upstream gaps observed (to be filed separately)

- **zaino** (pinned branch): `get_treestate` exposes no Ironwood tree, so the zaino backend errors on tree-state requests at or above NU6.3 activation. This needs a zaino fix before NU6.3 activates.
- *zewif-zcashd*: the synthesized legacy account's key source records the raw legacy-seed fingerprint where post-4.7.0 zcashd semantics imply the derived mnemonic's fingerprint; zallet normalizes, but the exporter should arguably emit the mnemonic fingerprint itself.
- *zcash_client_sqlite* ZeWIF import: no registration path for watch-only transparent addresses even though the document carries the pubkeys.
- *zewif*: no mutable access to wallets/accounts post-assembly, forcing whole-document rebuilds for enrichment.

## Testing

Eight new unit tests cover fingerprint decoding, network reconciliation (including regtest rejection), frontier conversion, and document enrichment (legacy-derivation normalization, birthday injection, transaction stripping); both backend matrices (zaino and zebra-state) build, test, and lint clean. An end-to-end migration of a real testnet wallet.dat is planned as manual validation before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)