### PR TITLE
Move the librustzcash and age pins to the latest git revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2861,8 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
 dependencies = [
  "aes",
  "bitvec",
@@ -5504,7 +5505,7 @@ dependencies = [
  "nix",
  "nonempty",
  "once_cell",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "phf",
  "proptest",
  "quote",
@@ -5540,18 +5541,18 @@ dependencies = [
  "uuid",
  "which 8.0.4",
  "xdg 2.5.2",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -5573,21 +5574,21 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5604,7 +5605,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -5622,14 +5623,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which 8.0.4",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -5637,7 +5638,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5652,7 +5653,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "prost",
  "rand 0.8.6",
  "rand_core 0.6.4",
@@ -5670,14 +5671,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zip32",
 ]
@@ -5685,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "corez",
  "hex",
@@ -5725,8 +5726,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5740,7 +5741,7 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
@@ -5748,10 +5749,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zeroize",
  "zip32",
 ]
@@ -5801,8 +5802,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5816,7 +5817,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -5824,15 +5825,15 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5848,7 +5849,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -5866,8 +5867,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "corez",
  "document-features",
@@ -5929,8 +5930,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bip32",
  "bs58",
@@ -5943,9 +5944,9 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6103,13 +6104,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.13.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ ripemd = "0.1"
 sha2 = "0.10"
 
 # Key storage
-age = { version = "0.11", features = ["armor", "cli-common", "plugin"] }
+# =0.11.1 selects the patched git age below over the incompatible crates.io release.
+age = { version = "=0.11.1", features = ["armor", "cli-common", "plugin"] }
 bech32 = "0.11"
 bip0039 = "0.12"
 
@@ -70,7 +71,7 @@ serde = { version = "1", features = ["serde_derive"] }
 semver = "1"
 serde_json = { version = "1", features = ["arbitrary_precision", "raw_value"] }
 toml = "0.8"
-zcash_address = "0.13.0-pre.0"
+zcash_address = "0.13.0"
 
 # Randomness
 rand = "0.8"
@@ -111,21 +112,21 @@ tracing-log = "0.2"
 tracing-subscriber = "0.3"
 
 # Zcash consensus
-zcash_protocol = "0.10.0-pre.0"
+zcash_protocol = "0.10.0"
 
 # Zcash payment protocols
-orchard = "0.15.0-pre.2"
+orchard = "0.15.0"
 sapling = { package = "sapling-crypto", version = "0.7" }
-transparent = { package = "zcash_transparent", version = "0.9.0-pre.0" }
+transparent = { package = "zcash_transparent", version = "0.9.0" }
 zcash_encoding = "0.4"
-zcash_keys = { version = "0.15.0-pre.0", features = [
+zcash_keys = { version = "0.15.0", features = [
     "transparent-inputs",
     "sapling",
     "orchard",
     "transparent-key-encoding",
 ] }
-zcash_primitives = "0.29.0-pre.0"
-zcash_proofs = "0.29.0-pre.0"
+zcash_primitives = "0.29.0"
+zcash_proofs = "0.29.0"
 zcash_script = "0.4.3"
 zcash_spec = "0.2"
 secp256k1 = { version = "0.29", features = ["recovery"] }
@@ -160,36 +161,20 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-# Temporary pin to librustzcash/main.
-# This should point to a proper release on crates.io
-#
-# Update the librustzcash rev ONLY via utils/sync-librustzcash.sh: it keeps all
-# three workspace manifests (root, backends/zebra, backends/zaino) and their
-# lockfiles on one identical rev, which utils/check-lockstep.sh enforces in CI.
-# Do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-# NOTE: zcash_history is deliberately NOT patched here: the root graph does not
-# use it (only the backend workspaces do, and their patch blocks carry it).
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-
-
-# Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
-# built against zcash/orchard main (adds the public `Builder::bundle_type()`
-# accessor), which the crates.io 0.15.0-pre.2 release predates. Required for the
-# librustzcash rev above to compile.
-orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
-# NOTE: incrementalmerkletree-testing is deliberately NOT patched here: the root
-# graph does not use it (only the backend workspaces do, and their patch blocks
-# carry it).
+# Temporary pins for APIs not yet on crates.io. Update the librustzcash rev
+# only via utils/sync-librustzcash.sh; utils/check-lockstep.sh enforces that
+# all three workspaces stay in lockstep.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1497,7 +1497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2646,7 +2646,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2893,7 +2893,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3270,7 +3270,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3448,8 +3448,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
 dependencies = [
  "aes",
  "bitvec",
@@ -4020,7 +4021,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4569,7 +4570,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4628,7 +4629,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5308,7 +5309,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6344,7 +6345,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6417,15 +6418,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6468,21 +6460,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6505,12 +6482,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6523,12 +6494,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6538,12 +6503,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6565,12 +6524,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6580,12 +6533,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6601,12 +6548,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6616,12 +6557,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6817,11 +6752,11 @@ dependencies = [
  "zaino-common",
  "zaino-fetch",
  "zaino-proto",
- "zcash_address 0.13.0-pre.0",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_address 0.13.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6864,7 +6799,7 @@ dependencies = [
  "known-folders",
  "nix 0.29.0",
  "nonempty 0.11.0",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "phf",
  "quote",
  "rand 0.8.6",
@@ -6897,18 +6832,18 @@ dependencies = [
  "uuid",
  "which 8.0.4",
  "xdg 2.5.2",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6925,7 +6860,7 @@ dependencies = [
  "incrementalmerkletree",
  "jsonrpsee",
  "once_cell",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "sapling-crypto",
  "tempfile",
  "tokio",
@@ -6935,10 +6870,10 @@ dependencies = [
  "zallet-core",
  "zallet-zebra-read-state",
  "zcash_client_backend",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zebra-rpc",
 ]
 
@@ -6948,7 +6883,7 @@ version = "0.1.0-alpha.4"
 dependencies = [
  "tokio",
  "tracing",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6970,21 +6905,21 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7001,7 +6936,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -7019,14 +6954,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which 8.0.4",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -7034,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7049,7 +6984,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty 0.11.0",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "prost",
  "rand 0.8.6",
  "rand_core 0.6.4",
@@ -7067,14 +7002,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zip32",
 ]
@@ -7082,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "corez",
  "hex",
@@ -7091,8 +7026,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_history"
-version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.5.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7132,8 +7067,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7147,7 +7082,7 @@ dependencies = [
  "group",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
@@ -7155,10 +7090,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zeroize",
  "zip32",
 ]
@@ -7208,8 +7143,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7223,7 +7158,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty 0.11.0",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -7231,15 +7166,15 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7255,7 +7190,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -7273,8 +7208,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "corez",
  "document-features",
@@ -7336,8 +7271,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bip32",
  "bs58",
@@ -7350,9 +7285,9 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7388,7 +7323,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "primitive-types 0.12.2",
  "rand_core 0.6.4",
  "rayon",
@@ -7412,14 +7347,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -7442,7 +7377,7 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand 0.8.6",
  "rayon",
  "sapling-crypto",
@@ -7454,11 +7389,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7542,7 +7477,7 @@ dependencies = [
  "metrics",
  "nix 0.30.1",
  "openrpsee",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "phf",
  "prost",
  "rand 0.8.6",
@@ -7565,13 +7500,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which 8.0.4",
- "zcash_address 0.13.0-pre.0",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_address 0.13.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7589,7 +7524,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.6",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_script",
  "zebra-chain",
 ]
@@ -7785,13 +7720,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.13.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -27,18 +27,18 @@ futures = "0.3"
 hex = "0.4"
 i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.15.0-pre.2"
+orchard = "0.15.0"
 sapling = { package = "sapling-crypto", version = "0.7" }
 jsonrpsee = "0.24"
 tokio = { version = "1", features = ["net", "rt-multi-thread"] }
-transparent = { package = "zcash_transparent", version = "0.9.0-pre.0" }
+transparent = { package = "zcash_transparent", version = "0.9.0" }
 zaino-common = "0.2"
 zaino-fetch = "0.2.1"
 zaino-state = "0.3.1"
 zcash_client_backend = "0.23"
-zcash_keys = { version = "0.15.0-pre.0", features = ["unstable"] }
-zcash_primitives = "0.29.0-pre.0"
-zcash_protocol = "0.10.0-pre.0"
+zcash_keys = { version = "0.15.0", features = ["unstable"] }
+zcash_primitives = "0.29.0"
+zcash_protocol = "0.10.0"
 zebra-rpc = "11"
 
 [features]
@@ -71,33 +71,21 @@ once_cell = "1.2"
 tempfile = "3"
 
 [patch.crates-io]
-# Keep this block in sync with the workspace-root Cargo.toml (utils/check-lockstep.sh
-# enforces resolved-version identity in CI; all binaries share one wallet database, so
-# the librustzcash stack must resolve identically in every workspace). Deliberate
-# delta vs the root block: zcash_history is patched HERE but not at the root, because
-# only the backend graphs use it.
-#
-# Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
-# all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-
-
-# Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
-# built against zcash/orchard main (adds the public `Builder::bundle_type()`
-# accessor), which the crates.io 0.15.0-pre.2 release predates. Required for the
-# librustzcash rev above to compile.
-orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
+# Keep in lockstep with the root Cargo.toml; update the librustzcash rev only
+# via utils/sync-librustzcash.sh. zcash_history is patched here (the backends
+# use it) but not at the root.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1258,7 +1258,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1404,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2542,7 +2542,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2745,7 +2745,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3100,7 +3100,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3254,8 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
 dependencies = [
  "aes",
  "bitvec",
@@ -3304,7 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3809,7 +3810,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4321,7 +4322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4867,7 +4868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5017,7 +5018,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6018,7 +6019,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6082,15 +6083,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6123,21 +6115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6175,12 +6152,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6193,12 +6164,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6208,12 +6173,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6241,12 +6200,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6256,12 +6209,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6277,12 +6224,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6292,12 +6233,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6440,7 +6375,7 @@ dependencies = [
  "known-folders",
  "nix 0.29.0",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "phf",
  "quote",
  "rand 0.8.6",
@@ -6473,18 +6408,18 @@ dependencies = [
  "uuid",
  "which 8.0.4",
  "xdg 2.5.2",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6504,7 +6439,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-http-client",
  "once_cell",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "regex",
  "sapling-crypto",
  "serde",
@@ -6515,9 +6450,9 @@ dependencies = [
  "zallet-core",
  "zallet-zebra-read-state",
  "zcash_client_backend",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-state",
 ]
@@ -6528,7 +6463,7 @@ version = "0.1.0-alpha.4"
 dependencies = [
  "tokio",
  "tracing",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6550,21 +6485,21 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6581,7 +6516,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -6599,14 +6534,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which 8.0.4",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -6614,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6629,7 +6564,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "prost",
  "rand 0.8.6",
  "rand_core 0.6.4",
@@ -6647,14 +6582,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zip32",
 ]
@@ -6662,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "corez",
  "hex",
@@ -6671,8 +6606,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_history"
-version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.5.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6712,8 +6647,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6727,7 +6662,7 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
@@ -6735,10 +6670,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zeroize",
  "zip32",
 ]
@@ -6788,8 +6723,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6803,7 +6738,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -6811,15 +6746,15 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6835,7 +6770,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -6853,8 +6788,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "corez",
  "document-features",
@@ -6916,8 +6851,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "bip32",
  "bs58",
@@ -6930,9 +6865,9 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6968,7 +6903,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "primitive-types",
  "rand_core 0.6.4",
  "rayon",
@@ -6992,14 +6927,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.13.0-pre.0",
+ "zcash_address 0.13.0",
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -7022,7 +6957,7 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "rand 0.8.6",
  "rayon",
  "sapling-crypto",
@@ -7034,11 +6969,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7122,7 +7057,7 @@ dependencies = [
  "metrics",
  "nix 0.30.1",
  "openrpsee",
- "orchard 0.15.0-pre.2",
+ "orchard 0.15.0",
  "phf",
  "prost",
  "rand 0.8.6",
@@ -7145,13 +7080,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which 8.0.4",
- "zcash_address 0.13.0-pre.0",
- "zcash_keys 0.15.0-pre.0",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_address 0.13.0",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0-pre.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7169,7 +7104,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.6",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0-pre.0",
+ "zcash_primitives 0.29.0",
  "zcash_script",
  "zebra-chain",
 ]
@@ -7365,13 +7300,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=29c7fb28889a69df15b44fc9465cf4a464f766e9#29c7fb28889a69df15b44fc9465cf4a464f766e9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a97a3d5f46d096b94ceb71271c7d38f20af4e1f1#a97a3d5f46d096b94ceb71271c7d38f20af4e1f1"
 dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.13.0-pre.0",
- "zcash_protocol 0.10.0-pre.0",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -36,23 +36,23 @@ futures = "0.3"
 hex = "0.4"
 i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.15.0-pre.2"
+orchard = "0.15.0"
 sapling = { package = "sapling-crypto", version = "0.7" }
 serde = { version = "1", features = ["serde_derive"] }
 jsonrpsee = { version = "0.24", features = ["async-client"] }
 jsonrpsee-http-client = { version = "0.24", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tower = { version = "0.4", features = ["timeout"] }
-transparent = { package = "zcash_transparent", version = "0.9.0-pre.0" }
+transparent = { package = "zcash_transparent", version = "0.9.0" }
 zcash_client_backend = "0.23"
-zcash_primitives = "0.29.0-pre.0"
-zcash_protocol = "0.10.0-pre.0"
+zcash_primitives = "0.29.0"
+zcash_protocol = "0.10.0"
 zebra-chain = "11"
 zebra-state = { version = "10", features = ["indexer"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.9", features = ["testing"] }
-age = { version = "0.11", features = ["armor", "cli-common", "plugin"] }
+age = { version = "=0.11.1", features = ["armor", "cli-common", "plugin"] }
 once_cell = "1.2"
 regex = "1.4"
 tempfile = "3"
@@ -75,33 +75,21 @@ rpc-cli = ["zallet-core/rpc-cli"]
 tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
-# Keep this block in sync with the workspace-root Cargo.toml (utils/check-lockstep.sh
-# enforces resolved-version identity in CI; all binaries share one wallet database, so
-# the librustzcash stack must resolve identically in every workspace). Deliberate
-# delta vs the root block: zcash_history is patched HERE but not at the root, because
-# only the backend graphs use it.
-#
-# Update the librustzcash rev ONLY via utils/sync-librustzcash.sh (which syncs
-# all three manifests and lockfiles at once); do not edit these revs by hand.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "29c7fb28889a69df15b44fc9465cf4a464f766e9" }
-
-
-# Replicated from librustzcash b43a4237's own [patch.crates-io]: main librustzcash is
-# built against zcash/orchard main (adds the public `Builder::bundle_type()`
-# accessor), which the crates.io 0.15.0-pre.2 release predates. Required for the
-# librustzcash rev above to compile.
-orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
+# Keep in lockstep with the root Cargo.toml; update the librustzcash rev only
+# via utils/sync-librustzcash.sh. zcash_history is patched here (the backends
+# use it) but not at the root.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "a97a3d5f46d096b94ceb71271c7d38f20af4e1f1" }
 
 age = { git = "https://github.com/str4d/rage.git", rev = "92f437bc2a061312fa6633bb70c91eef91142fd4" }
 


### PR DESCRIPTION
## Summary

Moves the `[patch.crates-io]` pins in all three workspaces (root,
`backends/zebra`, `backends/zaino`) to the latest upstream git revisions and
bumps the crate version requirements to their released numbers. The librustzcash
family and `age` stay on git pins because the wallet uses APIs that are not yet
published to crates.io. `orchard` is now unpinned (its 0.15.0 release is on
crates.io).

Both the zebra and zaino backends build, and `utils/check-lockstep.sh` passes.

## Pending upstream releases (tracking)

This section is updated as each dependency releases; a pin is dropped when its
release lands.

- [ ] **`zcash_client_backend` 0.24.0** (librustzcash): the sync component uses
      the `sync-decryptor` batch decryptor (`sync::decryptor`), only on
      librustzcash `main`. This blocks the entire librustzcash family pin; when
      0.24.0 ships, drop every librustzcash entry and use the crates.io releases.
      Currently pinned to `main` `a97a3d5f`.
- [ ] **`age`** (str4d/rage): the keystore uses `age::encrypted::EncryptedIdentity`
      and `Send + Sync` identities from `IdentityFile::into_identities`, which the
      crates.io 0.11.3 release lacks (it renamed the type and dropped the
      `Send + Sync` bound). Un-pin `age` and drop the `=0.11.1` requirement once a
      release carries these APIs. Currently pinned to `92f437bc`.
- [ ] **`zaino`** (zingolabs/zaino): NU6.3 / Ironwood `get_treestate` support.
      Un-pin once it lands in a release. Currently pinned to `dev` `8048bf8d`.
- [ ] **`zewif` / `zewif-zcashd`** (zcash): first crates.io release; un-pin then.

## Already released (done)

- [x] **`orchard` 0.15.0**: released; librustzcash `main` builds against it, so
      the orchard patch was removed.