### PR TITLE
backend: read the Ironwood note commitment tree in the zebra backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ be considered breaking changes.
   transient stale-view error (e.g. a reorg in progress right as the wallet
   started) that `steady_state`'s main loop already tolerates. It now retries the
   same way.
+- The `zebra` chain backend's `tree_state_as_of` always reported the Ironwood
+  note commitment tree as empty, regardless of the queried height. This was
+  correct before NU6.3 activated on any chain the backend could reach, but once
+  a chain crossed activation, every sync batch boundary re-derived the Ironwood
+  frontier as empty instead of reading the real (non-empty) tree, corrupting
+  the wallet's local shardtree state on the very next batch (surfacing as a
+  checkpoint or root conflict in `zcash_client_sqlite`, or an `Inserted root
+  conflicts with existing root` error from `shardtree`). The tree is now read
+  from the backend the same way as Sapling and Orchard, via
+  `ReadRequest::IronwoodTree`.
 
 ## [0.1.0-alpha.4] - 2026-06-25
 

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -362,14 +362,22 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
         }
         .to_frontier();
 
-        // Zebra does not expose a separate Ironwood note commitment tree, and Ironwood
-        // (NU6.3) is not active on any chain Zallet syncs today, so its final tree is always
-        // empty here. When Zebra surfaces an Ironwood treestate, read it like the Orchard tree
-        // above; Ironwood shares the Orchard tree's shape.
-        let final_ironwood_tree = CommitmentTree::<
-            orchard::tree::MerkleHashOrchard,
-            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-        >::empty()
+        // Ironwood (NU6.3) shares the Orchard tree's shape. Zebra returns `None` for
+        // heights before NU6.3 activation, where the pool (and so its tree) is empty.
+        let final_ironwood_tree = match self.reader.ironwood_tree_bytes(hash).await? {
+            Some(bytes) => read_commitment_tree::<
+                orchard::tree::MerkleHashOrchard,
+                _,
+                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+            >(&bytes[..])
+            .map_err(ChainError::invalid_data)?,
+            None if pinned_finalized => CommitmentTree::empty(),
+            None => {
+                return Err(ChainError::unavailable(
+                    "pinned ironwood treestate reorged away",
+                ));
+            }
+        }
         .to_frontier();
 
         Ok(Some(ChainState::new(
@@ -695,6 +703,9 @@ mod tests {
         async fn orchard_tree_bytes(&self, _: BlockHash) -> Result<Option<Vec<u8>>, ChainError> {
             Ok(None)
         }
+        async fn ironwood_tree_bytes(&self, _: BlockHash) -> Result<Option<Vec<u8>>, ChainError> {
+            Ok(None)
+        }
         async fn find_fork_point(
             &self,
             _: &BlockLocator,
@@ -805,9 +816,9 @@ mod tests {
     #[tokio::test]
     async fn tree_state_as_of_supplies_an_empty_ironwood_tree() {
         // The mock reader returns no tree bytes, so for a finalized height every pool's
-        // final tree is empty. This pins the Ironwood frontier that `ChainState::new` now
-        // requires: Zebra exposes no Ironwood treestate, so the zebra chain view must supply
-        // an empty one, matching the empty Sapling and Orchard trees.
+        // final tree is empty. For Ironwood this pins the `None` fallback: Zebra returns no
+        // tree for finalized heights where the pool was not yet active (pre-NU6.3), and the
+        // chain view must map that to an empty frontier like the Sapling and Orchard reads.
         let calls = Arc::new(AtomicU32::new(0));
         let view = test_view(10, 5, calls);
 

--- a/backends/zebra/src/chain/reader.rs
+++ b/backends/zebra/src/chain/reader.rs
@@ -63,6 +63,11 @@ pub trait ChainReader: Clone + Send + Sync + 'static {
         &self,
         hash: BlockHash,
     ) -> impl Future<Output = Result<Option<Vec<u8>>, ChainError>> + Send;
+    /// Ironwood (NU6.3) reuses the Orchard note commitment tree shape.
+    fn ironwood_tree_bytes(
+        &self,
+        hash: BlockHash,
+    ) -> impl Future<Output = Result<Option<Vec<u8>>, ChainError>> + Send;
     fn find_fork_point(
         &self,
         locator: &BlockLocator,
@@ -209,6 +214,18 @@ impl ChainReader for ReadStateChainReader {
         {
             ReadResponse::OrchardTree(opt) => Ok(opt.map(|tree| tree.to_rpc_bytes())),
             other => unreachable!("unexpected response to OrchardTree: {other:?}"),
+        }
+    }
+
+    async fn ironwood_tree_bytes(&self, hash: BlockHash) -> Result<Option<Vec<u8>>, ChainError> {
+        match self
+            .call(ReadRequest::IronwoodTree(HashOrHeight::Hash(
+                convert::to_zebra_hash(&hash),
+            )))
+            .await?
+        {
+            ReadResponse::IronwoodTree(opt) => Ok(opt.map(|tree| tree.to_rpc_bytes())),
+            other => unreachable!("unexpected response to IronwoodTree: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

`tree_state_as_of` in the `zebra` chain backend always reported the Ironwood note
commitment tree as empty, regardless of the queried height. This was correct before
NU6.3 activated on any chain the backend could reach, but testnet has since crossed
activation, and the stale assumption now silently corrupts sync: every batch boundary
re-derives the Ironwood frontier as empty instead of reading the real (non-empty) tree,
so the wallet's local shardtree conflicts with itself on the very next batch — surfacing
as a checkpoint conflict or `Inserted root conflicts with existing root` error from
`zcash_client_sqlite`/`shardtree`.

Fix: read the tree the same way as Sapling and Orchard, via `ReadRequest::IronwoodTree`
on the `ChainReader` trait. Ironwood shares the Orchard tree's shape, so the decode path
mirrors the existing `orchard_tree_bytes` handling exactly.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` (chain module) passing
- [x] Verified live on a synced testnet `zebrad` past NU6.3 activation height (4,134,000):
      wallet Ironwood checkpoints now record real chain-scale positions instead of
      restarting from 0, `steady_state` and history-recovery sync both run without
      crashing, and a same-wallet Orchard→Ironwood `z_sendmany` mined and confirmed with
      the value correctly landing in the recipient's Ironwood pool.

### AI disclosure

Claude Code was used for root-cause analysis, the fix, and this PR description. I
reviewed and independently verified the fix end-to-end on testnet.
