### PR TITLE
docker: bump the protobuf-compiler pin to 3.21.12-3+deb12u1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,41 @@ on `PATH` at run time.
 
 PRs MUST NOT introduce new warnings from `cargo +beta clippy --tests --all-features --all-targets`. Preexisting beta clippy warnings need not be resolved, but new ones introduced by a PR will block merging.
 
+## Auditing Dependency Version Bumps
+
+This applies to any change to a pinned dependency version: the `Dockerfile` and `Dockerfile.stagex` apt pins and base-image digests, and by extension any other pinned external artifact.
+
+A version bump is a supply-chain change. Bumping a pin means executing different third-party code in our build, so **a pin MUST NOT be bumped merely because the build went red.** "CI is broken, so I raised the number until it went green" is not a review; it is how a malicious or merely broken upstream gets in unexamined.
+
+Note that the Dockerfile's apt pins rot on their own, with no change on our side: `deb.debian.org` serves only the *current* revision of each package, so a Debian point release or security update deletes the pinned revision and the build fails with `Version '...' was not found`. That is expected, and it is exactly the moment this audit is required.
+
+**An agent bumping a pin MUST do all of the following**, and MUST NOT open the PR without them:
+
+1. **Read the actual diff.** Not the version number, not the changelog summary: the code. For a Debian package, fetch both source packages and diff them, e.g.
+
+   ```bash
+   curl -sfL http://deb.debian.org/debian/pool/main/p/protobuf/protobuf_<old>.debian.tar.xz -o old.tar.xz
+   curl -sfL http://deb.debian.org/debian/pool/main/p/protobuf/protobuf_<new>.debian.tar.xz -o new.tar.xz
+   # then diff debian/patches/series and inspect every added patch
+   ```
+
+   Determine which source trees each patch touches, and state whether they are code we actually ship or execute.
+
+2. **Link a discussion a human can follow.** The PR description MUST cite the upstream source: the Debian changelog URL (`https://metadata.ftp-master.debian.org/changelogs/main/<x>/<pkg>/<pkg>_<version>_changelog`), the CVE identifiers, the Debian bug numbers, and the upstream advisory or commit where applicable. A reviewer must be able to verify the claim without redoing the archaeology.
+
+3. **State the impact on us explicitly.** Which of the changed components does this image actually use? A protobuf update that only patches its Java, Python, and PHP runtimes does not affect a build that uses `protoc` solely for Rust codegen and ships none of those runtimes; say so, and say how you established it.
+
+4. **Confirm the new pin resolves**, against the digest-pinned base rather than your laptop:
+
+   ```bash
+   docker run --rm rust:<tag>@sha256:<digest> \
+     bash -c 'apt-get update -qq && apt-cache policy <package>'
+   ```
+
+5. **Keep the bump minimal.** Bump only the pins that actually moved; re-read the candidate versions and leave the rest alone. Never relax a pin to an unpinned or range version to dodge the problem, and never silence `hadolint`.
+
+If the diff is not benign, or you cannot establish what changed, STOP and say so in the PR rather than merging a version you have not audited.
+
 ## Commit & Pull Request Guidelines
 
 ### Commit History

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,16 +29,27 @@
 FROM rust:1.91.1-slim-bookworm@sha256:8514999d4786ef12efe89239e86b3d0a021b94b9d35108c8efe6c79ca7dc1a65 AS builder
 
 # Build deps: protobuf (tonic/PROTOC), clang+llvm (bindgen / *-sys C/C++ deps),
-# pkg-config, and git (zaino-state's build.rs embeds the commit). Versions are
-# pinned to the bookworm snapshot that the digest-pinned base resolves to; bump
-# them together with the base digest above.
+# pkg-config, and git (zaino-state's build.rs embeds the commit).
+#
+# These versions are NOT implied by the digest-pinned base: apt resolves them
+# against the live bookworm archive, which only ever serves the CURRENT revision
+# of each package. So a bookworm point release (or a security update) deletes the
+# revision pinned here and the build fails with "Version '...' was not found",
+# even though nothing in this repo changed. When that happens, re-read the
+# candidate versions from the pinned base and bump the offending pin:
+#
+#   docker run --rm rust:1.91.1-slim-bookworm@sha256:8514999d... \
+#     bash -c 'apt-get update -qq && apt-cache policy protobuf-compiler'
+#
+# (Pinning apt to a snapshot.debian.org timestamp would make this immune, at the
+# cost of no longer picking up security updates automatically.)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential=12.9 \
         clang=1:14.0-55.7~deb12u1 \
         llvm-dev=1:14.0-55.7~deb12u1 \
         libclang-dev=1:14.0-55.7~deb12u1 \
-        protobuf-compiler=3.21.12-3 \
+        protobuf-compiler=3.21.12-3+deb12u1 \
         pkg-config=1.8.1-1 \
         git=1:2.39.5-0+deb12u3 \
         ca-certificates=20230311+deb12u1 \


### PR DESCRIPTION
## The failure

Every PR's Docker job is currently red, with no change on our side:

```
E: Version '3.21.12-3' for 'protobuf-compiler' was not found
```

(e.g. #585, [run 29150756964](https://github.com/zcash/zallet/actions/runs/29150756964/job/86539767759).)

## Why it broke on its own

The Dockerfile's comment claimed the apt pins were "pinned to the bookworm snapshot that the digest-pinned base resolves to". **That is not true, and it is the root cause.** The base image is digest-pinned, but `apt` does not resolve against the base image: it resolves against the *live* `deb.debian.org` archive, which serves only the **current** revision of each package. There is no snapshot.

So when Debian shipped a point release replacing `protobuf-compiler` `3.21.12-3` with `3.21.12-3+deb12u1`, the old revision was **deleted from the archive** and our pin became unresolvable. Nothing in this repo changed; the archive moved underneath us. This will happen again every time Debian updates one of the eight pinned packages.

Re-reading the candidate versions from the digest-pinned base shows only protobuf moved; every other pin is still current, so this bumps exactly one line.

## Audit of the new revision

Per the new policy this PR adds, a pin bump is a supply-chain change and must be audited rather than merely made green. Here is that audit, in full, so you can check it.

**Upstream version is unchanged** (3.21.12). `+deb12u1` is a Debian revision: a security update, delivered via `bookworm/main` as part of a stable point release rather than as a DSA (Debian Security Advisory), i.e. Debian did not rate these as warranting an out-of-band advisory.

Changelog: https://metadata.ftp-master.debian.org/changelogs/main/p/protobuf/protobuf_3.21.12-3%2Bdeb12u1_changelog

Diffing the two Debian source packages, the change is **purely additive**: 11 new patches, no existing patch modified, and no change anywhere else in `debian/` except the changelog itself (no build-config or packaging change).

| Patches | CVE | Source tree touched | Do we ship/execute it? |
| --- | --- | --- | --- |
| `CVE-2024-7254-{1,2,3,5}` | [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254) (Java recursion limit), Debian [#1082381](https://bugs.debian.org/1082381) | `java/core/...` (+ one test) | **No** |
| `CVE-2024-7254-4` | same | `src/google/protobuf/unittest_lite.proto` (test fixture) | No |
| `CVE-2025-4565-{1,2,3}` | [CVE-2025-4565](https://nvd.nist.gov/vuln/detail/CVE-2025-4565) (Python recursion DoS), Debian [#1108057](https://bugs.debian.org/1108057) | `python/google/...` | **No** |
| `0001-Fix-Any-recursion-depth-bypass-in-Python-json_format` | [CVE-2026-0994](https://nvd.nist.gov/vuln/detail/CVE-2026-0994) (JSON recursion depth bypass), Debian [#1126302](https://bugs.debian.org/1126302) | `python/google/...` | **No** |
| `0002-Check-that-readRaw...`, `0003-php-Fix-that-recursion-limit...` | [CVE-2026-6409](https://nvd.nist.gov/vuln/detail/CVE-2026-6409) (PHP DoS), Debian [#1134895](https://bugs.debian.org/1134895) | `php/src`, `php/tests` | **No** |

**Impact on us: none, functionally.** Not one patch touches `src/google/protobuf/compiler/**`. The single file under `src/` is a unit-test `.proto` fixture. This image uses protobuf for exactly one thing, the `protoc` binary driving tonic's Rust codegen (`ENV PROTOC=/usr/bin/protoc`), and we ship no Java, Python, or PHP protobuf runtime, so all four CVEs are unreachable in our build and runtime. `protoc`'s codegen behaviour is unchanged (`libprotoc 3.21.12` before and after).

Net: a strict security improvement with no functional effect. Safe to take.

## Verification

- The pin resolves against the digest-pinned base (not my laptop):
  ```
  docker run --rm rust:1.91.1-slim-bookworm@sha256:8514999d... \
    bash -c 'apt-get update -qq && apt-cache policy protobuf-compiler'
  # Candidate: 3.21.12-3+deb12u1
  ```
- The exact failing layer now installs cleanly (`apt-get install` exit 0, `protoc --version` -> `libprotoc 3.21.12`).
- `hadolint Dockerfile` clean.
- `Dockerfile.stagex` is **unaffected**: it takes protobuf from a digest-pinned `stagex/user-protobuf:26.1@sha256:...` image rather than apt, so it cannot rot this way. No change needed there.

## Also in this PR

- **The Dockerfile comment is corrected** to describe the real constraint, with the one-liner for re-reading candidate versions when this recurs. The old comment actively misled: it told the next person these versions were implied by the base digest.
- **`AGENTS.md` gains an "Auditing Dependency Version Bumps" section.** It requires that an agent bumping any pin must (1) read the actual source diff, not the changelog summary, (2) **link the upstream discussion** so a human reviewer can verify without redoing the archaeology, (3) state the impact on what we actually ship, (4) confirm the pin resolves against the digest-pinned base, and (5) keep the bump minimal and never relax a pin or silence hadolint to dodge the problem.

  The motivation: bumping a pin means executing different third-party code in our build. "CI was red so I raised the number until it went green" is not a review, and it is precisely how a compromised or merely broken upstream slips in unexamined. This PR is written to be the worked example of that policy.

## A note on the longer-term fix

Bumping the pin restores the build but does not stop the rot: this recurs on every Debian point release. The durable options are to pin apt to a `snapshot.debian.org` timestamp (fully reproducible, but stops picking up security updates automatically, so it must be bumped deliberately), or to stop pinning apt revisions and rely on the base digest plus this audit discipline. Both are a real tradeoff between reproducibility and security latency, so I have not made that call here. Happy to follow up if you have a preference.