### PR TITLE
fix: reload sync engine viewing keys after key-adding RPCs

### DIFF
--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -61,6 +61,9 @@ impl StartCmd {
         // returns the height at which to shut down before reaching them.
         let shutdown_height = check_consensus_compatibility(&chain).await?;
 
+        // Build the decryptor up front so the RPC server has its handle before the initial scan.
+        let (decryptor_handle, decryptor_engine) = WalletSync::build_decryptor();
+
         // Launch RPC server.
         let rpc_task_handle = JsonRpc::spawn(
             &config,
@@ -68,6 +71,8 @@ impl StartCmd {
             #[cfg(zallet_build = "wallet")]
             keystore,
             chain.clone(),
+            #[cfg(zallet_build = "wallet")]
+            decryptor_handle.clone(),
         )
         .await?;
 
@@ -77,7 +82,15 @@ impl StartCmd {
             wallet_sync_recover_history_task_handle,
             wallet_sync_batch_decryptor_task_handle,
             wallet_sync_data_requests_task_handle,
-        ) = WalletSync::spawn(&config, db, chain, shutdown_height).await?;
+        ) = WalletSync::spawn(
+            &config,
+            db,
+            chain,
+            shutdown_height,
+            decryptor_handle,
+            decryptor_engine,
+        )
+        .await?;
 
         info!("Spawned Zallet tasks");
 

--- a/zallet-core/src/components/json_rpc.rs
+++ b/zallet-core/src/components/json_rpc.rs
@@ -18,6 +18,8 @@ use super::{TaskHandle, chain::Chain, database::Database};
 
 #[cfg(zallet_build = "wallet")]
 use super::keystore::KeyStore;
+#[cfg(zallet_build = "wallet")]
+use super::sync::WalletDecryptorHandle;
 
 #[cfg(zallet_build = "wallet")]
 mod asyncop;
@@ -36,6 +38,7 @@ impl JsonRpc {
         db: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
         chain: C,
+        #[cfg(zallet_build = "wallet")] decryptor: WalletDecryptorHandle,
     ) -> Result<TaskHandle, Error> {
         let rpc = config.rpc.clone();
 
@@ -54,6 +57,8 @@ impl JsonRpc {
                 #[cfg(zallet_build = "wallet")]
                 keystore,
                 chain,
+                #[cfg(zallet_build = "wallet")]
+                decryptor,
             )
             .await
         } else {

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -949,6 +949,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             self.wallet().await?.as_mut(),
             &self.keystore,
             self.chain().await?,
+            &self.decryptor,
             account_name,
             seedfp,
         )
@@ -963,6 +964,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             self.wallet().await?.as_mut(),
             &self.keystore,
             self.chain().await?,
+            &self.decryptor,
             accounts,
         )
         .await

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -12,7 +12,9 @@ use crate::components::{
 #[cfg(zallet_build = "wallet")]
 use {
     super::asyncop::{AsyncOperation, ContextInfo, OperationId},
-    crate::components::{json_rpc::payments::AmountParameter, keystore::KeyStore},
+    crate::components::{
+        json_rpc::payments::AmountParameter, keystore::KeyStore, sync::WalletDecryptorHandle,
+    },
     serde::Serialize,
     tokio::sync::RwLock,
 };
@@ -741,16 +743,23 @@ impl<C: Chain> RpcImpl<C> {
 pub(crate) struct WalletRpcImpl<C: Chain> {
     general: RpcImpl<C>,
     keystore: KeyStore,
+    decryptor: WalletDecryptorHandle,
     async_ops: RwLock<Vec<AsyncOperation>>,
 }
 
 #[cfg(zallet_build = "wallet")]
 impl<C: Chain> WalletRpcImpl<C> {
     /// Creates a new instance of the wallet-specific RPC handler.
-    pub(crate) fn new(wallet: Database, keystore: KeyStore, chain_view: C) -> Self {
+    pub(crate) fn new(
+        wallet: Database,
+        keystore: KeyStore,
+        chain_view: C,
+        decryptor: WalletDecryptorHandle,
+    ) -> Self {
         Self {
             general: RpcImpl::new(wallet, keystore.clone(), chain_view),
             keystore,
+            decryptor,
             async_ops: RwLock::new(Vec::new()),
         }
     }
@@ -1041,6 +1050,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             self.wallet().await?.as_mut(),
             &self.keystore,
             self.chain().await?,
+            &self.decryptor,
             key,
             rescan,
             start_height,

--- a/zallet-core/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_new_account.rs
@@ -12,6 +12,7 @@ use crate::components::{
         utils::{ensure_wallet_is_unlocked, parse_seedfp_parameter},
     },
     keystore::KeyStore,
+    sync::WalletDecryptorHandle,
 };
 
 /// Response to a `z_getnewaccount` RPC request.
@@ -37,6 +38,7 @@ pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
     chain: C,
+    decryptor: &WalletDecryptorHandle,
     account_name: &str,
     seedfp: Option<&str>,
 ) -> Response {
@@ -101,6 +103,11 @@ pub(crate) async fn call<C: Chain>(
     let (account_id, _usk) = wallet
         .create_account(account_name, &seed, &birthday, None)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    // Reload viewing keys so the new account is scanned without a restart (see z_importkey).
+    if decryptor.reload_keys().await.is_none() {
+        tracing::warn!("sync engine has shut down; new account won't be scanned until restart");
+    }
 
     Ok(Account {
         account_uuid: account_id.expose_uuid().to_string(),

--- a/zallet-core/src/components/json_rpc/methods/import_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_key.rs
@@ -11,6 +11,7 @@ use crate::components::{
     database::DbConnection,
     json_rpc::{server::LegacyCode, utils::fetch_account_birthday},
     keystore::KeyStore,
+    sync::WalletDecryptorHandle,
 };
 
 /// Response to a `z_importkey` RPC request.
@@ -68,6 +69,7 @@ pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
     chain: C,
+    decryptor: &WalletDecryptorHandle,
     key: &str,
     rescan: Option<&str>,
     start_height: Option<u64>,
@@ -150,6 +152,15 @@ pub(crate) async fn call<C: Chain>(
                 None,
             )
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+        // Reload viewing keys so the imported key is scanned without a restart. Don't wait
+        // for the reload to be processed: the marker is queued behind any blocks already in
+        // the decryptor, so awaiting it could block this call for a long time during sync.
+        if decryptor.reload_keys().await.is_none() {
+            tracing::warn!(
+                "sync engine has shut down; imported key won't be scanned until restart"
+            );
+        }
     }
 
     Ok(ResultType {

--- a/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
@@ -15,6 +15,7 @@ use crate::components::{
         utils::{ensure_wallet_is_unlocked, parse_seedfp_parameter},
     },
     keystore::KeyStore,
+    sync::WalletDecryptorHandle,
 };
 
 /// Response to a `z_recoveraccounts` RPC request.
@@ -54,6 +55,7 @@ pub(crate) async fn call<C: Chain>(
     wallet: &mut DbConnection,
     keystore: &KeyStore,
     chain: C,
+    decryptor: &WalletDecryptorHandle,
     accounts: Vec<AccountParameter<'_>>,
 ) -> Response {
     ensure_wallet_is_unlocked(keystore).await?;
@@ -133,6 +135,13 @@ pub(crate) async fn call<C: Chain>(
             })
         })
         .collect::<Result<_, _>>()?;
+
+    // Reload viewing keys so recovered accounts are scanned without a restart (see z_importkey).
+    if decryptor.reload_keys().await.is_none() {
+        tracing::warn!(
+            "sync engine has shut down; recovered accounts won't be scanned until restart"
+        );
+    }
 
     Ok(Accounts { accounts })
 }

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -19,7 +19,7 @@ use super::methods::{RpcImpl, RpcServer as _};
 #[cfg(zallet_build = "wallet")]
 use {
     super::methods::{WalletRpcImpl, WalletRpcServer},
-    crate::components::keystore::KeyStore,
+    crate::components::{keystore::KeyStore, sync::WalletDecryptorHandle},
 };
 
 mod error;
@@ -38,6 +38,7 @@ pub(crate) async fn spawn<C: Chain>(
     wallet: Database,
     #[cfg(zallet_build = "wallet")] keystore: KeyStore,
     chain: C,
+    #[cfg(zallet_build = "wallet")] decryptor: WalletDecryptorHandle,
 ) -> Result<ServerTask, Error> {
     // Caller should make sure `bind` only contains a single address (for now).
     assert_eq!(config.bind.len(), 1);
@@ -45,7 +46,8 @@ pub(crate) async fn spawn<C: Chain>(
 
     // Initialize the RPC methods.
     #[cfg(zallet_build = "wallet")]
-    let wallet_rpc_impl = WalletRpcImpl::new(wallet.clone(), keystore.clone(), chain.clone());
+    let wallet_rpc_impl =
+        WalletRpcImpl::new(wallet.clone(), keystore.clone(), chain.clone(), decryptor);
     let rpc_impl = RpcImpl::new(
         wallet,
         #[cfg(zallet_build = "wallet")]

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -211,7 +211,7 @@ async fn initialize<C: Chain>(
     chain: &C,
     params: &Network,
     db_data: &mut DbConnection,
-    decryptor: decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
+    decryptor: WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
 ) -> Result<(ChainBlock, BlockHeight), SyncError> {
     info!("Initializing wallet for syncing");
@@ -470,7 +470,7 @@ async fn steady_state<C: Chain>(
     mut prev_tip: ChainBlock,
     lower_boundary: Arc<AtomicU32>,
     tip_change_signal: Arc<Notify>,
-    decryptor: decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
+    decryptor: WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
 ) -> Result<(), SyncError> {
     info!("Steady-state sync task started");
@@ -565,7 +565,7 @@ async fn steady_state_iteration<C: Chain>(
     prev_tip: &mut ChainBlock,
     lower_boundary: &AtomicU32,
     tip_change_signal: &Notify,
-    decryptor: &decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
+    decryptor: &WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
 ) -> Result<ControlFlow<BlockHeight>, SyncError> {
     let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
@@ -695,7 +695,7 @@ async fn recover_history<C: Chain>(
     params: &Network,
     db_data: &mut DbConnection,
     upper_boundary: Arc<AtomicU32>,
-    decryptor: decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
+    decryptor: WalletDecryptorHandle,
     batch_size: u32,
     shutdown_height: Option<BlockHeight>,
 ) -> Result<(), SyncError> {

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -82,19 +82,31 @@ mod steps;
 #[derive(Debug)]
 pub(crate) struct WalletSync {}
 
+/// Handle the RPC layer uses to reload the sync engine's viewing keys after a key import.
+pub(crate) type WalletDecryptorHandle = decryptor::Handle<AccountUuid, (AccountUuid, Scope)>;
+
+/// Engine half of the batch decryptor, driven by the sync tasks spawned by [`WalletSync::spawn`].
+pub(crate) type WalletDecryptorEngine = decryptor::Engine<AccountUuid, (AccountUuid, Scope)>;
+
 impl WalletSync {
+    /// Builds the batch decryptor. Split from [`WalletSync::spawn`] so the RPC server can be
+    /// handed a handle before `spawn`'s initial scan, which would otherwise delay RPC startup.
+    pub(crate) fn build_decryptor() -> (WalletDecryptorHandle, WalletDecryptorEngine) {
+        // The batch decryptor's built-in defaults (queue size 1000, batch-size threshold
+        // 200, batch start delay 500ms) are appropriate for Zallet, so use them as-is.
+        decryptor::new().build()
+    }
+
     pub(crate) async fn spawn<C: Chain>(
         config: &ZalletConfig,
         db: Database,
         chain: C,
         shutdown_height: Option<BlockHeight>,
+        decryptor: WalletDecryptorHandle,
+        decryptor_engine: WalletDecryptorEngine,
     ) -> Result<(TaskHandle, TaskHandle, TaskHandle, TaskHandle), Error> {
         let params = config.consensus.network();
         let recover_batch_size = config.sync.recover_batch_size();
-
-        // The batch decryptor's built-in defaults (queue size 1000, batch-size threshold
-        // 200, batch start delay 500ms) are appropriate for Zallet, so use them as-is.
-        let (decryptor, decryptor_engine) = decryptor::new().build();
 
         // Spawn the processing tasks.
         let batch_decryptor_task = {

--- a/zallet-core/src/components/sync/steps.rs
+++ b/zallet-core/src/components/sync/steps.rs
@@ -17,7 +17,6 @@ use zcash_client_backend::{
 use zcash_client_sqlite::AccountUuid;
 use zcash_primitives::block::Block;
 use zcash_protocol::consensus::BlockHeight;
-use zip32::Scope;
 
 use crate::{
     components::{
@@ -27,7 +26,7 @@ use crate::{
     network::Network,
 };
 
-use super::{SyncError, decryptor};
+use super::{SyncError, WalletDecryptorHandle};
 
 pub(super) async fn update_subtree_roots<C: Chain>(
     chain: &C,
@@ -127,7 +126,7 @@ pub(super) async fn scan_blocks<V: ChainView>(
     db_data: &mut DbConnection,
     params: &Network,
     scan_range: &ScanRange,
-    decryptor: &decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
+    decryptor: &WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
 ) -> Result<ControlFlow<BlockHeight>, SyncError> {
     // Clamp the range to stop before any known consensus-divergence height (see
@@ -229,7 +228,7 @@ pub(super) async fn scan_block<V: ChainView>(
     db_data: &mut DbConnection,
     params: &Network,
     block: Block,
-    decryptor: &decryptor::Handle<AccountUuid, (AccountUuid, Scope)>,
+    decryptor: &WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
 ) -> Result<ControlFlow<BlockHeight>, SyncError> {
     let height = block.claimed_height();


### PR DESCRIPTION
Importing a key or adding an account to a **running** wallet never made the sync engine scan for it: the batch decryptor loads its viewing keys once at startup and only refreshes on `reload_keys()`, which nothing called. So imported/created keys went undetected (`z_gettotalbalance` stayed 0 at the chain tip) until a restart.

This threads the decryptor handle to the affected RPCs and reloads keys after each one. To avoid delaying RPC startup, the decryptor is now built up front and its handle shared with the RPC server, rather than reordering sync ahead of the RPC server.

**Scope** — reloads after all three key/account-adding RPCs: `z_importkey`, `z_getnewaccount`, `z_recoveraccount`. (`z_importviewingkey` isn't implemented; `z_importaddress` is transparent-only and doesn't use the shielded decryptor.) The reload is fire-and-don't-block (queued, not awaited) with a `warn!` if the engine has shut down, so it never hangs the RPC during heavy sync.

Rewind-to-height for already-scanned ranges (the other half of the caveat in #563) is tracked separately in #578.

**Commits:**
- fix(rpc): reload sync engine viewing keys after z_importkey
- fix(rpc): also reload after z_getnewaccount and z_recoveraccount
- refactor(sync): use WalletDecryptorHandle alias for existing decryptor usages

Closes #563
