### PR TITLE
fix(ci): arm64 image missing backend binaries + ship standalone binaries as a signed tarball

### DIFF
--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -307,22 +307,29 @@ jobs:
             "debian:${SMOKE_TEST_DISTRO}-slim" \
             /usr/local/bin/zallet-zaino -h
 
-      - name: Prepare standalone binary artifact
+      - name: Prepare standalone release tarball
         env:
           PLATFORM_KEY: ${{ matrix.platform_key }}
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
           set -euo pipefail
+          # Ship all three binaries (launcher + both real backends) in ONE
+          # self-sufficient tarball per platform, mirroring the .deb's layout
+          # (zcash/zallet#540) instead of three loose files. Preserves relative
+          # perms/paths so `tar -xzf ... && ./zallet -h` works out of the box.
+          STAGE="tarball/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
+          mkdir -p "$STAGE"
+          cp "build/${PLATFORM_KEY}/zallet"        "$STAGE/zallet"
+          cp "build/${PLATFORM_KEY}/zallet-zebra"  "$STAGE/zallet-zebra"
+          cp "build/${PLATFORM_KEY}/zallet-zaino"  "$STAGE/zallet-zaino"
+          chmod 0755 "$STAGE"/zallet*
           mkdir -p standalone
-          # The plain suffixed name stays the zebra-state BACKEND binary:
-          # standalone consumers expect a single self-sufficient file, and that
-          # is what this artifact has always been (its CLI name is `zallet`).
-          # The launcher — what the .deb installs as /usr/bin/zallet — needs a
-          # backend binary installed next to it, so it ships as an additive
-          # `-launcher` artifact rather than replacing the plain name.
-          cp "build/${PLATFORM_KEY}/zallet-zebra" "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
-          cp "build/${PLATFORM_KEY}/zallet-zaino"       "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-zaino"
-          cp "build/${PLATFORM_KEY}/zallet"             "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-launcher"
+          # Deterministic tarball: fixed mtime/owner so the .tar.gz digest
+          # doesn't depend on filesystem timestamps from this runner.
+          tar -C tarball --sort=name --owner=0 --group=0 --numeric-owner \
+            --mtime='@0' \
+            -czf "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz" \
+            "zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
 
       - name: Generate provenance chain metadata
         env:
@@ -333,15 +340,16 @@ jobs:
           GH_RUNNER_OS: ${{ runner.os }}
         run: |
           set -euo pipefail
-          BINARY_PATH="standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
-          BINARY_SHA256=$(sha256sum "$BINARY_PATH" | cut -d' ' -f1)
+          TARBALL_PATH="standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz"
+          TARBALL_SHA256=$(sha256sum "$TARBALL_PATH" | cut -d' ' -f1)
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          cat > "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.provenance.json" <<EOF
+          cat > "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz.provenance.json" <<EOF
           {
             "version": "1.0",
             "subject": {
-              "name": "zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}",
-              "sha256": "${BINARY_SHA256}"
+              "name": "zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz",
+              "sha256": "${TARBALL_SHA256}",
+              "contains": ["zallet", "zallet-zebra", "zallet-zaino"]
             },
             "source": {
               "image_ref": "${SOURCE_IMAGE_REF}",
@@ -358,22 +366,20 @@ jobs:
             },
             "verification": {
               "docker_image_attestation": "${SOURCE_IMAGE_REF}@${SOURCE_IMAGE_DIGEST}",
-              "note": "This binary was extracted from the Docker image above. Verify the image attestation for full build provenance."
+              "note": "This tarball's binaries were extracted from the Docker image above. Verify the image attestation for full build provenance."
             }
           }
           EOF
 
-      - name: GPG sign standalone binaries
+      - name: GPG sign standalone tarball
         env:
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
           set -euo pipefail
-          for b in "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}" \
-                   "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-zaino"; do
-            gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign "$b"
-          done
+          gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign \
+            "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz"
 
-      - name: Generate SPDX SBOM for standalone binary
+      - name: Generate SPDX SBOM for standalone tarball
         env:
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
@@ -382,48 +388,39 @@ jobs:
           import os
           from pathlib import Path
 
-          base = f"standalone/zallet-{os.environ['RELEASE_VERSION']}-{os.environ['BINARY_SUFFIX']}"
-          # SBOM for both backend binaries (default zebra-state + additive zaino).
-          for binary_path in (Path(base), Path(f"{base}-zaino")):
-              if not binary_path.exists():
-                  raise SystemExit(f"Missing binary at {binary_path}")
-              checksum = hashlib.sha256(binary_path.read_bytes()).hexdigest()
-              output = binary_path.parent / f"{binary_path.name}.sbom.spdx"
-              doc = f"""SPDXVersion: SPDX-2.3
+          tarball_path = Path(f"standalone/zallet-{os.environ['RELEASE_VERSION']}-{os.environ['BINARY_SUFFIX']}.tar.gz")
+          if not tarball_path.exists():
+              raise SystemExit(f"Missing tarball at {tarball_path}")
+          checksum = hashlib.sha256(tarball_path.read_bytes()).hexdigest()
+          output = tarball_path.parent / f"{tarball_path.name}.sbom.spdx"
+          doc = f"""SPDXVersion: SPDX-2.3
           DataLicense: CC0-1.0
           SPDXID: SPDXRef-DOCUMENT
-          DocumentName: {binary_path.name}
-          DocumentNamespace: https://github.com/{os.environ['GITHUB_REPOSITORY']}/sbom/{binary_path.name}-{checksum}
+          DocumentName: {tarball_path.name}
+          DocumentNamespace: https://github.com/{os.environ['GITHUB_REPOSITORY']}/sbom/{tarball_path.name}-{checksum}
           Creator: Tool: zallet-ci-spdx-1.0
           Created: 1970-01-01T00:00:00Z
-          PackageName: {binary_path.name}
+          PackageName: {tarball_path.name}
           PackageSPDXID: SPDXRef-Package-{checksum[:12]}
           PackageDownloadLocation: NOASSERTION
           FilesAnalyzed: false
           PackageChecksum: SHA256: {checksum}
+          # Contains: zallet (launcher), zallet-zebra, zallet-zaino
           """
-              output.write_text(doc, encoding="utf-8")
+          output.write_text(doc, encoding="utf-8")
           PY
 
-      - name: Generate build provenance attestation for binaries
+      - name: Generate build provenance attestation for tarball
         id: binary-attest
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          # Attest all standalone binaries in one call (multi-line subject-path).
-          subject-path: |
-            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}
-            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}-zaino
-            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}-launcher
+          subject-path: standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}.tar.gz
 
-      - name: Save binary attestation bundle
+      - name: Save tarball attestation bundle
         env:
           BUNDLE_PATH: ${{ steps.binary-attest.outputs['bundle-path'] }}
         run: |
-          # One bundle covers all subjects; publish it under each name so every
-          # binary has a co-located .intoto.jsonl next to it in the Release.
-          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}.intoto.jsonl"
-          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}-zaino.intoto.jsonl"
-          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}-launcher.intoto.jsonl"
+          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}.tar.gz.intoto.jsonl"
 
       - name: Seed cargo target tree with the imported artifacts
         run: |

--- a/.github/workflows/build-arm64-nix.yml
+++ b/.github/workflows/build-arm64-nix.yml
@@ -178,12 +178,19 @@ jobs:
         run: |
           set -Eeuo pipefail
           REPO="docker.io/${NS}/${IMG}"
-          # Minimal scratch image around the static musl binary, matching the
-          # amd64 StageX runtime stage (USER 1000, ENTRYPOINT zallet).
-          mkdir -p ctx && cp build/runtime/linux-arm64/zallet ctx/zallet
+          # Minimal scratch image around the static musl binaries, matching the
+          # amd64 StageX runtime stage exactly: the launcher plus both real
+          # backend binaries it dispatches to (zcash/zallet#540).
+          mkdir -p ctx
+          cp build/runtime/linux-arm64/zallet        ctx/zallet
+          cp build/runtime/linux-arm64/zallet-zebra   ctx/zallet-zebra
+          cp build/runtime/linux-arm64/zallet-zaino   ctx/zallet-zaino
           cat > ctx/Dockerfile <<'DF'
           FROM scratch
           COPY zallet /usr/local/bin/zallet
+          COPY zallet-zebra /usr/local/bin/zallet-zebra
+          COPY zallet-zaino /usr/local/bin/zallet-zaino
+          WORKDIR /var/lib/zallet
           USER 1000:1000
           ENTRYPOINT ["zallet"]
           DF

--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -52,12 +52,10 @@ The official Docker image and Debian package ship the launcher and **both** back
 All three share the same CLI surface, config format, and subcommands; only the chain-data
 backend differs, and you can bypass the launcher by running a backend binary directly (it
 will refuse to run against a config whose `backend` key names the other backend). The
-pre-compiled standalone binaries on the GitHub Releases page are:
-`zallet-<version>-linux-<arch>` (the self-sufficient zebra-state backend),
-`zallet-<version>-linux-<arch>-zaino` (the zaino backend), and
-`zallet-<version>-linux-<arch>-launcher` (the launcher; it needs a backend binary
-installed next to it or on the `PATH`, so most single-binary deployments want one of the
-backend binaries instead).
+GitHub Releases page ships one signed tarball per platform,
+`zallet-<version>-linux-<arch>.tar.gz`, containing all three binaries (`zallet`,
+`zallet-zebra`, `zallet-zaino`) side by side — extract it and run whichever one you need
+directly, or run `zallet` for config-driven dispatch.
 
 ### Building from source with a chosen backend
 


### PR DESCRIPTION
## Summary

Two related release-pipeline fixes, verified against the published `v0.1.0-beta.1` release.

### 1. arm64 Docker image is missing `zallet-zebra` and `zallet-zaino` (real bug, confirmed by running the launcher)

Ran the published `zodlinc/zallet:v0.1.0-beta.1` image for real on a native arm64 EC2:

```
$ docker run --rm zodlinc/zallet:v0.1.0-beta.1
error: failed to run the backend binary `zallet-zebra`: No such file or directory (os error 2)
```

`crane export ... --platform linux/arm64 | tar -tv` confirms the arm64 image filesystem only has `/usr/local/bin/zallet` (964 KB, the launcher) — `zallet-zebra` and `zallet-zaino` are absent. The amd64 image is unaffected (has all three, confirmed the same way).

Root cause: `build-arm64-nix.yml`'s Nix build already stages all three binaries correctly under `build/runtime/linux-arm64/` (the `.deb` and standalone artifacts for arm64 are fine) — but the separate "Build + push the arm64 image variant" step that assembles the scratch Docker image only ever copied `zallet` into its build context, with a single `COPY` line in its synthetic Dockerfile. `Dockerfile.stagex` (amd64) already has all three `COPY` lines.

This is the same shape of bug as #542 (which fixed this exact step once already), reintroduced when the workspace split (#540/#566) renamed `zallet-zebra-state` → `zallet-zebra` without this one step being updated to match. Also added the missing `WORKDIR /var/lib/zallet` so the arm64 runtime stage matches amd64 exactly.

### 2. Standalone binaries: three loose files → one signed tarball per platform

Currently each platform ships three independent files (`zallet-<ver>-<arch>`, `-zaino`, `-launcher`), each with its own ad-hoc GPG signature / SBOM / provenance attestation. Changed to a single `zallet-<ver>-<arch>.tar.gz` per platform containing all three binaries side by side — mirrors the `.deb`'s all-three-binaries layout. The tarball is what gets GPG-signed, SBOM'd, and attested, so verifying one signature covers everything inside instead of needing to check three files individually. Built deterministically (`--sort=name --mtime=@0 --owner=0 --group=0`) so the tarball digest doesn't depend on runner filesystem timestamps.

Updated `book/src/guide/installation/README.md` to describe the new tarball layout.

## Test plan

- [ ] CI green, in particular the arm64 (Nix) build job and the `.deb`/binaries matrix
- [ ] After merge, re-run a release and verify with `crane export <image>@<digest> --platform linux/arm64 | tar -tv` that the arm64 image contains `zallet`, `zallet-zebra`, and `zallet-zaino`
- [ ] Verify the published `.tar.gz` extracts to all three binaries with correct perms, and its `.asc`/`.sbom.spdx`/`.intoto.jsonl` verify against it