### PR TITLE
backend: support regtest in the zebra read-state backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- The `zebra` chain backend (and the `zaino` backend's read-state-service mode)
+  now support regtest. The read-state service builds a Zebra Regtest network
+  whose network-upgrade activation heights mirror the wallet's configured
+  `regtest_nuparams`, so it interprets the co-located zebrad's on-disk state
+  under matching consensus rules. Previously these backends rejected regtest at
+  startup with an "does not support regtest" error.
+
 ### Fixed
 
 - `steady_state` sync no longer crashes the whole wallet when the backend's best

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -228,9 +228,8 @@ impl ZainoChain {
             None => (ValidatorConnector::Fetch(fetcher.clone()), None),
             Some(rss) => {
                 let (read_state_service, chain_tip_change, sync_task) = {
-                    use zcash_protocol::consensus::Parameters as _;
-                    let zebra_network = network_to_zebra(params.network_type())
-                        .map_err(|e| ErrorKind::Init.context(e))?;
+                    let zebra_network =
+                        network_to_zebra(&params).map_err(|e| ErrorKind::Init.context(e))?;
                     init_read_state_service(
                         &zebra_network,
                         &rss.grpc_address,

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -100,9 +100,8 @@ impl ZebraChain {
         // The chain-tip-change watcher is only needed by the zaino backend's
         // `ValidatorConnector::State`; this backend follows the tip directly.
         let (read_state_service, _chain_tip_change, sync_task) = {
-            use zcash_protocol::consensus::Parameters as _;
             let zebra_network =
-                network_to_zebra(params.network_type()).map_err(|e| ErrorKind::Init.context(e))?;
+                network_to_zebra(&params).map_err(|e| ErrorKind::Init.context(e))?;
             init_read_state_service(
                 &zebra_network,
                 &rss.grpc_address,
@@ -603,19 +602,42 @@ mod tests {
 
     #[test]
     fn network_to_zebra_maps_main_and_test() {
+        let main = Network::from_type(NetworkType::Main, &[]);
+        let test = Network::from_type(NetworkType::Test, &[]);
+        assert!(matches!(network_to_zebra(&main), Ok(ZebraNetwork::Mainnet)));
         assert!(matches!(
-            network_to_zebra(NetworkType::Main),
-            Ok(ZebraNetwork::Mainnet)
-        ));
-        assert!(matches!(
-            network_to_zebra(NetworkType::Test),
+            network_to_zebra(&test),
             Ok(ZebraNetwork::Testnet(_))
         ));
     }
 
     #[test]
-    fn network_to_zebra_rejects_regtest() {
-        assert!(network_to_zebra(NetworkType::Regtest).is_err());
+    fn network_to_zebra_builds_regtest_with_matching_heights() {
+        use zcash_protocol::consensus::{NetworkUpgrade, Parameters as _};
+        use zebra_chain::block::Height as ZebraHeight;
+        use zebra_chain::parameters::NetworkUpgrade as ZebraUpgrade;
+
+        // NU5 at height 2 (earlier upgrades inherit height 1 in regtest). Regtest
+        // is now supported rather than rejected.
+        let regtest = Network::from_type(
+            NetworkType::Regtest,
+            &["c2d6d0b4:2".to_string().try_into().unwrap()],
+        );
+        let zebra = network_to_zebra(&regtest).expect("regtest network builds");
+        assert!(zebra.is_regtest());
+
+        // The configured NU5 height is threaded into the Zebra regtest network,
+        // matching what the wallet parameters report.
+        assert_eq!(
+            regtest
+                .activation_height(NetworkUpgrade::Nu5)
+                .map(u32::from),
+            Some(2),
+        );
+        assert_eq!(
+            ZebraUpgrade::Nu5.activation_height(&zebra),
+            Some(ZebraHeight(2)),
+        );
     }
 
     use std::sync::atomic::{AtomicU32, Ordering};

--- a/backends/zebra/src/main.rs
+++ b/backends/zebra/src/main.rs
@@ -3,7 +3,7 @@
 //! This binary reads finalized chain state directly from a co-located zebrad's
 //! state database and follows the non-finalized tip over zebrad's gRPC indexer
 //! interface. It requires a zebrad built with the (non-default) `indexer`
-//! feature, and does not support regtest.
+//! feature.
 
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -108,8 +108,9 @@ Notes:
 - zebrad's on-disk state format must match Zallet's `zebra-state` version; a
   mismatch fails fast with a "no zebra-state v… database found" error rather than
   silently creating an empty database.
-- Reading state this way does not support regtest; use the JSON-RPC `zaino` backend
-  (without this section) for regtest.
+- Regtest is supported: the backend builds a Zebra Regtest network from the wallet's
+  configured `regtest_nuparams`, so it interprets zebrad's state under matching
+  consensus rules.
 
 If you have an existing `zcash.conf`, you can use it as a starting point:
 ```

--- a/crates/zebra-read-state/src/lib.rs
+++ b/crates/zebra-read-state/src/lib.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use tokio::net::lookup_host;
 use tokio::task::JoinHandle;
 use tracing::info;
-use zcash_protocol::consensus::NetworkType;
+use zcash_protocol::consensus::{NetworkType, NetworkUpgrade, Parameters};
 use zebra_rpc::sync::init_read_state_with_syncer;
 use zebra_state::{ChainTipChange, ReadStateService};
 
@@ -106,20 +106,41 @@ impl std::error::Error for ReadStateError {
     }
 }
 
-/// Converts a network type into the corresponding `zebra-chain` network.
+/// Converts the wallet's consensus parameters into the corresponding
+/// `zebra-chain` network.
 ///
-/// Returns an error for regtest, which the read-state-service backend does not
-/// support.
-pub fn network_to_zebra(
-    network: NetworkType,
+/// For regtest, a Zebra Regtest network is constructed whose network-upgrade
+/// activation heights mirror the wallet's configured `regtest_nuparams` (read
+/// through the [`Parameters`] trait), so the on-disk state produced by the
+/// co-located zebrad is interpreted under matching consensus rules. The pre-NU5
+/// upgrades default to height 1 (filled by zebra's regtest parameter builder),
+/// so only the configured heights need to be supplied.
+pub fn network_to_zebra<P: Parameters>(
+    params: &P,
 ) -> Result<zebra_chain::parameters::Network, ReadStateError> {
-    use zebra_chain::parameters::Network as ZebraNetwork;
-    match network {
+    use zebra_chain::parameters::{Network as ZebraNetwork, testnet::ConfiguredActivationHeights};
+    match params.network_type() {
         NetworkType::Main => Ok(ZebraNetwork::Mainnet),
         NetworkType::Test => Ok(ZebraNetwork::new_default_testnet()),
-        NetworkType::Regtest => Err(ReadStateError::UnsupportedNetwork(
-            "the read-state-service indexer backend does not support regtest",
-        )),
+        NetworkType::Regtest => {
+            let height = |nu: NetworkUpgrade| params.activation_height(nu).map(u32::from);
+            let heights = ConfiguredActivationHeights {
+                before_overwinter: Some(1),
+                overwinter: height(NetworkUpgrade::Overwinter),
+                sapling: height(NetworkUpgrade::Sapling),
+                blossom: height(NetworkUpgrade::Blossom),
+                heartwood: height(NetworkUpgrade::Heartwood),
+                canopy: height(NetworkUpgrade::Canopy),
+                nu5: height(NetworkUpgrade::Nu5),
+                nu6: height(NetworkUpgrade::Nu6),
+                nu6_1: height(NetworkUpgrade::Nu6_1),
+                nu6_2: height(NetworkUpgrade::Nu6_2),
+                nu6_3: height(NetworkUpgrade::Nu6_3),
+                nu7: None,
+                ..Default::default()
+            };
+            Ok(ZebraNetwork::new_regtest(heights.into()))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The `zebra` chain backend (and the `zaino` backend's read-state-service
mode) previously rejected regtest at startup with a "does not support
regtest" error. This wires regtest through so both backends can read a
co-located regtest zebrad's on-disk state.

## What changed

- `network_to_zebra` (in the shared `zallet-zebra-read-state` crate) now
  takes the wallet's full consensus parameters (`&impl Parameters`)
  instead of a bare `NetworkType`. For regtest it reads each network
  upgrade's activation height through the `Parameters` trait, builds
  Zebra's `ConfiguredActivationHeights`, and constructs a Zebra Regtest
  network via `Network::new_regtest`, so the read-state service
  interprets zebrad's state under matching consensus rules.
- Both backend call sites pass their network parameters through. The
  read-state crate stays decoupled from `zallet-core` (it only needs
  `zcash_protocol` and `zebra-chain`).
- Docs (`main.rs` module comment, `book/src/guide/setup.md`) updated to
  drop the "regtest unsupported" wording.

## Testing

- New unit test `network_to_zebra_builds_regtest_with_matching_heights`
  asserts a configured NU5 height is threaded end-to-end into the Zebra
  regtest network; `network_to_zebra_maps_main_and_test` still passes.
- `cargo clippy --all-targets` and `cargo fmt -- --check` clean for the
  zebra backend, the zaino backend, and the read-state crate.