### PR TITLE
Add utils/sync-librustzcash.sh to move the librustzcash pin in lockstep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
       # but crates touching the shared wallet database must stay in lockstep.
       - name: Check wallet-critical dependency lockstep
         run: ./utils/check-lockstep.sh
+      # Exercise the sync helper end to end: with no argument it re-pins every
+      # workspace to the rev already in the root Cargo.toml and regenerates the
+      # lockfiles, so on an in-lockstep tree it must be a no-op. A non-empty diff
+      # means the committed lockfiles drifted from what the manifests resolve to.
+      - name: Verify librustzcash sync script is idempotent
+        run: |
+          ./utils/sync-librustzcash.sh
+          git diff --exit-code
       - name: Run tests (zallet-core)
         run: >
           cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,11 @@ tonic = "0.14"
 [patch.crates-io]
 # Temporary pin to librustzcash/main.
 # This should point to a proper release on crates.io
+#
+# Update the librustzcash rev ONLY via utils/sync-librustzcash.sh: it keeps all
+# three workspace manifests (root, backends/zebra, backends/zaino) and their
+# lockfiles on one identical rev, which utils/check-lockstep.sh enforces in CI.
+# Do not edit these revs by hand.
 equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }
 f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }
 transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -76,6 +76,9 @@ tempfile = "3"
 # the librustzcash stack must resolve identically in every workspace). Deliberate
 # delta vs the root block: zcash_history is patched HERE but not at the root, because
 # only the backend graphs use it.
+#
+# Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
+# all three manifests and lockfiles at once); do not edit these revs by hand.
 equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }
 f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }
 transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -80,6 +80,9 @@ tokio-console = ["zallet-core/tokio-console"]
 # the librustzcash stack must resolve identically in every workspace). Deliberate
 # delta vs the root block: zcash_history is patched HERE but not at the root, because
 # only the backend graphs use it.
+#
+# Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
+# all three manifests and lockfiles at once); do not edit these revs by hand.
 equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }
 f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }
 transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "cac64ba2b47545f23d356002e4a9f02aaaabc083" }

--- a/utils/sync-librustzcash.sh
+++ b/utils/sync-librustzcash.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Sync the librustzcash [patch.crates-io] pin to a single git rev across all
+# three workspace manifests (root, backends/zebra, backends/zaino) and refresh
+# each lockfile so the wallet-critical crates resolve identically.
+#
+# This is the ONLY supported way to move the librustzcash ref. All three
+# binaries open the same wallet database, so zcash_client_sqlite (and the rest
+# of the librustzcash stack) MUST resolve to one identical rev in every
+# workspace; utils/check-lockstep.sh enforces that in CI. Hand-editing a single
+# manifest drifts the resolution graphs and breaks the lockstep check. Run this
+# instead:
+#
+#   utils/sync-librustzcash.sh <git-rev>
+#
+# With no argument it reuses the rev currently pinned in the root Cargo.toml,
+# which re-syncs the backends and regenerates the lockfiles idempotently (this
+# is what CI runs to verify the tree is in lockstep).
+#
+# Only the librustzcash pins are touched: the age/zewif/zaino pins point at
+# other repositories and are left untouched.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Workspace dirs and their manifests, index-aligned.
+DIRS=(. backends/zebra backends/zaino)
+MANIFESTS=(Cargo.toml backends/zebra/Cargo.toml backends/zaino/Cargo.toml)
+LIBRUSTZCASH_GIT='https://github.com/zcash/librustzcash.git'
+
+# The librustzcash rev currently pinned at the root, used as the default target.
+current_root_rev() {
+  awk -v url="$LIBRUSTZCASH_GIT" '
+    index($0, url) && match($0, /rev = "[0-9a-f]+"/) {
+      s = substr($0, RSTART, RLENGTH)
+      gsub(/rev = "|"/, "", s)
+      print s
+      exit
+    }
+  ' Cargo.toml
+}
+
+REV="${1:-$(current_root_rev)}"
+
+if [[ ! "$REV" =~ ^[0-9a-f]{7,40}$ ]]; then
+  echo "error: '$REV' is not a valid git rev (expected 7-40 hex chars)." >&2
+  echo "usage: $(basename "$0") <librustzcash-git-rev>" >&2
+  exit 2
+fi
+
+echo "Syncing librustzcash pin to $REV across ${#MANIFESTS[@]} manifests..."
+
+# 1. Rewrite the rev on every line that patches a crate from librustzcash.git.
+#    Portable in-place edit (works with both BSD and GNU sed).
+esc_url="${LIBRUSTZCASH_GIT//./\\.}"
+for m in "${MANIFESTS[@]}"; do
+  tmp="$(mktemp)"
+  sed -E "s#(${esc_url}\", rev = \")[0-9a-f]{7,40}#\\1${REV}#g" "$m" > "$tmp"
+  mv "$tmp" "$m"
+done
+
+# 2. Reconcile each lockfile with the edited manifest. Changing a [patch] rev
+#    makes cargo re-resolve only the affected crates on the next lockfile-aware
+#    command, so `cargo metadata` regenerates each Cargo.lock without churning
+#    unrelated dependencies. (`cargo update -p <name>` is unusable here: a crate
+#    such as zcash_transparent exists at two versions in the graph, making a
+#    bare package spec ambiguous.)
+for d in "${DIRS[@]}"; do
+  echo "  ${d}: cargo metadata (reconciling lockfile)"
+  ( cd "$d" && cargo metadata --format-version 1 >/dev/null )
+done
+
+# 3. Self-verify that the three graphs are back in lockstep.
+echo
+exec "$(dirname "$0")/check-lockstep.sh"


### PR DESCRIPTION
## Summary

Adds `utils/sync-librustzcash.sh`, the missing companion to
`utils/check-lockstep.sh`: a one-command way to move the librustzcash
`[patch.crates-io]` pin across all three workspaces (root, `backends/zebra`,
`backends/zaino`) so their lockfiles resolve identically.

## Why

All three binaries open the same wallet database, so the librustzcash stack
(notably `zcash_client_sqlite`) must resolve to one identical rev in every
workspace; `check-lockstep.sh` enforces that in CI. Its only remedy on drift
was a manual "edit each manifest and run cargo update per workspace", which is
error-prone. This script automates that.

## What it does

- `utils/sync-librustzcash.sh <rev>` rewrites the librustzcash rev in all three
  manifests, reconciles each lockfile with `cargo metadata`, and self-verifies
  with `check-lockstep.sh`.
- With no argument it reuses the rev already pinned in the root `Cargo.toml`
  (idempotent re-sync).
- Only the librustzcash pins are touched; the `age`/`zewif`/`zaino` pins are
  left alone.
- Uses `cargo metadata` rather than `cargo update -p <name>`, which is
  ambiguous when a crate such as `zcash_transparent` resolves to two versions
  in the graph.

## CI

A new step in the required job runs the script with no argument and asserts
`git diff --exit-code`, so an in-lockstep tree stays a no-op and any lockfile
drift is caught.

Verified locally: idempotent (no lockfile churn), `check-lockstep.sh` passes,
shellcheck-clean.

## Notes

Each patch block gains a comment naming the script as the only supported way to
move the rev.

Generated with [Claude Code](https://claude.com/claude-code)