### PR TITLE
Retry on BlockConflict instead of crashing the whole wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 During the alpha period, no Semantic Versioning is followed; all releases should
 be considered breaking changes.
 
+## [Unreleased]
+
+### Fixed
+
+- `steady_state` sync no longer crashes the whole wallet when the backend's best
+  chain reorgs away a block the wallet had already stored (`BlockConflict`).
+  Previously this error wasn't recognized as retryable, so it propagated as a
+  fatal error and required a full restart to recover. It's now handled the same
+  way as other reorgs: the wallet's last known-good position is run through the
+  existing fork-point search (which walks back as far as it actually needs to,
+  rather than assuming the reorg is exactly one block deep), then rewinds and
+  resumes syncing automatically.
+- `initialize()`'s startup catch-up scan could also crash the wallet on a
+  transient stale-view error (e.g. a reorg in progress right as the wallet
+  started) that `steady_state`'s main loop already tolerates. It now retries the
+  same way.
+
 ## [0.1.0-alpha.4] - 2026-06-25
 
 ### Added

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -59,6 +59,7 @@ use zcash_client_backend::{
     sync::decryptor,
 };
 use zcash_client_sqlite::AccountUuid;
+use zcash_client_sqlite::error::SqliteClientError;
 use zcash_primitives::block::BlockHash;
 #[cfg(not(feature = "spend-index"))]
 use zcash_protocol::TxId;
@@ -294,7 +295,7 @@ async fn initialize<C: Chain>(
             }
         };
 
-        if steps::scan_blocks(
+        match steps::scan_blocks(
             chain_view,
             db_data,
             params,
@@ -302,13 +303,28 @@ async fn initialize<C: Chain>(
             &decryptor,
             shutdown_height,
         )
-        .await?
-        .is_break()
+        .await
         {
-            // The chain has already reached the consensus-divergence height during initial
-            // scanning. Stop here with the tip we have; `steady_state` will shut the wallet
-            // down rather than advance past the boundary.
-            break (current_tip, starting_boundary);
+            Ok(flow) if flow.is_break() => {
+                // The chain has already reached the consensus-divergence height during
+                // initial scanning. Stop here with the tip we have; `steady_state` will
+                // shut the wallet down rather than advance past the boundary.
+                break (current_tip, starting_boundary);
+            }
+            Ok(_) => {}
+            // A stale-view error here means the initial "Verify"/catch-up scan captured
+            // a snapshot referencing a non-finalized block that was reorged away before
+            // it could be read — the same transient condition `steady_state` already
+            // tolerates (see `is_retryable`). Unlike `steady_state`'s loop, this one has
+            // no built-in retry, so without this it crashed the whole wallet on startup
+            // whenever a reorg happened to be in progress right as it started.
+            Err(error) if is_retryable(&error) => {
+                warn!(
+                    "Chain view became stale during initial scan, re-pinning to the current tip: {error}"
+                );
+                time::sleep(REORG_RETRY_BACKOFF).await;
+            }
+            Err(error) => return Err(error),
         }
     };
 
@@ -486,6 +502,38 @@ async fn steady_state<C: Chain>(
                 if is_retryable(&error) {
                     warn!("Chain view became stale, re-pinning to the current tip: {error}");
                     time::sleep(REORG_RETRY_BACKOFF).await;
+                    continue;
+                }
+                // A block conflict means the backend's best chain reorged away the block
+                // previously stored at this height. The conflict only tells us that
+                // *this* height is wrong, not how deep the reorg actually goes — a reorg
+                // that replaced more than one block would leave the block just below the
+                // conflict wrong too, and `put_block` only ever checks for a collision at
+                // the exact height it's writing, not that its parent still matches what's
+                // stored one below it. So don't assume a depth-1 rewind is enough: treat
+                // the wallet's last known-good position (`height - 1`) as a fresh
+                // "previous tip" and run it through the same fork-point search used for
+                // ordinary reorg detection, which walks back as far as it actually needs to.
+                if let SyncError::Other(ref e) = error
+                    && let SqliteClientError::BlockConflict(height) = **e
+                {
+                    let rewind_height = height - 1;
+                    warn!(
+                        "Block at height {height} conflicts with previously stored data \
+                         (likely a reorg); searching for the fork point and retrying"
+                    );
+                    let candidate_tip = ChainBlock::new(
+                        rewind_height,
+                        db_data.get_block_hash(rewind_height)?.ok_or_else(|| {
+                            SyncError::WalletDivergedBelowBirthday {
+                                birthday: rewind_height,
+                            }
+                        })?,
+                    );
+                    let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
+                    let fork_point = locate_fork_point(&chain_view, db_data, candidate_tip).await?;
+                    db_data.truncate_to_height(fork_point.height())?;
+                    prev_tip = fork_point;
                     continue;
                 }
                 return Err(error);


### PR DESCRIPTION
## Summary

- `BlockConflict` (the backend's best chain reorged away a block the wallet had already stored) wasn't recognized by `is_retryable`, so it propagated as a fatal error and crashed the whole wallet — requiring a manual restart to recover — even though reorg-recovery machinery to handle exactly this case (fork-point search + truncate + resume) already exists for other error paths.
- Rather than assuming the reorg is exactly one block deep, the fix treats the wallet's last known-good position (`height - 1`) as a fresh "previous tip" and runs it through the *existing* fork-point search (`locate_fork_point`/`step_back_to_best_chain`), which walks back as far as it actually needs to. `BlockConflict` only tells us the block at that height is wrong, not how deep the reorg goes, and `put_block` only checks for a collision at the exact height it's writing — not that its parent still matches what's stored one below it — so a fixed depth-1 rewind isn't safe in general.
- Also fixes the same class of bug in `initialize()`'s startup catch-up scan, which had no retry at all for the stale-view error (`ChainError::Unavailable`) that `steady_state`'s main loop already tolerates — so a reorg in progress right as the wallet started would also crash it.

Closes #556

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p zallet-core --all-targets -- -D warnings`
- [x] `cargo test -p zallet-core` — 172 passed
- [x] `cargo build` for all three chain backends (`zebra`, `zaino`, and the launcher)
- [x] Manually reproduced `BlockConflict` against a live testnet sync by injecting a synthetic conflicting block hash a few blocks ahead of the wallet's synced tip, and confirmed:
  - Before this fix: fatal crash (`Failed to synchronize zallet: ...`), process exits, requires manual restart.
  - After this fix: `WARN steady_state: Block at height N conflicts with previously stored data (likely a reorg); searching for the fork point and retrying` — wallet rewinds, resumes, and syncs cleanly to the chain tip afterward, no crash, no manual intervention.