### PR TITLE
rpc: surface Ironwood in z_getnotescount and decoderawtransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ be considered breaking changes.
   against the `ironwood_received_notes` table. Previously the method elided
   Ironwood actions entirely (they were reported for neither spends, outputs, nor
   sent-to addresses).
+- `z_getnotescount` now reports Ironwood notes under a new `ironwood` field,
+  alongside `sapling` and `orchard`. Previously Ironwood notes were counted in no
+  field at all. (This required advancing the librustzcash pin, whose
+  `WalletRead::get_account_metadata` gained Ironwood note-count support.)
+- `getrawtransaction` and `decoderawtransaction` now surface the Ironwood bundle
+  of a v6 transaction under a new `ironwood` key. Ironwood actions are
+  Orchard-shaped, so the object has the same shape as the existing `orchard` one.
+  Previously the Ironwood bundle was omitted from the decoded output.
+
+### Changed
+
+- Advanced the librustzcash pin (to `29c7fb2`) and, in lockstep, moved the
+  `shardtree` dependency to the published `0.7` release, dropping the temporary
+  `shardtree`/`incrementalmerkletree` git `[patch.crates-io]` (now unnecessary).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2211,7 +2211,8 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
 ]
@@ -4021,8 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
 dependencies = [
  "bitflags",
  "either",
@@ -5570,7 +5572,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5583,7 +5585,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5612,7 +5614,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -5634,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5682,7 +5683,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "corez",
  "hex",
@@ -5723,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5799,7 +5800,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5829,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5864,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "corez",
  "document-features",
@@ -5927,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bip32",
  "bs58",
@@ -6100,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ incrementalmerkletree = "0.8.2"
 rusqlite = { version = "0.37", features = ["time"] }
 schemerz = "0.2"
 schemerz-rusqlite = "0.370.0"
-shardtree = "0.6"
+shardtree = "0.7"
 time = "0.3"
 uuid = "1"
 zcash_client_backend = "0.23"
@@ -165,28 +165,20 @@ tonic = "0.14"
 # three workspace manifests (root, backends/zebra, backends/zaino) and their
 # lockfiles on one identical rev, which utils/check-lockstep.sh enforces in CI.
 # Do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
 # NOTE: zcash_history is deliberately NOT patched here: the root graph does not
 # use it (only the backend workspaces do, and their patch blocks carry it).
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
 
-# TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
-# The librustzcash rev above requires these shardtree/incrementalmerkletree APIs
-# and carries this same patch in its own workspace, but Cargo only honours
-# [patch] from the ROOT workspace, so it must be replicated here. Points at
-# zcash/incrementalmerkletree main (includes #184); replace with a published
-# shardtree release once one is cut.
-shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 
 # Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
 # built against zcash/orchard main (adds the public `Builder::bundle_type()`

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2563,7 +2563,8 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
 ]
@@ -5068,8 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
 dependencies = [
  "bitflags 2.13.0",
  "either",
@@ -6967,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6980,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7009,7 +7011,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -7031,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7079,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "corez",
  "hex",
@@ -7089,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7130,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7206,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7236,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7271,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "corez",
  "document-features",
@@ -7334,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bip32",
  "bs58",
@@ -7782,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -79,28 +79,19 @@ tempfile = "3"
 #
 # Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
 # all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
 
-# TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
-# The librustzcash rev above requires these shardtree/incrementalmerkletree APIs
-# and carries this same patch in its own workspace, but Cargo only honours
-# [patch] from the ROOT workspace, so it must be replicated in every manifest.
-# Points at zcash/incrementalmerkletree main (includes #184); replace with a
-# published shardtree release once one is cut. Keep in lockstep with the root and
-# backends/zebra manifests.
-shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 
 # Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
 # built against zcash/orchard main (adds the public `Builder::bundle_type()`

--- a/backends/zaino/supply-chain/config.toml
+++ b/backends/zaino/supply-chain/config.toml
@@ -853,7 +853,7 @@ version = "0.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.incrementalmerkletree]]
-version = "0.8.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.indenter]]
@@ -1601,7 +1601,7 @@ version = "1.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shardtree]]
-version = "0.6.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2459,7 +2459,8 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
 ]
@@ -4746,8 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
 dependencies = [
  "bitflags",
  "either",
@@ -6547,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6560,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6589,7 +6591,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -6611,7 +6612,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6659,7 +6660,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "corez",
  "hex",
@@ -6669,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6710,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6786,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6816,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6851,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "corez",
  "document-features",
@@ -6914,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "bip32",
  "bs58",
@@ -7362,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9fe5abf78a15940aa84fd895fed75162f21fcb53#9fe5abf78a15940aa84fd895fed75162f21fcb53"
+source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -83,28 +83,19 @@ tokio-console = ["zallet-core/tokio-console"]
 #
 # Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
 # all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9fe5abf78a15940aa84fd895fed75162f21fcb53" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
 
-# TEMPORARY: explicit checkpoint retention (ensure_retained / retained_checkpoints).
-# The librustzcash rev above requires these shardtree/incrementalmerkletree APIs
-# and carries this same patch in its own workspace, but Cargo only honours
-# [patch] from the ROOT workspace, so it must be replicated in every manifest.
-# Points at zcash/incrementalmerkletree main (includes #184); replace with a
-# published shardtree release once one is cut. Keep in lockstep with the root and
-# backends/zaino manifests.
-shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 
 # Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
 # built against zcash/orchard main (adds the public `Builder::bundle_type()`

--- a/backends/zebra/supply-chain/config.toml
+++ b/backends/zebra/supply-chain/config.toml
@@ -805,7 +805,7 @@ version = "0.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.incrementalmerkletree]]
-version = "0.8.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.indenter]]
@@ -1485,7 +1485,7 @@ version = "1.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shardtree]]
-version = "0.6.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -716,7 +716,7 @@ version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.incrementalmerkletree]]
-version = "0.8.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.indenter]]
@@ -1248,7 +1248,7 @@ version = "1.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shardtree]]
-version = "0.6.2@git:decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]

--- a/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
@@ -30,6 +30,12 @@ pub(crate) struct GetNotesCount {
 
     /// The number of Orchard notes in the wallet.
     orchard: u32,
+
+    /// The number of Ironwood notes in the wallet.
+    ///
+    /// Ironwood (NU6.3, ZIP 2005) notes are Orchard-shaped but tracked as a
+    /// distinct pool.
+    ironwood: u32,
 }
 
 pub(super) const PARAM_MINCONF_DESC: &str =
@@ -55,6 +61,7 @@ pub(crate) fn call(
 
     let mut sapling = 0;
     let mut orchard = 0;
+    let mut ironwood = 0;
     for account_id in wallet
         .get_account_ids()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
@@ -69,11 +76,15 @@ pub(crate) fn call(
         if let Some(note_count) = account_metadata.note_count(ShieldedPool::Orchard) {
             orchard += note_count as u32;
         }
+        if let Some(note_count) = account_metadata.note_count(ShieldedPool::Ironwood) {
+            ironwood += note_count as u32;
+        }
     }
 
     Ok(GetNotesCount {
         sprout: 0,
         sapling,
         orchard,
+        ironwood,
     })
 }

--- a/zallet-core/src/components/json_rpc/methods/get_raw_transaction.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_raw_transaction.rs
@@ -174,6 +174,13 @@ pub(crate) struct TransactionDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     orchard: Option<Orchard>,
 
+    /// JSON object with Ironwood-specific information.
+    ///
+    /// Ironwood (NU6.3, ZIP 2005) actions are Orchard-shaped, so this has the
+    /// same shape as the `orchard` field. Omitted if `version < 6`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ironwood: Option<Orchard>,
+
     /// The `joinSplitSig` public validating key.
     ///
     /// Encoded as a byte-reversed hex string for legacy reasons.
@@ -633,6 +640,13 @@ pub(super) fn tx_to_json(
         .has_orchard()
         .then(|| Orchard::encode(tx.orchard_bundle()));
 
+    // Ironwood actions are Orchard-shaped, so they serialize with the same
+    // encoder as the Orchard bundle, under a distinct `ironwood` key.
+    let ironwood = tx
+        .version()
+        .has_ironwood()
+        .then(|| Orchard::encode(tx.ironwood_bundle()));
+
     TransactionDetails {
         txid: tx.txid().to_string(),
         authdigest: ReverseHex::encode(&tx.auth_commitment().as_bytes().try_into().unwrap()),
@@ -652,6 +666,7 @@ pub(super) fn tx_to_json(
         v_shielded_output,
         binding_sig,
         orchard,
+        ironwood,
         #[cfg(zallet_unimplemented)]
         join_split_pub_key,
         #[cfg(zallet_unimplemented)]


### PR DESCRIPTION
## Motivation

Two informational RPCs still omitted the Ironwood (NU6.3, ZIP 2005) value pool
once it is active, even though the balance/listing RPCs already surface it:

- `z_getnotescount` reported only `sapling` and `orchard`, so Ironwood notes were
  counted in no field at all.
- `getrawtransaction` / `decoderawtransaction` rendered the `orchard` bundle but
  not the Ironwood one, so a v6 transaction's Ironwood actions never appeared in
  the decoded output.

## Changes

- **`z_getnotescount`**: add an `ironwood` field and count
  `ShieldedPool::Ironwood` notes from the account metadata.
- **`getrawtransaction` / `decoderawtransaction`**: add an `ironwood` object,
  gated on `tx.version().has_ironwood()`, encoding `tx.ironwood_bundle()` with the
  same encoder as the Orchard bundle (Ironwood actions are Orchard-shaped, so the
  object has the same shape as `orchard`).
- **Dependency bump (first commit)**: `z_getnotescount` depends on
  `WalletRead::get_account_metadata` counting Ironwood notes, which required
  advancing the librustzcash pin (to `29c7fb2`). That revision moved off the
  git-patched shardtree (0.6.2) onto the published `shardtree 0.7`, so the
  workspace `shardtree` requirement moves to `0.7` and the temporary
  `shardtree`/`incrementalmerkletree` git `[patch.crates-io]` is dropped from all
  three manifests (only the `orchard` patch remains, still required).

## Testing

Verified against the Z3 integration-tests stack (zebrad + zaino + zallet) with
the `zaino` backend:

- `z_getnotescount` returns `{sprout, sapling, orchard, ironwood}` and reports the
  correct Ironwood note count once the notes' transactions are mined (the count
  keys off `transactions.mined_height`, which backfills a scan pass after a note
  first becomes visible).
- `decoderawtransaction` of a v6 Ironwood spend now includes an `ironwood` object
  carrying the bundle's actions.

Corresponding integration-tests assertions are added in
zcash/integration-tests#159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)