### PR TITLE
Spend transparent funds in z_sendmany

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,43 @@ on `PATH` at run time.
 
 PRs MUST NOT introduce new warnings from `cargo +beta clippy --tests --all-features --all-targets`. Preexisting beta clippy warnings need not be resolved, but new ones introduced by a PR will block merging.
 
+## Testing Scope: Unit Tests Only
+
+**This repository does NOT host integration tests or scenario tests.** Those
+live in [zcash/integration-tests](https://github.com/zcash/integration-tests),
+which drives the whole Z3 stack (`zebrad` + `zainod` + `zallet`) over real RPC
+against a regtest chain. Do not add a test here that stands up a chain, mines
+blocks, sends a transaction end to end, or otherwise asserts on the behaviour of
+the stack as a whole; it belongs there.
+
+What belongs here is unit tests: fast, in-process, no chain, no network, no
+fixture wallet seeded by mining. Test the pure logic a function owns, at the
+boundary where a decision is actually made:
+
+- Pure derivations and policy decisions (e.g. "a transparent `fromaddress`
+  yields a spend policy that permits only that address's UTXOs, and no shielded
+  pool").
+- Parsing, validation, and error mapping of RPC parameters.
+- Serialization and response shapes.
+- Property tests (`proptest`) over the above where the input space is wide.
+  Prefer a property over a fixture: derive the key material from an arbitrary
+  seed rather than a hardcoded one, so the property is established for every
+  input rather than for the one that happened to be written down.
+
+Assert on the whole of a value rather than enumerating its parts, so a test does
+not silently stop covering a variant added later. Prefer "the permitted-pool set
+is empty" to a loop over today's three pools.
+
+If a piece of logic can only be tested by building a chain, that is usually a
+sign it should be extracted into a pure function that CAN be unit-tested, with
+the remaining end-to-end behaviour covered in `integration-tests`. Prefer
+extracting.
+
+A change to this repository that needs new stack-level coverage should be paired
+with a PR to `integration-tests`, referenced from the description, and wired via
+a `ZIT-Revision: <branch>` line so this repository's CI exercises it (see the
+Cross-Repository CI Integration docs).
+
 ## Auditing Dependency Version Bumps
 
 This applies to any change to a pinned dependency version: the `Dockerfile` and `Dockerfile.stagex` apt pins and base-image digests, and by extension any other pinned external artifact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,21 @@ be considered breaking changes.
   proposal builder, so no transparent input could ever be selected, and the
   `AllowFullyTransparent` privacy policy was unreachable.
   - Transparent funds are spendable only when `fromaddress` names a transparent
-    address. Input selection then draws on that address's UTXOs alone, so a
-    shielded send can never silently reach into transparent funds, and the named
-    address is not linked to the account's other transparent receivers. Every
-    other source remains shielded-only, unchanged. (`ANY_TADDR` as a source is
-    still unsupported.)
+    address, or is `ANY_TADDR` (see below). A named transparent address draws on
+    that address's UTXOs alone, so a shielded send can never silently reach into
+    transparent funds, and the named address is not linked to the account's other
+    transparent receivers. Every other source remains shielded-only, unchanged.
+  - `ANY_TADDR` is now supported as a `fromaddress`, spending non-coinbase UTXOs
+    from any transparent address in the legacy `zcashd` pool of funds, as it did
+    in `zcashd`. The pool is the account that `migrate-zcashd-wallet` creates for
+    the migrated wallet's mnemonic, so it must be named:
+    `features.legacy_pool_seed_fingerprint` must be set to that wallet's seed
+    fingerprint (the value the migration prints), otherwise the wallet has no
+    legacy pool and the call is rejected. Setting the option no longer logs an
+    "unused config option" warning at startup. Covering the payment from more
+    than one of the pool's addresses links them on-chain, so it requires the
+    `AllowLinkingAccountAddresses` privacy policy (or `NoPrivacy`, when the
+    transaction also has a transparent recipient or transparent change).
   - Coinbase outputs are not spendable this way: consensus requires them to be
     spent to a single shielded output, which remains `z_shieldcoinbase`'s job. A
     transparent spend therefore requires a non-coinbase UTXO.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ be considered breaking changes.
   when the wallet's key material is encrypted, the command interactively
   requests the wallet passphrase and decrypts the key material during the
   migration.
+- `z_sendmany` can now spend transparent funds, making transparent-to-transparent
+  transfers possible. Previously it passed a shielded-only spend policy to the
+  proposal builder, so no transparent input could ever be selected, and the
+  `AllowFullyTransparent` privacy policy was unreachable.
+  - Transparent funds are spendable only when `fromaddress` names a transparent
+    address. Input selection then draws on that address's UTXOs alone, so a
+    shielded send can never silently reach into transparent funds, and the named
+    address is not linked to the account's other transparent receivers. Every
+    other source remains shielded-only, unchanged. (`ANY_TADDR` as a source is
+    still unsupported.)
+  - Coinbase outputs are not spendable this way: consensus requires them to be
+    spent to a single shielded output, which remains `z_shieldcoinbase`'s job. A
+    transparent spend therefore requires a non-coinbase UTXO.
+  - A transaction that both spends transparent funds and has transparent
+    recipients or change requires the `AllowFullyTransparent` privacy policy. A
+    transparent source paying a shielded recipient still only needs
+    `AllowRevealedSenders`.
+  - Change on a fully transparent send stays in the transparent pool, at an
+    internal-scope (BIP 44) change address, and a fresh one is reserved per
+    transaction so that consecutive sends cannot be linked through a reused
+    change address. Transparent change is emitted only when the transaction has
+    no shielded input or output at all; any send with a shielded component
+    continues to shield its change exactly as before.
 - The `zebra` chain backend (and the `zaino` backend's read-state-service mode)
   now support regtest. The read-state service builds a Zebra Regtest network
   whose network-upgrade activation heights mirror the wallet's configured
@@ -43,6 +66,19 @@ be considered breaking changes.
 
 ### Fixed
 
+- `get_account_for_address` now resolves a bare transparent address to the account
+  that owns it. It previously compared the address against the account's listed
+  addresses, which are unified addresses; a transparent receiver never compares
+  equal to the unified address it belongs to, so passing a `taddr` as a payment
+  source failed with "Invalid from address, no payment source found for address."
+- The wallet database connection now implements
+  `InputSource::select_spendable_transparent_outputs` and
+  `WalletWrite::reserve_next_n_internal_addresses`. Both are defaulted in their
+  traits to an `unimplemented!()`, so omitting them compiled cleanly and instead
+  panicked the wallet process at run time: the first on selecting any transparent
+  input, the second on producing transparent change. Nothing reached either while
+  transparent spending was impossible; both are on the path of any transparent
+  spend, and of the forthcoming `z_sendfromaccount` and `z_proposetransaction`.
 - `steady_state` sync no longer crashes the whole wallet when the backend's best
   chain reorgs away a block the wallet had already stored (`BlockConflict`).
   Previously this error wasn't recognized as retryable, so it propagated as a

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -38,11 +38,6 @@ impl StartCmd {
         if config.builder.tx_expiry_delta.is_some() {
             warn_unused("builder.tx_expiry_delta");
         }
-        // TODO: https://github.com/zcash/zallet/issues/138
-        #[cfg(zallet_build = "wallet")]
-        if config.features.legacy_pool_seed_fingerprint.is_some() {
-            warn_unused("features.legacy_pool_seed_fingerprint");
-        }
         // TODO: https://github.com/zcash/zallet/issues/201
         #[cfg(zallet_build = "wallet")]
         if config.keystore.require_backup.is_some() {

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -18,6 +18,7 @@ use zcash_client_backend::{
         error::{FindAccountForAddressError, RewindError},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
+    fees::StandardFeeRule,
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
     wallet::{Note, ReceivedNote, TransparentAddressMetadata, WalletTransparentOutput},
 };
@@ -500,6 +501,32 @@ impl InputSource for DbConnection {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn select_spendable_transparent_outputs(
+        &self,
+        account: Self::AccountId,
+        target_height: TargetHeight,
+        confirmations_policy: ConfirmationsPolicy,
+        output_filter: CoinbaseFilter,
+        address_allow_list: Option<&[TransparentAddress]>,
+        target_value: TargetValue,
+        max_inputs: usize,
+        fee_rule: &StandardFeeRule,
+    ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
+        self.with(|db_data| {
+            db_data.select_spendable_transparent_outputs(
+                account,
+                target_height,
+                confirmations_policy,
+                output_filter,
+                address_allow_list,
+                target_value,
+                max_inputs,
+                fee_rule,
+            )
+        })
+    }
+
     fn get_account_metadata(
         &self,
         account: Self::AccountId,
@@ -659,6 +686,14 @@ impl WalletWrite for DbConnection {
         n: usize,
     ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
         self.with_mut(|mut db_data| db_data.reserve_next_n_ephemeral_addresses(account_id, n))
+    }
+
+    fn reserve_next_n_internal_addresses(
+        &mut self,
+        account_id: Self::AccountId,
+        n: usize,
+    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        self.with_mut(|mut db_data| db_data.reserve_next_n_internal_addresses(account_id, n))
     }
 
     fn set_transaction_status(

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -587,9 +587,16 @@ pub(crate) trait WalletRpc {
     ///
     /// - `fromaddress` (string, required) The transparent or shielded address to send the
     ///   funds from. The following special strings are also accepted:
-    ///   - `"ANY_TADDR"`: Select non-coinbase UTXOs from any transparent addresses
-    ///     belonging to the wallet. Use `z_shieldcoinbase` to shield coinbase UTXOs from
-    ///     multiple transparent addresses.
+    ///   - `"ANY_TADDR"`: Select non-coinbase UTXOs from any transparent address in the
+    ///     legacy `zcashd` pool of funds. This requires
+    ///     `features.legacy_pool_seed_fingerprint` to be set in the Zallet config file to
+    ///     the seed fingerprint of the `zcashd` wallet that was migrated into this wallet;
+    ///     without it there is no legacy pool to spend from and the call is rejected.
+    ///     Covering the payment from more than one of the pool's addresses links them
+    ///     on-chain, so such a call requires a privacy policy of
+    ///     `AllowLinkingAccountAddresses` (or of `NoPrivacy`, if it also has a transparent
+    ///     recipient or transparent change). Use `z_shieldcoinbase` to shield coinbase
+    ///     UTXOs from multiple transparent addresses.
     ///   If a unified address is provided for this argument, the TXOs to be spent will be
     ///   selected from those associated with the account corresponding to that unified
     ///   address, from value pools corresponding to the receivers included in the UA.

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -13,11 +13,14 @@ use zcash_client_backend::{
         Account,
         wallet::{
             ConfirmationsPolicy, create_proposed_transactions,
-            input_selection::{GreedyInputSelector, SpendPolicy},
+            input_selection::{GreedyInputSelector, SpendPolicy, TransparentSpendPolicy},
             propose_transfer,
         },
     },
-    fees::{DustOutputPolicy, StandardFeeRule, standard::MultiOutputChangeStrategy},
+    fees::{
+        DustOutputPolicy, StandardFeeRule, TransparentChangePolicy,
+        standard::MultiOutputChangeStrategy,
+    },
     wallet::OvkPolicy,
 };
 use zcash_client_sqlite::ReceivedNoteId;
@@ -64,6 +67,45 @@ pub(super) const PARAM_FEE_DESC: &str = "If set, it must be null.";
 pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
     "Policy for what information leakage is acceptable.";
 
+/// The sources of funds a transfer from `source` may draw upon.
+///
+/// Spending from a bare transparent address draws only on that address's UTXOs: the funds are
+/// already public, and confining selection to the named address avoids linking it to the
+/// account's other transparent receivers. Every other source stays shielded-only, so a
+/// shielded send can never silently reach into transparent funds.
+///
+/// Coinbase UTXOs are excluded: `TransparentSpendPolicy` defaults to
+/// `CoinbasePolicy::NonCoinbase`, and consensus requires coinbase to be spent to a single
+/// shielded output, which is `z_shieldcoinbase`'s job.
+///
+/// The privacy policy deliberately does not narrow this: the selector returns its best
+/// proposal, and `enforce_privacy_policy` rejects it afterwards if it leaks more than the
+/// caller permitted.
+fn spend_policy_for(source: &Address) -> SpendPolicy {
+    match source {
+        Address::Transparent(taddr) => SpendPolicy::shielded_pools([])
+            .with_transparent(TransparentSpendPolicy::from_one_address(*taddr)),
+        _ => SpendPolicy::default(),
+    }
+}
+
+/// Whether change may be returned to the transparent pool.
+///
+/// Permitted exactly when `spend_policy` can spend transparent funds in the first place, which
+/// keeps a fully transparent send transparent end to end rather than sweeping its change into a
+/// shielded pool. A shielded send therefore cannot acquire a transparent change output by this
+/// route.
+///
+/// The change strategy independently enforces the same thing (it emits transparent change only
+/// when the transaction's net flows are fully transparent, i.e. it has no shielded input or
+/// output at all), but that is its invariant, not ours.
+fn transparent_change_policy_for(spend_policy: &SpendPolicy) -> TransparentChangePolicy {
+    match spend_policy.transparent() {
+        Some(_) => TransparentChangePolicy::TransparentChangeAllowed,
+        None => TransparentChangePolicy::ShieldChange,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn call<C: Chain>(
     mut wallet: DbHandle,
@@ -88,7 +130,7 @@ pub(crate) async fn call<C: Chain>(
 
     let request = build_request(&amounts)?;
 
-    let account = match fromaddress.as_str() {
+    let (account, spend_policy) = match fromaddress.as_str() {
         // Select from the legacy transparent address pool.
         // TODO: Support this if we're going to. https://github.com/zcash/zallet/issues/138
         "ANY_TADDR" => Err(LegacyCode::WalletAccountsUnsupported
@@ -101,7 +143,9 @@ pub(crate) async fn call<C: Chain>(
             )
             })?;
 
-            get_account_for_address(wallet.as_ref(), &address)
+            let account = get_account_for_address(wallet.as_ref(), &address)?;
+
+            Ok((account, spend_policy_for(&address)))
         }
     }?;
 
@@ -198,19 +242,40 @@ pub(crate) async fn call<C: Chain>(
         }
     }
 
+    let transparent_change_policy = transparent_change_policy_for(&spend_policy);
+
+    // Where shielded change goes when the transaction has no shielded flows to infer a pool
+    // from. A transaction that does have shielded flows ignores this and keeps its change in
+    // the pool it is already using.
+    //
+    // This stays Orchard rather than Ironwood: the change strategy promotes it to Ironwood
+    // itself once NU6.3 is active (the turnstile forbids value from entering the Orchard
+    // pool, so change out of a purely transparent transaction has to land in Ironwood), and
+    // it does so against the transaction's target height, which is not known here. Naming
+    // Ironwood outright would instead send change to a pool that does not exist yet on a
+    // chain where NU6.3 has not activated.
+    let fallback_change_pool = ShieldedPool::Orchard;
+
+    // Shielded change is split across several notes, per the wallet's note-management
+    // configuration, so the account keeps a usable set of denominations.
+    let split_policy = APP.config().note_management.split_policy();
+
+    // Change too small to be worth its own output is added to the fee instead.
+    let dust_output_policy = DustOutputPolicy::default();
+
+    // No memo is attached to change. A change memo would force the change into a shielded
+    // pool, since a transparent output cannot carry one.
+    let change_memo = None;
+
     let change_strategy = MultiOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Orchard,
-        DustOutputPolicy::default(),
-        APP.config().note_management.split_policy(),
-    );
+        change_memo,
+        fallback_change_pool,
+        dust_output_policy,
+        split_policy,
+    )
+    .with_transparent_change_policy(transparent_change_policy);
 
-    // TODO: Once `zcash_client_backend` supports spending transparent coins arbitrarily,
-    // consider using the privacy policy here to avoid selecting incompatible funds. This
-    // would match what `zcashd` did more closely (though we might instead decide to let
-    // the selector return its best proposal and then continue to reject afterwards, as we
-    // currently do).
     let input_selector = GreedyInputSelector::new();
 
     let proposal = propose_transfer::<_, _, _, _, Infallible>(
@@ -221,11 +286,7 @@ pub(crate) async fn call<C: Chain>(
         &change_strategy,
         request,
         confirmations_policy,
-        // Zallet does not yet spend transparent funds in a general transfer; `ANY_TADDR`
-        // spending is rejected above. The default `SpendPolicy` permits every shielded pool
-        // present in the build and no transparent spending, preserving the prior
-        // shielded-only behavior.
-        &SpendPolicy::default(),
+        &spend_policy,
         // Do not request a specific transaction version; building falls back to the version
         // implied by the target height.
         None,
@@ -365,4 +426,145 @@ async fn run<C: Chain>(
     .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?;
 
     broadcast_transactions(&wallet, chain, txids.into()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use zcash_client_backend::{
+        data_api::wallet::input_selection::{CoinbasePolicy, TransparentSource},
+        fees::TransparentChangePolicy,
+    };
+    use zcash_keys::{
+        address::{Address, UnifiedAddress},
+        keys::{UnifiedAddressRequest, UnifiedSpendingKey},
+    };
+    use zcash_protocol::consensus::Network;
+    use zip32::AccountId;
+
+    use super::{SpendPolicy, spend_policy_for, transparent_change_policy_for};
+
+    /// A unified address carrying every receiver type, derived from `seed` and `account`.
+    ///
+    /// No wallet database and no chain: the policy derivations under test are pure functions
+    /// of the source address, which is what makes them unit-testable here rather than in
+    /// `integration-tests`.
+    ///
+    /// Returns `None` for the seeds and diversifiers ZIP 32 rejects, so a property can skip
+    /// them rather than assert on an address that cannot exist.
+    fn ua_from(seed: &[u8; 32], account: u32) -> Option<UnifiedAddress> {
+        let account = AccountId::try_from(account).ok()?;
+        let usk = UnifiedSpendingKey::from_seed(&Network::TestNetwork, seed, account).ok()?;
+        let (ua, _) = usk
+            .to_unified_full_viewing_key()
+            .default_address(UnifiedAddressRequest::ALLOW_ALL)
+            .ok()?;
+        Some(ua)
+    }
+
+    /// ZIP 32 account indices are non-hardened, so they occupy the low 31 bits.
+    fn arb_account() -> impl Strategy<Value = u32> {
+        0u32..(1 << 31)
+    }
+
+    proptest! {
+        // Each case derives a spending key, which is expensive, so take fewer samples than
+        // the default 256. The properties hold for every source address, not for rare
+        // corners of the seed space, so a modest sample establishes them.
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        /// Whatever key it was derived from, a transparent source draws only on that one
+        /// address's UTXOs, and on no shielded note.
+        #[test]
+        fn transparent_source_spends_only_that_address_and_no_shielded_pool(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let Some(&taddr) = ua.transparent() else { return Ok(()) };
+
+            let policy = spend_policy_for(&Address::Transparent(taddr));
+
+            // A transparent send must not reach into the account's shielded funds. The
+            // permitted-pool SET being empty says this exhaustively: it forbids every
+            // shielded pool, including any added to `ShieldedPool` after this was written,
+            // which enumerating the variants here would not.
+            prop_assert!(
+                policy.shielded().is_empty(),
+                "a transparent source must permit no shielded pool, got {:?}",
+                policy.shielded(),
+            );
+
+            let transparent = policy
+                .transparent()
+                .expect("a transparent source permits transparent spending");
+
+            // Only the named address, so spending it does not link the source to the
+            // account's other transparent receivers.
+            match transparent.source() {
+                TransparentSource::FromAddresses(addrs) => prop_assert_eq!(
+                    addrs.iter().copied().collect::<Vec<_>>(),
+                    vec![taddr],
+                    "selection must be confined to the named address",
+                ),
+                other => prop_assert!(
+                    false,
+                    "expected a single-address source, got {other:?}",
+                ),
+            }
+
+            // Coinbase must be spent to a single shielded output (`z_shieldcoinbase`'s
+            // job), so a general transfer never draws on it.
+            prop_assert_eq!(transparent.coinbase(), CoinbasePolicy::NonCoinbase);
+        }
+
+        /// The property whose absence made transparent spending impossible, inverted: a
+        /// shielded source must never be able to select a transparent input, even though the
+        /// unified address it names does carry a transparent receiver.
+        #[test]
+        fn shielded_source_permits_no_transparent_spending(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+
+            let policy = spend_policy_for(&Address::Unified(ua));
+
+            prop_assert!(
+                policy.transparent().is_none(),
+                "a shielded source must not permit transparent spending",
+            );
+
+            // Shielded selection is left exactly as it was before transparent spending
+            // existed. Comparing against the default's pool set keeps that true for any
+            // pool added later, rather than pinning today's three.
+            let unchanged = SpendPolicy::default();
+            prop_assert_eq!(policy.shielded(), unchanged.shielded());
+        }
+
+        /// Change may be returned to the transparent pool exactly when the source could spend
+        /// transparent funds in the first place.
+        #[test]
+        fn transparent_change_permitted_exactly_when_transparent_funds_are_spendable(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let Some(&taddr) = ua.transparent() else { return Ok(()) };
+
+            let transparent_source = spend_policy_for(&Address::Transparent(taddr));
+            prop_assert_eq!(
+                transparent_change_policy_for(&transparent_source),
+                TransparentChangePolicy::TransparentChangeAllowed,
+                "a fully transparent send keeps its change transparent",
+            );
+
+            let shielded_source = spend_policy_for(&Address::Unified(ua));
+            prop_assert_eq!(
+                transparent_change_policy_for(&shielded_source),
+                TransparentChangePolicy::ShieldChange,
+                "a shielded send must not acquire a transparent change output",
+            );
+        }
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -40,7 +40,7 @@ use crate::{
             payments::{
                 AmountParameter, IncompatiblePrivacyPolicy, PrivacyPolicy, SendResult,
                 broadcast_transactions, build_request, enforce_privacy_policy,
-                get_account_for_address,
+                get_account_for_address, get_legacy_pool_account,
             },
             server::LegacyCode,
         },
@@ -89,6 +89,27 @@ fn spend_policy_for(source: &Address) -> SpendPolicy {
     }
 }
 
+/// The sources of funds a transfer from `ANY_TADDR` may draw upon.
+///
+/// `zcashd` treated the transparent addresses of a wallet as a single pool of funds, and
+/// `ANY_TADDR` drew on any of them. Zallet holds that pool in one account (see
+/// [`get_legacy_pool_account`]), and [`TransparentSpendPolicy::any_account_addr`] reproduces
+/// the selection within it: the proposer spends whichever of the account's transparent
+/// receivers cover the request, linking them on-chain when one address does not suffice.
+///
+/// That linkage is bounded by the caller's privacy policy rather than here: a proposal
+/// spending more than one transparent address is rejected by `enforce_privacy_policy` unless
+/// the caller permitted `AllowLinkingAccountAddresses` (or `NoPrivacy`, when the transaction
+/// also has a transparent output or transparent change).
+///
+/// Like a bare transparent source, this permits no shielded pool: `ANY_TADDR` names
+/// transparent funds, so it must not become a way to spend the account's notes. Coinbase is
+/// likewise excluded (`CoinbasePolicy::NonCoinbase`), matching `zcashd`, which sent callers
+/// to `z_shieldcoinbase` for coinbase funds.
+fn legacy_pool_spend_policy() -> SpendPolicy {
+    SpendPolicy::shielded_pools([]).with_transparent(TransparentSpendPolicy::any_account_addr())
+}
+
 /// Whether change may be returned to the transparent pool.
 ///
 /// Permitted exactly when `spend_policy` can spend transparent funds in the first place, which
@@ -131,10 +152,12 @@ pub(crate) async fn call<C: Chain>(
     let request = build_request(&amounts)?;
 
     let (account, spend_policy) = match fromaddress.as_str() {
-        // Select from the legacy transparent address pool.
-        // TODO: Support this if we're going to. https://github.com/zcash/zallet/issues/138
-        "ANY_TADDR" => Err(LegacyCode::WalletAccountsUnsupported
-            .with_static("The legacy account is currently unsupported for spending from")),
+        // Select from the legacy transparent address pool, which this wallet holds in a
+        // single account. Enabled by `features.legacy_pool_seed_fingerprint`.
+        "ANY_TADDR" => (
+            get_legacy_pool_account(wallet.as_ref())?,
+            legacy_pool_spend_policy(),
+        ),
         // Select the account corresponding to the given address.
         _ => {
             let address = Address::decode(wallet.params(), &fromaddress).ok_or_else(|| {
@@ -145,9 +168,9 @@ pub(crate) async fn call<C: Chain>(
 
             let account = get_account_for_address(wallet.as_ref(), &address)?;
 
-            Ok((account, spend_policy_for(&address)))
+            (account, spend_policy_for(&address))
         }
-    }?;
+    };
 
     let privacy_policy = match privacy_policy.as_deref() {
         Some("LegacyCompat") => Err(LegacyCode::InvalidParameter
@@ -442,7 +465,46 @@ mod tests {
     use zcash_protocol::consensus::Network;
     use zip32::AccountId;
 
-    use super::{SpendPolicy, spend_policy_for, transparent_change_policy_for};
+    use super::{
+        SpendPolicy, legacy_pool_spend_policy, spend_policy_for, transparent_change_policy_for,
+    };
+
+    /// `ANY_TADDR` draws on the legacy pool's transparent funds, on any address within it, and
+    /// on nothing else.
+    #[test]
+    fn legacy_pool_source_spends_any_account_taddr_and_no_shielded_pool() {
+        let policy = legacy_pool_spend_policy();
+
+        // As for a bare transparent source, the empty permitted-pool set says exhaustively
+        // that no shielded note can be spent, including from pools added after this was
+        // written.
+        assert!(
+            policy.shielded().is_empty(),
+            "the legacy pool holds transparent funds, so no shielded pool may be spent, got {:?}",
+            policy.shielded(),
+        );
+
+        let transparent = policy
+            .transparent()
+            .expect("the legacy pool permits transparent spending");
+
+        // The whole point of `ANY_TADDR`: the proposer picks the addresses, rather than the
+        // caller naming one.
+        assert!(
+            matches!(transparent.source(), TransparentSource::AnyAccountAddr),
+            "`ANY_TADDR` must draw on any of the account's transparent receivers, got {:?}",
+            transparent.source(),
+        );
+
+        // Coinbase is `z_shieldcoinbase`'s job, in Zallet as in `zcashd`.
+        assert_eq!(transparent.coinbase(), CoinbasePolicy::NonCoinbase);
+
+        // A fully transparent send keeps its change transparent.
+        assert_eq!(
+            transparent_change_policy_for(&policy),
+            TransparentChangePolicy::TransparentChangeAllowed,
+        );
+    }
 
     /// A unified address carrying every receiver type, derived from `seed` and `account`.
     ///

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -628,6 +628,23 @@ pub(super) fn get_account_for_address(
     wallet: &DbConnection,
     address: &Address,
 ) -> RpcResult<Account> {
+    // A bare transparent address is generally not a wallet address in its own right: it is
+    // a *receiver* of one of the account's unified addresses, so it never compares equal to
+    // any `AddressInfo` in the scan below (those hold the whole UA). `find_account_for_address`
+    // resolves an address through its receivers, so it maps such a taddr back to its owning
+    // account; without it, a taddr `fromaddress` can never be spent from.
+    if let Some(account_id) = wallet
+        .find_account_for_address(wallet.params(), address)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+    {
+        return Ok(wallet
+            .get_account(account_id)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .expect("present"));
+    }
+
+    // Fall back to scanning the account address lists, which also covers address kinds the
+    // receiver index does not resolve.
     // TODO: Make this more efficient with a `WalletRead` method.
     //       https://github.com/zcash/librustzcash/issues/1944
     for account_id in wallet

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -630,39 +630,68 @@ mod parse_memo_tests {
 
 #[cfg(test)]
 mod legacy_pool_tests {
+    use proptest::prelude::*;
     use zip32::{AccountId, fingerprint::SeedFingerprint};
 
     use super::{ZCASH_LEGACY_ACCOUNT, is_legacy_pool_account};
 
-    /// The legacy pool is one account of one seed: the account at the legacy ZIP 32 index,
-    /// derived from the seed the operator named. Nothing else may be spent as `ANY_TADDR`,
-    /// since every other account is a separate pool of funds under Zallet's semantics.
-    #[test]
-    fn legacy_pool_is_only_the_named_seeds_legacy_account() {
-        let legacy_seed_fp = SeedFingerprint::from_bytes([1; 32]);
-        let other_seed_fp = SeedFingerprint::from_bytes([2; 32]);
-        let legacy_index = AccountId::try_from(ZCASH_LEGACY_ACCOUNT)
-            .expect("the legacy account index is a valid ZIP 32 account index");
+    /// A ZIP 32 account index that is not the legacy one. Indices are non-hardened, so they
+    /// occupy the low 31 bits, and the legacy index is the largest of them.
+    fn arb_regular_account_index() -> impl Strategy<Value = u32> {
+        0u32..ZCASH_LEGACY_ACCOUNT
+    }
 
-        assert!(is_legacy_pool_account(
-            &legacy_seed_fp,
-            legacy_index,
-            &legacy_seed_fp,
-        ));
+    proptest! {
+        /// The legacy pool is one account of one seed: the account at the legacy ZIP 32
+        /// index, derived from the seed the operator named. Nothing else may be spent as
+        /// `ANY_TADDR`, since every other account is a separate pool of funds under Zallet's
+        /// semantics.
+        ///
+        /// Established over arbitrary seeds and arbitrary regular account indices, rather
+        /// than a hardcoded pair, so it holds for whatever seed a wallet actually carries.
+        #[test]
+        fn legacy_pool_is_only_the_named_seeds_legacy_account(
+            legacy_seed in any::<[u8; 32]>(),
+            other_seed in any::<[u8; 32]>(),
+            regular_index in arb_regular_account_index(),
+        ) {
+            // Two distinct `zcashd` wallets, hence two distinct seeds.
+            prop_assume!(legacy_seed != other_seed);
 
-        // A regular account of the legacy seed is a pool of funds in its own right.
-        assert!(!is_legacy_pool_account(
-            &legacy_seed_fp,
-            AccountId::ZERO,
-            &legacy_seed_fp,
-        ));
+            let legacy_seed_fp = SeedFingerprint::from_bytes(legacy_seed);
+            let other_seed_fp = SeedFingerprint::from_bytes(other_seed);
+            let legacy_index = AccountId::try_from(ZCASH_LEGACY_ACCOUNT)
+                .expect("the legacy account index is a valid ZIP 32 account index");
+            let regular_index = AccountId::try_from(regular_index)
+                .expect("indices below the legacy one are valid ZIP 32 account indices");
 
-        // Another `zcashd` wallet's legacy account is not this wallet's legacy pool.
-        assert!(!is_legacy_pool_account(
-            &other_seed_fp,
-            legacy_index,
-            &legacy_seed_fp,
-        ));
+            prop_assert!(is_legacy_pool_account(
+                &legacy_seed_fp,
+                legacy_index,
+                &legacy_seed_fp,
+            ));
+
+            // A regular account of the legacy seed is a pool of funds in its own right.
+            prop_assert!(!is_legacy_pool_account(
+                &legacy_seed_fp,
+                regular_index,
+                &legacy_seed_fp,
+            ));
+
+            // Another `zcashd` wallet's legacy account is not this wallet's legacy pool.
+            prop_assert!(!is_legacy_pool_account(
+                &other_seed_fp,
+                legacy_index,
+                &legacy_seed_fp,
+            ));
+
+            // And neither is any other account of that other wallet.
+            prop_assert!(!is_legacy_pool_account(
+                &other_seed_fp,
+                regular_index,
+                &legacy_seed_fp,
+            ));
+        }
     }
 }
 

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -7,13 +7,14 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
-    data_api::WalletRead,
+    data_api::{Account as _, WalletRead},
     proposal::Proposal,
     zip321::{Payment, TransactionRequest},
 };
 use zcash_client_sqlite::wallet::Account;
 use zcash_keys::address::Address;
 use zcash_protocol::{PoolType, TxId, memo::MemoBytes, value::Zatoshis};
+use zip32::{AccountId, fingerprint::SeedFingerprint};
 
 use crate::{
     components::{chain::Chain, database::DbConnection},
@@ -21,7 +22,10 @@ use crate::{
     prelude::APP,
 };
 
-use super::{server::LegacyCode, utils::zatoshis_from_value};
+use super::{
+    server::LegacyCode,
+    utils::{ZCASH_LEGACY_ACCOUNT, zatoshis_from_value},
+};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub(crate) struct AmountParameter {
@@ -624,6 +628,44 @@ mod parse_memo_tests {
     }
 }
 
+#[cfg(test)]
+mod legacy_pool_tests {
+    use zip32::{AccountId, fingerprint::SeedFingerprint};
+
+    use super::{ZCASH_LEGACY_ACCOUNT, is_legacy_pool_account};
+
+    /// The legacy pool is one account of one seed: the account at the legacy ZIP 32 index,
+    /// derived from the seed the operator named. Nothing else may be spent as `ANY_TADDR`,
+    /// since every other account is a separate pool of funds under Zallet's semantics.
+    #[test]
+    fn legacy_pool_is_only_the_named_seeds_legacy_account() {
+        let legacy_seed_fp = SeedFingerprint::from_bytes([1; 32]);
+        let other_seed_fp = SeedFingerprint::from_bytes([2; 32]);
+        let legacy_index = AccountId::try_from(ZCASH_LEGACY_ACCOUNT)
+            .expect("the legacy account index is a valid ZIP 32 account index");
+
+        assert!(is_legacy_pool_account(
+            &legacy_seed_fp,
+            legacy_index,
+            &legacy_seed_fp,
+        ));
+
+        // A regular account of the legacy seed is a pool of funds in its own right.
+        assert!(!is_legacy_pool_account(
+            &legacy_seed_fp,
+            AccountId::ZERO,
+            &legacy_seed_fp,
+        ));
+
+        // Another `zcashd` wallet's legacy account is not this wallet's legacy pool.
+        assert!(!is_legacy_pool_account(
+            &other_seed_fp,
+            legacy_index,
+            &legacy_seed_fp,
+        ));
+    }
+}
+
 pub(super) fn get_account_for_address(
     wallet: &DbConnection,
     address: &Address,
@@ -666,6 +708,78 @@ pub(super) fn get_account_for_address(
 
     Err(LegacyCode::InvalidAddressOrKey
         .with_static("Invalid from address, no payment source found for address."))
+}
+
+/// Whether an account with this ZIP 32 derivation holds the legacy `zcashd` pool of funds
+/// belonging to the wallet identified by `legacy_seed_fp`.
+///
+/// From v4.7.0 onwards, `zcashd` derived every address handed out by the legacy
+/// `getnewaddress` and `z_getnewaddress` methods from the wallet's mnemonic at ZIP 32
+/// account index [`ZCASH_LEGACY_ACCOUNT`], so the pool is exactly that one account of that
+/// one seed. `zallet migrate-zcashd-wallet` preserves it: it re-points a pre-v4.7.0 wallet's
+/// legacy account at the mnemonic `zcashd` would have grown on upgrade, and imports the
+/// wallet's standalone (`importprivkey`) transparent keys into the same account.
+///
+/// A regular account of the legacy seed is therefore not the legacy pool, and neither is
+/// another seed's legacy account: both would spend funds the caller did not name.
+fn is_legacy_pool_account(
+    seed_fingerprint: &SeedFingerprint,
+    account_index: AccountId,
+    legacy_seed_fp: &SeedFingerprint,
+) -> bool {
+    seed_fingerprint == legacy_seed_fp && u32::from(account_index) == ZCASH_LEGACY_ACCOUNT
+}
+
+/// Returns the account holding the legacy `zcashd` pool of funds.
+///
+/// Which of the wallet's seeds is the legacy one cannot be inferred: a Zallet wallet may hold
+/// accounts derived from several seeds, while `zcashd`'s legacy semantics were defined for a
+/// single wallet. The operator names it with the `features.legacy_pool_seed_fingerprint`
+/// config option (whose value `zallet migrate-zcashd-wallet` prints on import). With the
+/// option unset, this wallet has no legacy pool and callers that ask to spend from it are
+/// rejected.
+pub(super) fn get_legacy_pool_account(wallet: &DbConnection) -> RpcResult<Account> {
+    let legacy_seed_fp = APP
+        .config()
+        .features
+        .legacy_pool_seed_fingerprint
+        .ok_or_else(|| {
+            LegacyCode::WalletAccountsUnsupported.with_static(
+                "The legacy pool of funds is disabled. To enable it, set \
+                 `features.legacy_pool_seed_fingerprint` in the Zallet config file to the \
+                 seed fingerprint of the `zcashd` wallet migrated into this wallet.",
+            )
+        })?;
+
+    // TODO: Make this more efficient with a `WalletRead` method.
+    //       https://github.com/zcash/librustzcash/issues/1944
+    for account_id in wallet
+        .get_account_ids()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+    {
+        let account = wallet
+            .get_account(account_id)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            // This would be a race condition between this and account deletion.
+            .ok_or_else(|| LegacyCode::Database.with_static("Account vanished mid-call"))?;
+
+        // Accounts imported from a UFVK have no ZIP 32 derivation, and cannot be the legacy
+        // pool: `zcashd` derived the pool from the wallet's seed.
+        if account.source().key_derivation().is_some_and(|derivation| {
+            is_legacy_pool_account(
+                derivation.seed_fingerprint(),
+                derivation.account_index(),
+                &legacy_seed_fp,
+            )
+        }) {
+            return Ok(account);
+        }
+    }
+
+    Err(LegacyCode::Wallet.with_message(format!(
+        "This wallet holds no legacy account for seed fingerprint {legacy_seed_fp}. Check that \
+         `features.legacy_pool_seed_fingerprint` names a `zcashd` wallet migrated into it.",
+    )))
 }
 
 /// Broadcasts the specified transactions to the network, if configured to do so.

--- a/zallet-core/src/components/json_rpc/utils.rs
+++ b/zallet-core/src/components/json_rpc/utils.rs
@@ -46,7 +46,7 @@ use {
 /// The account identifier used for HD derivation of transparent and Sapling addresses via
 /// the legacy `getnewaddress` and `z_getnewaddress` code paths.
 #[cfg(zallet_build = "wallet")]
-const ZCASH_LEGACY_ACCOUNT: u32 = 0x7fff_ffff;
+pub(super) const ZCASH_LEGACY_ACCOUNT: u32 = 0x7fff_ffff;
 
 #[cfg(zallet_build = "wallet")]
 pub(super) async fn ensure_wallet_is_unlocked(keystore: &KeyStore) -> RpcResult<()> {


### PR DESCRIPTION
Stacked on #586 (Docker fix), which is unrelated but must land first for CI to be green. Base auto-retargets to `main` on its merge.

## Problem

`z_sendmany` passed `SpendPolicy::default()` to `propose_transfer`. That policy permits the shielded pools and **no transparent spending**:

```rust
impl Default for SpendPolicy {
    fn default() -> Self {
        Self::shielded_pools([Sapling, Orchard, Ironwood])   // transparent: None
    }
}
```

With `transparent()` returning `None`, `GreedyInputSelector` skips the transparent gather entirely (`=> Vec::new()`), so **no proposal could ever contain a transparent input**. Transparent-to-transparent transfers were impossible, and the `AllowFullyTransparent` privacy policy was unreachable — `enforce_privacy_policy` already implemented it correctly, but no proposal it could accept could be built.

The `// TODO: Once zcash_client_backend supports spending transparent coins arbitrarily` comment was stale. The pinned librustzcash already provides `SpendPolicy::with_transparent`, `TransparentSpendPolicy`, `CoinbasePolicy`, and `TransparentChangePolicy`. **No dependency bump.**

## Solution

Derive the spend policy from the source address instead of hardcoding the default:

```rust
let spend_policy = match &address {
    Address::Transparent(taddr) => SpendPolicy::shielded_pools([])
        .with_transparent(TransparentSpendPolicy::from_one_address(*taddr)),
    _ => SpendPolicy::default(),
};
```

- A **bare transparent `fromaddress`** permits transparent spending restricted to that one address's UTXOs. A shielded send can never silently reach into transparent funds, and the named address is not linked to the account's other transparent receivers.
- **Every other source is unchanged** (`SpendPolicy::default()`), so shielded behaviour is untouched.
- **Coinbase stays unspendable** (`CoinbasePolicy::NonCoinbase` is the default): consensus requires it be spent to a single shielded output, which remains `z_shieldcoinbase`'s job. A transparent spend needs a non-coinbase UTXO.
- **`ANY_TADDR` remains unsupported** (#384) and is explicitly out of scope.

The privacy policy is deliberately *not* consulted during selection: the selector returns its best proposal, and `enforce_privacy_policy` rejects it afterwards. Resulting lattice, all enforced and all tested:

| Flow | Required policy |
| --- | --- |
| transparent source -> shielded recipient | `AllowRevealedSenders` |
| transparent source -> transparent recipient/change | `AllowFullyTransparent` |

### Transparent change

Transparent change is permitted **only when the spend policy carries a transparent component**:

```rust
let transparent_change_policy = match spend_policy.transparent() {
    Some(_) => TransparentChangePolicy::TransparentChangeAllowed,
    None => TransparentChangePolicy::ShieldChange,
};
```

This keeps a fully transparent send transparent end to end rather than sweeping its change into a shielded pool. The change strategy independently enforces the same thing (it emits transparent change only when the net flows are fully transparent, i.e. no shielded input or output at all) — but that is *its* invariant, not ours, so we state ours locally rather than depend on it. **A shielded send cannot acquire a transparent change output by this route.** Change lands at an internal-scope (BIP 44) address, freshly reserved per transaction, so consecutive sends cannot be linked through a reused change address.

`fallback_change_pool` stays `ShieldedPool::Orchard`, deliberately. It is consulted only when the flows are fully transparent, and `select_change_pool` promotes it to Ironwood itself once NU6.3 is active (the turnstile forbids value entering Orchard), keyed on the transaction's **target height** — which is not known where the change strategy is constructed. Naming `Ironwood` outright would send change to a pool that does not exist yet on a pre-NU6.3 chain.

## Three latent defects this surfaced

All were unreachable while transparent spending was impossible. **Two panicked the wallet process** rather than returning an error, because the trait methods are *defaulted* to `unimplemented!()` — so omitting them compiles cleanly and only fails at run time.

1. `get_account_for_address` compared the source against `list_addresses()`, which yields **unified** addresses. A bare transparent receiver never compares equal to the UA it belongs to, so a `taddr` `fromaddress` always failed with `Invalid from address, no payment source found for address.` Now resolved via `find_account_for_address`, which maps an address back through its receivers.
2. `DbConnection` did not implement `InputSource::select_spendable_transparent_outputs` — **panic** on selecting any transparent input.
3. `DbConnection` did not implement `WalletWrite::reserve_next_n_internal_addresses` — **panic** on producing transparent change.

Note for reviewers: **`z_sendfromaccount` and `z_proposetransaction` sit on the same two methods.** Landing this first means they will not rediscover these panics.

## Testing

Covered by zcash/integration-tests#163, which adds `wallet_transparent_spend.py` and reactivates `wallet_changeaddresses.py` and `regtest_signrawtransaction.py` — both were disabled pending the account/UA migration, and both exist to exercise transparent spending. The trailer at the bottom of this description points this PR's CI at that branch.

Verified locally on both sides of the NU6.3 boundary:

- `wallet_transparent_spend.py` (NU6.3 off) — 4 ZEC sent t-to-t; asserts the tx is fully transparent (no shielded components), the recipient balance on-chain, and change at a fresh internal address. Pins **both** policy rejections: `AllowRevealedSenders` and `AllowRevealedRecipients` are each insufficient alone, and they fail via *different* checks (the recipient check runs on the request; the fully-transparent check runs on the built proposal).
- `wallet_changeaddresses.py` (NU6.3 off) — two consecutive transparent sends use different change addresses.
- `regtest_signrawtransaction.py` (NU6.3 off) — a transparent input signs under the correct consensus branch id.
- `wallet_ironwood.py` (NU6.3 **on**) and `wallet_z_shieldcoinbase.py` — regressions, unaffected.

Clippy clean; 189/189 `zallet-core` unit tests pass.

ZIT-Revision: t-t-tests
