### PR TITLE
fix(keystore): await aborted relock task in lock()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ be considered breaking changes.
   embedding them in the HTTP URL.
 
 ### Fixed
+- `walletlock` now awaits aborted relock tasks before returning, preventing a race
+  where a rapid `walletpassphrase` after `walletlock` could leave the wallet locked
+  despite reporting success.
 - `listaddresses` no longer returns an internal error when the wallet contains
   standalone imported transparent keys (e.g. from a `zcashd` migration).
 - No longer crashes in regtest mode when a Sapling or NU5 activation height is

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -380,6 +380,9 @@ impl KeyStore {
         let mut relock_task = self.relock_task.lock().await;
         if let Some((_, existing_timeout)) = relock_task.take() {
             existing_timeout.abort();
+            // Wait for the task to either finish or abort, to ensure there's zero
+            // possibility of a subsequent `unlock` having its identities cleared.
+            let _ = existing_timeout.await;
         }
 
         self.identities.write().await.clear();


### PR DESCRIPTION
Subsumes https://github.com/zcash/zallet/pull/468

KeyStore::lock() aborted the background relock task but did not await its completion, unlike unlock(). A rapid walletpassphrase after walletlock could therefore leave the wallet locked despite reporting success when the stale task cleared identities after unlock() repopulated them.

Fixes GHSA-8cfr-hmvc-2333.