### PR TITLE
Integrate Ironwood (NU6.3) wallet support: treestate, RPC surface, and sync plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6482,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "corez",
  "hex",
@@ -6617,7 +6617,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "corez",
  "document-features",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bip32",
  "bs58",
@@ -6995,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,8 +3319,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
+source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6482,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "corez",
  "hex",
@@ -6617,7 +6617,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "corez",
  "document-features",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bip32",
  "bs58",
@@ -6995,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,19 +164,19 @@ tonic = "0.14"
 # three workspace manifests (root, backends/zebra, backends/zaino) and their
 # lockfiles on one identical rev, which utils/check-lockstep.sh enforces in CI.
 # Do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
 # NOTE: zcash_history is deliberately NOT patched here: the root graph does not
 # use it (only the backend workspaces do, and their patch blocks carry it).
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
 
 # TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
 # The librustzcash rev above requires these shardtree/incrementalmerkletree APIs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tracing-subscriber = "0.3"
 zcash_protocol = "0.10.0-pre.0"
 
 # Zcash payment protocols
-orchard = "0.15.0-pre.1"
+orchard = "0.15.0-pre.2"
 sapling = { package = "sapling-crypto", version = "0.7" }
 transparent = { package = "zcash_transparent", version = "0.9.0-pre.0" }
 zcash_encoding = "0.4"
@@ -186,6 +186,12 @@ zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe
 # shardtree release once one is cut.
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
+
+# Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
+# built against zcash/orchard main (adds the public `Builder::bundle_type()`
+# accessor), which the crates.io 0.15.0-pre.2 release predates. Required for the
+# librustzcash rev above to compile.
+orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
 # NOTE: incrementalmerkletree-testing is deliberately NOT patched here: the root
 # graph does not use it (only the backend workspaces do, and their patch blocks
 # carry it).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,19 +164,19 @@ tonic = "0.14"
 # three workspace manifests (root, backends/zebra, backends/zaino) and their
 # lockfiles on one identical rev, which utils/check-lockstep.sh enforces in CI.
 # Do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
 # NOTE: zcash_history is deliberately NOT patched here: the root graph does not
 # use it (only the backend workspaces do, and their patch blocks carry it).
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
 
 # TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
 # The librustzcash rev above requires these shardtree/incrementalmerkletree APIs

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bip32",
  "bitflags 2.13.0",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "corez",
  "hex",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7862,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7938,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7968,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "corez",
  "document-features",
@@ -8066,7 +8066,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bip32",
  "bs58",
@@ -8524,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bip32",
  "bitflags 2.13.0",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "corez",
  "hex",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7862,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7938,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7968,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "corez",
  "document-features",
@@ -8066,7 +8066,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bip32",
  "bs58",
@@ -8524,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -3855,8 +3855,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
+source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
 dependencies = [
  "aes",
  "bitvec",
@@ -4552,7 +4551,6 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4937,7 +4935,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -7458,10 +7455,11 @@ dependencies = [
 [[package]]
 name = "zaino-common"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zaino.git?rev=e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c#e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c"
+source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
 dependencies = [
  "hex",
  "nu-ansi-term",
+ "rustls",
  "serde",
  "thiserror 2.0.18",
  "time",
@@ -7469,16 +7467,14 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tree",
  "zebra-chain",
- "zingo_common_components",
 ]
 
 [[package]]
 name = "zaino-fetch"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c#e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c"
+source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
 dependencies = [
  "base64 0.22.1",
- "byteorder",
  "derive_more",
  "hex",
  "http",
@@ -7488,7 +7484,6 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -7503,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "zaino-proto"
 version = "0.1.3"
-source = "git+https://github.com/zingolabs/zaino.git?rev=e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c#e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c"
+source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
 dependencies = [
  "prost",
  "tonic",
@@ -7517,7 +7512,7 @@ dependencies = [
 [[package]]
 name = "zaino-state"
 version = "0.3.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c#e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c"
+source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.0",
@@ -8497,15 +8492,6 @@ dependencies = [
  "zcash_transparent 0.8.0",
  "zewif",
  "zip32",
-]
-
-[[package]]
-name = "zingo_common_components"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f41ddb12ba9aa1fdbf4025fb54639f1fddd25c6e297574922b39fabfb730d4"
-dependencies = [
- "hex",
 ]
 
 [[package]]

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -79,18 +79,18 @@ tempfile = "3"
 #
 # Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
 # all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
 
 # TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
 # The librustzcash rev above requires these shardtree/incrementalmerkletree APIs

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -79,18 +79,18 @@ tempfile = "3"
 #
 # Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
 # all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
 
 # TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
 # The librustzcash rev above requires these shardtree/incrementalmerkletree APIs

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 hex = "0.4"
 i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.15.0-pre.1"
+orchard = "0.15.0-pre.2"
 sapling = { package = "sapling-crypto", version = "0.7" }
 jsonrpsee = "0.24"
 tokio = { version = "1", features = ["net", "rt-multi-thread"] }
@@ -102,16 +102,24 @@ zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 
+# Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
+# built against zcash/orchard main (adds the public `Builder::bundle_type()`
+# accessor), which the crates.io 0.15.0-pre.2 release predates. Required for the
+# librustzcash rev above to compile.
+orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
+
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 
 zewif = { git = "https://github.com/zcash/zewif.git", rev = "0a5a234490a339ca8dda13614146e4769a3cd963" }
 zewif-zcashd = { git = "https://github.com/zcash/zewif-zcashd.git", rev = "c640713b91b79d153a7fee2888088931cd7e8326" }
 
-# TEMPORARY: pin the zaino crates to zingolabs/zaino `feat/ironwood_nu6_3`
-# (currently e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c), which updates zaino for
-# the NU6.3 / ironwood librustzcash and zebra lines. This is a dedicated commit
-# to be fixed up as that branch advances; repoint at upstream zaino once the
-# NU6.3 work lands there.
-zaino-common = { git = "https://github.com/zingolabs/zaino.git", rev = "e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c" }
-zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c" }
-zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "e7c9dfdb891d45c18ba53d75f5a54a90d3ec627c" }
+# TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
+# which surfaces the Ironwood (NU6.3) note commitment treestate from
+# `get_treestate` (now a `(sapling, orchard, ironwood)` triple of
+# `PoolTreestate`). Reading the real Ironwood frontier is required for Ironwood
+# notes to be spendable; an empty frontier conflicts with the wallet's advancing
+# tree and sync fails with `CheckpointConflict`. Repoint at upstream zaino once
+# the NU6.3 work lands in a release.
+zaino-common = { git = "https://github.com/zingolabs/zaino.git", rev = "8048bf8df61cd409af8c22518a16514bee02a0fb" }
+zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "8048bf8df61cd409af8c22518a16514bee02a0fb" }
+zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "8048bf8df61cd409af8c22518a16514bee02a0fb" }

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -494,11 +494,22 @@ impl ChainView for ZainoChainView {
             }
             .to_frontier();
 
+            // Zaino's treestate lookup exposes no separate Ironwood note commitment tree,
+            // and Ironwood (NU6.3) is not active on any chain Zallet syncs today, so its
+            // final tree is always empty here. When an Ironwood treestate is surfaced, read
+            // it like the Orchard tree above; Ironwood shares the Orchard tree's shape.
+            let final_ironwood_tree = CommitmentTree::<
+                orchard::tree::MerkleHashOrchard,
+                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+            >::empty()
+            .to_frontier();
+
             Some(ChainState::new(
                 height,
                 BlockHash(hash.0),
                 final_sapling_tree,
                 final_orchard_tree,
+                final_ironwood_tree,
             ))
         } else {
             None

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -405,6 +405,27 @@ impl Chain for ZainoChain {
             .collect::<Result<Vec<_>, ChainError>>()
     }
 
+    async fn get_ironwood_subtree_roots(
+        &self,
+    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
+        // Ironwood shares the Orchard commitment tree's node type, so its subtree roots
+        // decode as `MerkleHashOrchard` just like Orchard's. Zaino reports no roots until
+        // NU6.3 has produced at least one full subtree.
+        self.subscriber
+            .get_subtree_roots(ShieldedPool::Ironwood, 0, None)
+            .await
+            .map_err(ChainError::backend)?
+            .into_iter()
+            .map(|(root_hash, end_height)| {
+                Ok(CommitmentTreeRoot::from_parts(
+                    BlockHeight::from_u32(end_height),
+                    orchard::tree::MerkleHashOrchard::from_bytes(&root_hash)
+                        .expect("zaino should provide canonical encodings"),
+                ))
+            })
+            .collect::<Result<Vec<_>, ChainError>>()
+    }
+
     async fn snapshot(&self) -> Result<ZainoChainView, ChainError> {
         let snapshot = self
             .subscriber

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -227,7 +227,7 @@ impl ZainoChain {
         let (source, sync_handle) = match &config.indexer.read_state_service {
             None => (ValidatorConnector::Fetch(fetcher.clone()), None),
             Some(rss) => {
-                let (read_state_service, sync_task) = {
+                let (read_state_service, chain_tip_change, sync_task) = {
                     use zcash_protocol::consensus::Parameters as _;
                     let zebra_network = network_to_zebra(params.network_type())
                         .map_err(|e| ErrorKind::Init.context(e))?;
@@ -243,6 +243,11 @@ impl ZainoChain {
                     read_state_service,
                     mempool_fetcher: fetcher.clone(),
                     network: network_to_zaino(params),
+                    chain_tip_change,
+                    // The wallet retains ownership of the syncer via the
+                    // `AbortOnDrop` guard below (aborted on every shutdown path),
+                    // so the connector does not also manage the sync task here.
+                    sync_task_handle: None,
                 });
                 (source, Some(AbortOnDrop::new(sync_task)))
             }
@@ -466,7 +471,7 @@ impl ChainView for ZainoChainView {
             .map_err(ChainError::backend)?;
 
         let chain_state = if let Some(hash) = block_hash {
-            let (sapling_treestate, orchard_treestate) = self
+            let (sapling_treestate, orchard_treestate, ironwood_treestate) = self
                 .chain
                 .get_treestate(&hash)
                 .await
@@ -474,34 +479,42 @@ impl ChainView for ZainoChainView {
 
             let final_sapling_tree = match sapling_treestate {
                 None => CommitmentTree::empty(),
-                Some(sapling_tree_bytes) => read_commitment_tree::<
+                Some(sapling_treestate) => read_commitment_tree::<
                     sapling::Node,
                     _,
                     { sapling::NOTE_COMMITMENT_TREE_DEPTH },
-                >(&sapling_tree_bytes[..])
+                >(&sapling_treestate.final_state[..])
                 .map_err(ChainError::backend)?,
             }
             .to_frontier();
 
             let final_orchard_tree = match orchard_treestate {
                 None => CommitmentTree::empty(),
-                Some(orchard_tree_bytes) => read_commitment_tree::<
+                Some(orchard_treestate) => read_commitment_tree::<
                     orchard::tree::MerkleHashOrchard,
                     _,
                     { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-                >(&orchard_tree_bytes[..])
+                >(&orchard_treestate.final_state[..])
                 .map_err(ChainError::backend)?,
             }
             .to_frontier();
 
-            // Zaino's treestate lookup exposes no separate Ironwood note commitment tree,
-            // and Ironwood (NU6.3) is not active on any chain Zallet syncs today, so its
-            // final tree is always empty here. When an Ironwood treestate is surfaced, read
-            // it like the Orchard tree above; Ironwood shares the Orchard tree's shape.
-            let final_ironwood_tree = CommitmentTree::<
-                orchard::tree::MerkleHashOrchard,
-                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-            >::empty()
+            // Ironwood shares the Orchard tree's shape. The validator reports an
+            // Ironwood treestate only from NU6.3 activation onward; before then it is
+            // `None` and the final tree is empty. Reading the real frontier (rather than
+            // always using an empty tree) is required once Ironwood notes exist,
+            // otherwise the wallet's advancing Ironwood commitment tree conflicts with
+            // the empty checkpoint frontier and `put_blocks` fails with a
+            // `CheckpointConflict`.
+            let final_ironwood_tree = match ironwood_treestate {
+                None => CommitmentTree::empty(),
+                Some(ironwood_treestate) => read_commitment_tree::<
+                    orchard::tree::MerkleHashOrchard,
+                    _,
+                    { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+                >(&ironwood_treestate.final_state[..])
+                .map_err(ChainError::backend)?,
+            }
             .to_frontier();
 
             Some(ChainState::new(

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "corez",
  "hex",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7523,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7588,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "corez",
  "document-features",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "bip32",
  "bs58",
@@ -8100,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ea2992595d944d2fddc0d38ef24e242be7e037ba#ea2992595d944d2fddc0d38ef24e242be7e037ba"
+source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "corez",
  "hex",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7523,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7588,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "corez",
  "document-features",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "bip32",
  "bs58",
@@ -8100,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=52a19f0ec046b622fbd618b6434e0bdd4d896117#52a19f0ec046b622fbd618b6434e0bdd4d896117"
+source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -3670,8 +3670,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
+source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
 dependencies = [
  "aes",
  "bitvec",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -83,18 +83,18 @@ tokio-console = ["zallet-core/tokio-console"]
 #
 # Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
 # all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "ea2992595d944d2fddc0d38ef24e242be7e037ba" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
 
 # TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
 # The librustzcash rev above requires these shardtree/incrementalmerkletree APIs

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -83,18 +83,18 @@ tokio-console = ["zallet-core/tokio-console"]
 #
 # Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
 # all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "52a19f0ec046b622fbd618b6434e0bdd4d896117" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
 
 # TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
 # The librustzcash rev above requires these shardtree/incrementalmerkletree APIs

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3"
 hex = "0.4"
 i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.15.0-pre.1"
+orchard = "0.15.0-pre.2"
 sapling = { package = "sapling-crypto", version = "0.7" }
 serde = { version = "1", features = ["serde_derive"] }
 jsonrpsee = { version = "0.24", features = ["async-client"] }
@@ -105,6 +105,12 @@ zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe
 # backends/zaino manifests.
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
+
+# Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
+# built against zcash/orchard main (adds the public `Builder::bundle_type()`
+# accessor), which the crates.io 0.15.0-pre.2 release predates. Required for the
+# librustzcash rev above to compile.
+orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -355,11 +355,22 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
         }
         .to_frontier();
 
+        // Zebra does not expose a separate Ironwood note commitment tree, and Ironwood
+        // (NU6.3) is not active on any chain Zallet syncs today, so its final tree is always
+        // empty here. When Zebra surfaces an Ironwood treestate, read it like the Orchard tree
+        // above; Ironwood shares the Orchard tree's shape.
+        let final_ironwood_tree = CommitmentTree::<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >::empty()
+        .to_frontier();
+
         Ok(Some(ChainState::new(
             height,
             hash,
             final_sapling_tree,
             final_orchard_tree,
+            final_ironwood_tree,
         )))
     }
 

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -766,4 +766,25 @@ mod tests {
         // Above the captured tip.
         assert_eq!(view.resolve(BlockHeight::from_u32(11)).await.unwrap(), None);
     }
+
+    #[tokio::test]
+    async fn tree_state_as_of_supplies_an_empty_ironwood_tree() {
+        // The mock reader returns no tree bytes, so for a finalized height every pool's
+        // final tree is empty. This pins the Ironwood frontier that `ChainState::new` now
+        // requires: Zebra exposes no Ironwood treestate, so the zebra chain view must supply
+        // an empty one, matching the empty Sapling and Orchard trees.
+        let calls = Arc::new(AtomicU32::new(0));
+        let view = test_view(10, 5, calls);
+
+        let state = view
+            .tree_state_as_of(BlockHeight::from_u32(3))
+            .await
+            .unwrap()
+            .expect("a finalized height with no tree bytes resolves to an empty chain state");
+
+        assert_eq!(state.block_height(), BlockHeight::from_u32(3));
+        assert_eq!(state.final_sapling_tree().tree_size(), 0);
+        assert_eq!(state.final_orchard_tree().tree_size(), 0);
+        assert_eq!(state.final_ironwood_tree().tree_size(), 0);
+    }
 }

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -97,7 +97,9 @@ impl ZebraChain {
         )?;
 
         // Open zebrad's state read-only and start the non-finalized syncer.
-        let (read_state_service, sync_task) = {
+        // The chain-tip-change watcher is only needed by the zaino backend's
+        // `ValidatorConnector::State`; this backend follows the tip directly.
+        let (read_state_service, _chain_tip_change, sync_task) = {
             use zcash_protocol::consensus::Parameters as _;
             let zebra_network =
                 network_to_zebra(params.network_type()).map_err(|e| ErrorKind::Init.context(e))?;

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -197,6 +197,16 @@ impl Chain for ZebraChain {
         self.reader().orchard_subtree_roots().await
     }
 
+    async fn get_ironwood_subtree_roots(
+        &self,
+    ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
+        // TODO: The zebra read-state reader does not expose Ironwood subtree roots yet,
+        // and this backend does not serve regtest/NU6.3 (where Ironwood activates), so
+        // report none for now. Wire this up like `orchard_subtree_roots` once the reader
+        // surfaces the Ironwood tree.
+        Ok(vec![])
+    }
+
     async fn snapshot(&self) -> Result<Self::View, ChainError> {
         let reader = self.reader();
         let tip = reader

--- a/crates/zebra-read-state/src/lib.rs
+++ b/crates/zebra-read-state/src/lib.rs
@@ -23,7 +23,7 @@ use tokio::task::JoinHandle;
 use tracing::info;
 use zcash_protocol::consensus::NetworkType;
 use zebra_rpc::sync::init_read_state_with_syncer;
-use zebra_state::ReadStateService;
+use zebra_state::{ChainTipChange, ReadStateService};
 
 /// A boxed error from the zebra crates.
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -151,7 +151,7 @@ pub async fn init_read_state_service(
     zebra_network: &zebra_chain::parameters::Network,
     grpc_address: &str,
     zebra_state_path: PathBuf,
-) -> Result<(ReadStateService, JoinHandle<()>), ReadStateError> {
+) -> Result<(ReadStateService, ChainTipChange, JoinHandle<()>), ReadStateError> {
     // Resolve the gRPC indexer address used by the non-finalized syncer.
     let grpc_addr = lookup_host(grpc_address)
         .await
@@ -195,7 +195,7 @@ pub async fn init_read_state_service(
     }
 
     info!("Initializing read-only Zebra state service");
-    let (read_state_service, _latest_tip, _tip_change, sync_task) =
+    let (read_state_service, _latest_tip, tip_change, sync_task) =
         init_read_state_with_syncer(zebra_config, zebra_network, grpc_addr)
             .await
             // Outer JoinError from the spawned init task.
@@ -203,5 +203,5 @@ pub async fn init_read_state_service(
             // Inner BoxError from read-state initialization.
             .map_err(ReadStateError::Init)?;
 
-    Ok((read_state_service, sync_task))
+    Ok((read_state_service, tip_change, sync_task))
 }

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -143,6 +143,17 @@ pub trait Chain: Clone + Send + Sync + 'static {
         Output = Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError>,
     > + Send;
 
+    /// Returns the Ironwood note commitment subtree roots, in index order.
+    ///
+    /// Ironwood (NU6.3) shares the Orchard commitment tree's node type. These roots are
+    /// required for received Ironwood notes to become spendable: without them the
+    /// Ironwood tree never stabilizes and notes stay pending.
+    fn get_ironwood_subtree_roots(
+        &self,
+    ) -> impl Future<
+        Output = Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError>,
+    > + Send;
+
     /// Captures a consistent view of the chain as of the current tip.
     ///
     /// Every read through the returned [`ChainView`] reflects one fixed chain history for
@@ -1178,6 +1189,12 @@ mod tests {
         }
 
         async fn get_orchard_subtree_roots(
+            &self,
+        ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
+            unreachable!("the compatibility check does not read subtree roots")
+        }
+
+        async fn get_ironwood_subtree_roots(
             &self,
         ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
             unreachable!("the compatibility check does not read subtree roots")

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -376,6 +376,13 @@ impl WalletRead for DbConnection {
         self.with(|db_data| db_data.get_orchard_nullifiers(query))
     }
 
+    fn get_ironwood_nullifiers(
+        &self,
+        query: zcash_client_backend::data_api::NullifierQuery,
+    ) -> Result<Vec<(Self::AccountId, orchard::note::Nullifier)>, Self::Error> {
+        self.with(|db_data| db_data.get_ironwood_nullifiers(query))
+    }
+
     fn get_transparent_receivers(
         &self,
         account: Self::AccountId,
@@ -774,5 +781,34 @@ impl WalletCommitmentTrees for DbConnection {
         >],
     ) -> Result<(), ShardTreeError<Self::Error>> {
         self.with_mut(|mut db_data| db_data.put_orchard_subtree_roots(start_index, roots))
+    }
+
+    // Ironwood shares the Orchard note commitment tree's shape (same shard store and depths),
+    // so these mirror the Orchard methods; `with_ironwood_tree_mut` returns `Option` because a
+    // backend may not track an Ironwood tree, but `WalletDb` does, so we forward to it rather
+    // than fall back to the trait's no-op default (which would silently drop Ironwood tree
+    // updates made through this connection).
+    fn with_ironwood_tree_mut<F, A, E>(&mut self, callback: F) -> Result<Option<A>, E>
+    where
+        for<'a> F: FnMut(
+            &'a mut ShardTree<
+                Self::OrchardShardStore<'a>,
+                { ORCHARD_SHARD_HEIGHT * 2 },
+                ORCHARD_SHARD_HEIGHT,
+            >,
+        ) -> Result<A, E>,
+        E: From<ShardTreeError<Self::Error>>,
+    {
+        self.with_mut(|mut db_data| db_data.with_ironwood_tree_mut(callback))
+    }
+
+    fn put_ironwood_subtree_roots(
+        &mut self,
+        start_index: u64,
+        roots: &[zcash_client_backend::data_api::chain::CommitmentTreeRoot<
+            orchard::tree::MerkleHashOrchard,
+        >],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        self.with_mut(|mut db_data| db_data.put_ironwood_subtree_roots(start_index, roots))
     }
 }

--- a/zallet-core/src/components/database/tests.rs
+++ b/zallet-core/src/components/database/tests.rs
@@ -1,6 +1,8 @@
 use rand::rngs::OsRng;
 use rusqlite::{Connection, OptionalExtension, named_params};
+use shardtree::error::ShardTreeError;
 use tempfile::tempdir;
+use zcash_client_backend::data_api::{NullifierQuery, WalletCommitmentTrees, WalletRead};
 use zcash_client_sqlite::{WalletDb, util::SystemClock, wallet::init::WalletMigrator};
 use zcash_protocol::consensus::{self, NetworkType, Parameters};
 
@@ -231,6 +233,56 @@ fn incompatible_alpha_is_reported_before_network_mismatch() {
         err.to_string().contains("fresh Zallet wallet"),
         "unexpected error: {err}",
     );
+}
+
+#[test]
+fn db_connection_forwards_ironwood_reads_and_tree_ops() {
+    // DbConnection wraps WalletDb and must forward the Ironwood WalletRead /
+    // WalletCommitmentTrees methods to it rather than fall back to the trait's no-op
+    // defaults. On a freshly migrated wallet with no notes:
+    //   * get_ironwood_nullifiers (required on the scan path) returns an empty set,
+    //   * put_ironwood_subtree_roots accepts an empty batch, and
+    //   * with_ironwood_tree_mut reaches WalletDb's real Ironwood tree (Some), proving it
+    //     is not the WalletCommitmentTrees default (which returns None).
+    crate::i18n::load_languages(&[]);
+
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let db = database::Database::open(&config).await.unwrap();
+            let mut handle = db.handle().await.unwrap();
+
+            let nullifiers = handle.get_ironwood_nullifiers(NullifierQuery::All).unwrap();
+            assert!(
+                nullifiers.is_empty(),
+                "a fresh wallet has no Ironwood nullifiers, got {nullifiers:?}",
+            );
+
+            handle
+                .put_ironwood_subtree_roots(0, &[])
+                .expect("an empty Ironwood subtree-root batch should be accepted");
+
+            let reached_real_tree =
+                handle
+                    .with_ironwood_tree_mut(|_tree| {
+                        Ok::<
+                            (),
+                            ShardTreeError<
+                                <database::DbConnection as WalletCommitmentTrees>::Error,
+                            >,
+                        >(())
+                    })
+                    .expect("with_ironwood_tree_mut should succeed on a migrated wallet");
+            assert!(
+                reached_real_tree.is_some(),
+                "with_ironwood_tree_mut must reach WalletDb's Ironwood tree, not the no-op default",
+            );
+        });
 }
 
 fn test_config(datadir: &std::path::Path, network_type: NetworkType) -> ZalletConfig {

--- a/zallet-core/src/components/json_rpc/methods/get_balances.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_balances.rs
@@ -75,6 +75,13 @@ struct AccountBalance {
     #[serde(skip_serializing_if = "Option::is_none")]
     orchard: Option<Balance>,
 
+    /// The balance held by the account in the Ironwood shielded pool.
+    ///
+    /// Ironwood (NU6.3, ZIP 2005) notes are Orchard-shaped but tracked as a
+    /// distinct pool. Omitted if no Ironwood funds are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ironwood: Option<Balance>,
+
     /// The total funds in all pools held by the account.
     total: Balance,
 }
@@ -179,6 +186,7 @@ pub(crate) fn call(wallet: &DbConnection, minconf: Option<u32>) -> Response {
                 transparent_watchonly: vec![],
                 sapling: opt_balance_from(account.sapling_balance())?,
                 orchard: opt_balance_from(account.orchard_balance())?,
+                ironwood: opt_balance_from(account.ironwood_balance())?,
                 total: balance_from(account)?,
             })
         })

--- a/zallet-core/src/components/json_rpc/methods/list_transactions.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_transactions.rs
@@ -17,6 +17,7 @@ use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 const POOL_TRANSPARENT: &str = "transparent";
 const POOL_SAPLING: &str = "sapling";
 const POOL_ORCHARD: &str = "orchard";
+const POOL_IRONWOOD: &str = "ironwood";
 
 /// Response to a `z_viewtransaction` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -62,9 +63,10 @@ impl WalletTxOutput {
         }
     }
 
-    /// Builds the output detail for a `v_tx_outputs` row, or `None` if the output
-    /// belongs to a pool that Zallet does not yet surface (Ironwood), so that the
-    /// output is elided from `listtransactions` rather than failing the whole call.
+    /// Builds the output detail for a `v_tx_outputs` row.
+    ///
+    /// Returns `None` only if the pool code is one Zallet cannot render (there is
+    /// currently no such case; every known pool, including Ironwood, is surfaced).
     #[allow(clippy::too_many_arguments)]
     fn new(
         pool_code: i64,
@@ -82,8 +84,8 @@ impl WalletTxOutput {
             PoolType::Transparent => POOL_TRANSPARENT,
             PoolType::Shielded(ShieldedPool::Sapling) => POOL_SAPLING,
             PoolType::Shielded(ShieldedPool::Orchard) => POOL_ORCHARD,
-            // Ironwood is not yet supported; elide such outputs from the results.
-            PoolType::Shielded(ShieldedPool::Ironwood) => return Ok(None),
+            // Ironwood notes are Orchard-shaped but tracked as a distinct pool.
+            PoolType::Shielded(ShieldedPool::Ironwood) => POOL_IRONWOOD,
         }
         .to_string();
 

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -46,7 +46,7 @@ pub(crate) struct UnspentOutput {
 
     /// The shielded value pool.
     ///
-    /// One of `["sapling", "orchard", "transparent"]`.
+    /// One of `["sapling", "orchard", "ironwood", "transparent"]`.
     pool: String,
 
     /// The Transparent UTXO, Sapling output or Orchard action index.
@@ -246,7 +246,11 @@ pub(crate) fn call(
         let notes = wallet
             .select_unspent_notes(
                 account_id,
-                &[ShieldedPool::Sapling, ShieldedPool::Orchard],
+                &[
+                    ShieldedPool::Sapling,
+                    ShieldedPool::Orchard,
+                    ShieldedPool::Ironwood,
+                ],
                 target_height,
                 &[],
             )
@@ -365,6 +369,62 @@ pub(crate) fn call(
             unspent_outputs.push(UnspentOutput {
                 txid: note.txid().to_string(),
                 pool: "orchard".into(),
+                outindex: note.output_index().into(),
+                confirmations,
+                is_watch_only,
+                account_uuid: account_id.expose_uuid().to_string(),
+                // TODO: Ensure we generate the same kind of shielded address as `zcashd`.
+                address: (!wallet_internal).then(|| {
+                    UnifiedAddress::from_receivers(Some(note.note().recipient()), None, None)
+                        .expect("valid")
+                        .encode(wallet.params())
+                }),
+                value: value_from_zatoshis(note.value()),
+                value_zat: u64::from(note.value()),
+                memo: Some(memo),
+                memo_str,
+                wallet_internal,
+            })
+        }
+
+        // Ironwood notes are Orchard-shaped (their recipient is an Orchard
+        // address and they live behind an Orchard receiver), so this mirrors
+        // the Orchard block above; only the reported pool and the memo lookup
+        // protocol differ.
+        for note in notes.ironwood().iter().filter(|n| {
+            addresses.iter().all(|addr| {
+                addr.as_understood_unified_receivers()
+                    .iter()
+                    .any(|r| match r {
+                        zcash_keys::address::Receiver::Orchard(address) => {
+                            address == &n.note().recipient()
+                        }
+                        _ => false,
+                    })
+            })
+        }) {
+            let tx_mined_height = get_mined_height(*note.txid())?;
+            let confirmations = tx_mined_height
+                .map_or(0, |h| u32::from(target_height.saturating_sub(u32::from(h))));
+
+            // skip notes that do not have sufficient confirmations according to minconf,
+            // or that have too many confirmations according to maxconf
+            if tx_mined_height
+                .iter()
+                .any(|h| *h > target_height.saturating_sub(minconf))
+                || maxconf.iter().any(|c| confirmations > *c)
+            {
+                continue;
+            }
+
+            let wallet_internal = note.spending_key_scope() == Scope::Internal;
+
+            let (memo, memo_str) =
+                get_memo(*note.txid(), ShieldedPool::Ironwood, note.output_index())?;
+
+            unspent_outputs.push(UnspentOutput {
+                txid: note.txid().to_string(),
+                pool: "ironwood".into(),
                 outindex: note.output_index().into(),
                 confirmations,
                 is_watch_only,

--- a/zallet-core/src/components/json_rpc/methods/z_get_balance_for_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_get_balance_for_account.rs
@@ -48,6 +48,14 @@ struct Pools {
     /// Omitted if zero.
     #[serde(skip_serializing_if = "Option::is_none")]
     orchard: Option<PoolBalance>,
+
+    /// The amount held by the account in the Ironwood value pool.
+    ///
+    /// Ironwood (NU6.3, ZIP 2005) notes are Orchard-shaped; funds received to an
+    /// Orchard receiver once NU6.3 is active are reported here rather than under
+    /// `orchard`. Omitted if zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ironwood: Option<PoolBalance>,
 }
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
@@ -105,6 +113,7 @@ fn response_for_balance(
             transparent: pool_balance(account_balance.unshielded_balance().spendable_value()),
             sapling: pool_balance(account_balance.sapling_balance().spendable_value()),
             orchard: pool_balance(account_balance.orchard_balance().spendable_value()),
+            ironwood: pool_balance(account_balance.ironwood_balance().spendable_value()),
         },
         minimum_confirmations: minconf.unwrap_or(1),
     }
@@ -127,8 +136,13 @@ mod tests {
     use super::response_for_balance;
 
     /// Builds an `AccountBalance` with the given spendable values (in zatoshis)
-    /// in the transparent, Sapling, and Orchard pools respectively.
-    fn account_balance(transparent: u64, sapling: u64, orchard: u64) -> AccountBalance {
+    /// in the transparent, Sapling, Orchard, and Ironwood pools respectively.
+    fn account_balance(
+        transparent: u64,
+        sapling: u64,
+        orchard: u64,
+        ironwood: u64,
+    ) -> AccountBalance {
         let zat = Zatoshis::const_from_u64;
         let mut balance = AccountBalance::ZERO;
         balance
@@ -143,6 +157,9 @@ mod tests {
             .with_orchard_balance_mut::<_, BalanceError>(|b| b.add_spendable_value(zat(orchard)))
             .unwrap();
         balance
+            .with_ironwood_balance_mut::<_, BalanceError>(|b| b.add_spendable_value(zat(ironwood)))
+            .unwrap();
+        balance
     }
 
     /// Renders the response for a balance to its JSON representation (the actual
@@ -151,10 +168,11 @@ mod tests {
         transparent: u64,
         sapling: u64,
         orchard: u64,
+        ironwood: u64,
         minconf: Option<u32>,
     ) -> serde_json::Value {
         serde_json::to_value(response_for_balance(
-            &account_balance(transparent, sapling, orchard),
+            &account_balance(transparent, sapling, orchard, ironwood),
             minconf,
         ))
         .unwrap()
@@ -165,7 +183,7 @@ mod tests {
     #[test]
     fn empty_account_has_no_pools() {
         assert_eq!(
-            rendered(0, 0, 0, None),
+            rendered(0, 0, 0, 0, None),
             json!({"pools": {}, "minimum_confirmations": 1}),
         );
     }
@@ -175,15 +193,19 @@ mod tests {
     #[test]
     fn single_pool_is_rendered() {
         assert_eq!(
-            rendered(0, 5 * COIN, 0, None),
+            rendered(0, 5 * COIN, 0, 0, None),
             json!({"pools": {"sapling": {"valueZat": 5 * COIN}}, "minimum_confirmations": 1}),
         );
         assert_eq!(
-            rendered(0, 0, 5 * COIN, None),
+            rendered(0, 0, 5 * COIN, 0, None),
             json!({"pools": {"orchard": {"valueZat": 5 * COIN}}, "minimum_confirmations": 1}),
         );
         assert_eq!(
-            rendered(COIN, 0, 0, None),
+            rendered(0, 0, 0, 5 * COIN, None),
+            json!({"pools": {"ironwood": {"valueZat": 5 * COIN}}, "minimum_confirmations": 1}),
+        );
+        assert_eq!(
+            rendered(COIN, 0, 0, 0, None),
             json!({"pools": {"transparent": {"valueZat": COIN}}, "minimum_confirmations": 1}),
         );
     }
@@ -193,7 +215,7 @@ mod tests {
     #[test]
     fn multiple_pools_are_rendered() {
         assert_eq!(
-            rendered(0, 5 * COIN, 625 * COIN / 100, None),
+            rendered(0, 5 * COIN, 625 * COIN / 100, 0, None),
             json!({
                 "pools": {
                     "sapling": {"valueZat": 5 * COIN},
@@ -204,11 +226,27 @@ mod tests {
         );
     }
 
+    // The Ironwood pool appears alongside the other shielded pools when funded
+    // (Ironwood notes are Orchard-shaped but tracked as a distinct pool).
+    #[test]
+    fn ironwood_pool_is_rendered_alongside_others() {
+        assert_eq!(
+            rendered(0, 0, 5 * COIN, 3 * COIN, None),
+            json!({
+                "pools": {
+                    "orchard": {"valueZat": 5 * COIN},
+                    "ironwood": {"valueZat": 3 * COIN},
+                },
+                "minimum_confirmations": 1,
+            }),
+        );
+    }
+
     // Pools with a zero balance are omitted even when other pools are funded.
     #[test]
     fn zero_pools_are_omitted_among_funded_pools() {
         assert_eq!(
-            rendered(COIN, 0, 2 * COIN, None),
+            rendered(COIN, 0, 2 * COIN, 0, None),
             json!({
                 "pools": {
                     "transparent": {"valueZat": COIN},
@@ -223,15 +261,15 @@ mod tests {
     #[test]
     fn minimum_confirmations_echoes_minconf() {
         assert_eq!(
-            rendered(0, COIN, 0, None)["minimum_confirmations"],
+            rendered(0, COIN, 0, 0, None)["minimum_confirmations"],
             json!(1)
         );
         assert_eq!(
-            rendered(0, COIN, 0, Some(5))["minimum_confirmations"],
+            rendered(0, COIN, 0, 0, Some(5))["minimum_confirmations"],
             json!(5)
         );
         assert_eq!(
-            rendered(0, COIN, 0, Some(0))["minimum_confirmations"],
+            rendered(0, COIN, 0, 0, Some(0))["minimum_confirmations"],
             json!(0)
         );
     }

--- a/zallet-core/src/components/json_rpc/methods/z_get_total_balance.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_get_total_balance.rs
@@ -22,7 +22,7 @@ pub(crate) struct TotalBalance {
     /// The total value of unspent transparent outputs, in ZEC
     transparent: String,
 
-    /// The total value of unspent Sapling and Orchard outputs, in ZEC
+    /// The total value of unspent Sapling, Orchard, and Ironwood outputs, in ZEC
     private: String,
 
     /// The total value of unspent shielded and transparent outputs, in ZEC
@@ -63,7 +63,10 @@ pub(crate) fn call(
             |(transparent, private), (_, balance)| {
                 (
                     transparent + balance.unshielded_balance().total(),
-                    private + balance.sapling_balance().total() + balance.orchard_balance().total(),
+                    private
+                        + balance.sapling_balance().total()
+                        + balance.orchard_balance().total()
+                        + balance.ironwood_balance().total(),
                 )
             },
         )

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -13,7 +13,7 @@ use zcash_client_backend::{
         Account,
         wallet::{
             ConfirmationsPolicy, create_proposed_transactions,
-            input_selection::{GreedyInputSelector, TransparentSpendPolicy},
+            input_selection::{GreedyInputSelector, SpendPolicy},
             propose_transfer,
         },
     },
@@ -222,8 +222,13 @@ pub(crate) async fn call<C: Chain>(
         request,
         confirmations_policy,
         // Zallet does not yet spend transparent funds in a general transfer; `ANY_TADDR`
-        // spending is rejected above. This preserves the prior shielded-only behavior.
-        &TransparentSpendPolicy::ShieldedOnly,
+        // spending is rejected above. The default `SpendPolicy` permits every shielded pool
+        // present in the build and no transparent spending, preserving the prior
+        // shielded-only behavior.
+        &SpendPolicy::default(),
+        // Do not request a specific transaction version; building falls back to the version
+        // implied by the target height.
+        None,
     )
     // TODO: Map errors to `zcashd` shape.
     .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?;
@@ -236,7 +241,7 @@ pub(crate) async fn call<C: Chain>(
             .shielded_inputs()
             .iter()
             .flat_map(|inputs| inputs.notes())
-            .filter(|note| note.note().protocol() == ShieldedPool::Orchard)
+            .filter(|note| note.note().pool() == ShieldedPool::Orchard)
             .count();
 
         let orchard_outputs = step

--- a/zallet-core/src/components/sync/steps.rs
+++ b/zallet-core/src/components/sync/steps.rs
@@ -162,6 +162,7 @@ pub(super) async fn scan_blocks<V: ChainView>(
             from_state.block_hash(),
             Some(from_state.final_sapling_tree().tree_size() as u32),
             Some(from_state.final_orchard_tree().tree_size() as u32),
+            Some(from_state.final_ironwood_tree().tree_size() as u32),
         ));
 
         // Get the nullifiers for the unspent notes we are tracking, and the transparent
@@ -250,6 +251,7 @@ pub(super) async fn scan_block<V: ChainView>(
         from_state.block_hash(),
         Some(from_state.final_sapling_tree().tree_size() as u32),
         Some(from_state.final_orchard_tree().tree_size() as u32),
+        Some(from_state.final_ironwood_tree().tree_size() as u32),
     ));
 
     // Get the nullifiers for the unspent notes we are tracking, and the transparent

--- a/zallet-core/src/components/sync/steps.rs
+++ b/zallet-core/src/components/sync/steps.rs
@@ -53,6 +53,17 @@ pub(super) async fn update_subtree_roots<C: Chain>(
     info!("Orchard tree has {} subtrees", orchard_roots.len());
     db_data.put_orchard_subtree_roots(0, &orchard_roots)?;
 
+    // Ironwood (NU6.3) shares the Orchard tree shape. Inserting its subtree roots is what
+    // lets received Ironwood notes become spendable; without them the tree never
+    // stabilizes and the notes stay pending.
+    let ironwood_roots = chain
+        .get_ironwood_subtree_roots()
+        .await
+        .map_err(SyncError::Chain)?;
+
+    info!("Ironwood tree has {} subtrees", ironwood_roots.len());
+    db_data.put_ironwood_subtree_roots(0, &ironwood_roots)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Integrate Ironwood (ZIP 2005, NU6.3) wallet support into Zallet end to end: the
node-facing treestate plumbing, the JSON-RPC surface, and the sync path, on top
of the librustzcash Ironwood wallet APIs.

## Dependency pins

- **librustzcash → `main` (`b43a4237`)**, advanced from the NU6.3 base through
  the #2539 Ironwood wallet-support work in the root, zebra, and zaino
  workspaces. Main librustzcash is built against `zcash/orchard` `main` (which
  adds the public `Builder::bundle_type()` accessor), so its
  `[patch.crates-io] orchard = { git = "zcash/orchard", rev = "475ef0ff" }` is
  replicated across all three manifests; without it the pinned rev does not
  compile against the crates.io `0.15.0-pre.2` release.
- **zaino → `dev` (`8048bf8d`)**, which surfaces the Ironwood note commitment
  treestate from `get_treestate` (now a `(sapling, orchard, ironwood)` triple of
  `PoolTreestate`). This required adapting the zaino backend to two accompanying
  `dev` API changes: `ValidatorConnector::State` gained `chain_tip_change` and
  `sync_task_handle`. The chain-tip-change watcher is threaded out of
  `init_read_state_service` (it was already produced by the zebra read-state
  init and discarded); `sync_task_handle` is left `None`, since the wallet keeps
  ownership of the syncer via its existing `AbortOnDrop` guard.

## librustzcash API adaptation (base commits)

- `WalletRead::get_ironwood_nullifiers` is now required (called on the scan
  path); forward it to `WalletDb` in `DbConnection`.
- Forward the `WalletCommitmentTrees` Ironwood methods (`with_ironwood_tree_mut`,
  `put_ironwood_subtree_roots`) to `WalletDb` rather than fall back to the
  trait's no-op defaults, which would silently drop Ironwood tree updates.
- `propose_transfer` now takes an explicit `SpendPolicy` and an
  `Option<TxVersion>`: pass `SpendPolicy::default()` and `None`.
- `Note::protocol()` became `Note::pool()`, classifying Orchard and Ironwood by
  value pool; update the call sites in `z_send_many` and the privacy-policy
  check in `payments`.
- `BlockMetadata::from_parts` and `ChainState::new` gained an Ironwood tree
  argument.

## RPC surface

Surface the Ironwood pool across the JSON-RPC methods (previously they elided
Ironwood or reported only transparent/sapling/orchard):

- `z_getbalanceforaccount`: add an `ironwood` pool.
- `z_gettotalbalance`: count Ironwood funds in `private`.
- `getbalances`: add a per-account `ironwood` balance.
- `z_listunspent`: list Ironwood notes with `pool == "ironwood"`.
- `listtransactions`: stop eliding Ironwood outputs; report their pool.

(`z_viewtransaction` is intentionally left for a follow-up: surfacing Ironwood
spends/outputs there needs trial-decryption under the Ironwood (version 3) note
domain, not the Orchard (version 2) one.)

## Sync path

- **Read the real Ironwood treestate** in the zaino backend's
  `tree_state_as_of` instead of hardcoding an empty tree. Once NU6.3 is active
  and Ironwood notes exist, an empty checkpoint frontier conflicts with the
  wallet's advancing Ironwood tree and `put_blocks` fails with a shardtree
  `CheckpointConflict`, crashing sync. The zebra backend still supplies an empty
  Ironwood frontier (its read-state view does not expose one yet).
- **Fetch and store Ironwood subtree roots** during sync (`update_subtree_roots`
  previously handled only Sapling and Orchard): add `get_ironwood_subtree_roots`
  to the `Chain` trait (implemented against zaino's `get_subtree_roots` for the
  Ironwood pool) and `put_ironwood_subtree_roots` into the wallet DB.

## Status

Ironwood works end to end with this PR: shielding coinbase into an Orchard UA
once NU6.3 is active mints version-3 (Ironwood) notes that are scanned,
positioned in the tree, counted as `private`, reported under the `ironwood`
pool, spendable, and spendable-out (a spend consumes an Ironwood note and its
value returns as new, spendable Ironwood notes). The `CheckpointConflict` sync
crash is fixed.

The `zcash/integration-tests` `wallet_ironwood.py` test exercises this full
receive-then-spend flow and passes. One prerequisite lives on the test side, not
here: the wallet database must be **created** with the NU6.3 activation height
already configured, because the librustzcash Ironwood migration bakes that
height into the `v_ironwood_shard_scan_ranges` SQL view; if NU6.3 is only
configured after the database exists, the view bakes a NULL height and Ironwood
notes never become spendable. On mainnet/testnet the NU6.3 height is a fixed
consensus parameter, so this only needs care in regtest.
