### PR TITLE
fix(sync): don't shut down the wallet when a transaction data request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ be considered breaking changes.
   longer leave the spending key stored (and exportable via `z_exportkey`) while
   the wallet has no account to scan for it.
 
+### Fixed
+
+- A failure to service a single transaction data request (for example when the
+  requested transaction was reorged away and the validator answers
+  `RPC -5: No such mempool or main chain transaction`) no longer shuts the
+  wallet down. The request is logged and retried on a later sync iteration.
+  Previously the failing request was regenerated from the wallet database on
+  every startup, so one stale request could put the wallet into a permanent
+  crash-loop.
+
 ## [0.1.0-beta.1] - 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,12 @@ be considered breaking changes.
 - A failure to service a single transaction data request (for example when the
   requested transaction was reorged away and the validator answers
   `RPC -5: No such mempool or main chain transaction`) no longer shuts the
-  wallet down. The request is logged and retried on a later sync iteration.
-  Previously the failing request was regenerated from the wallet database on
-  every startup, so one stale request could put the wallet into a permanent
-  crash-loop.
+  wallet down. The request is logged and retried on a later sync iteration,
+  unless the chain source reported invalid data, which still aborts (it
+  indicates a bug, corruption, or a version mismatch that retrying cannot
+  resolve). Previously the failing request was regenerated from the wallet
+  database on every startup, so one stale request could put the wallet into a
+  permanent crash-loop.
 
 ## [0.1.0-beta.1] - 2026-07-12
 

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -151,6 +151,31 @@ instead, or you may lose access to funds.
 - `address` (string, required) The Sapling payment address corresponding to the
   spending key to export.
 
+## `z_exportviewingkey`
+
+*Only available in wallet builds of Zallet.*
+
+Reveals the viewing key corresponding to 'zaddr'.
+
+#### Arguments
+
+- `zaddr` (string, required) The Sapling payment address or unified
+  address.
+- `ivk` (boolean, optional, default=`false`) When `true`, export the
+  unified incoming viewing key (UIVK) for the account holding `zaddr`
+  instead of the full viewing key.
+
+#### Returns
+A string containing the viewing key:
+- For a Sapling payment address, the Sapling extended full viewing key
+  (`zxviews…`).
+- For a unified address, the unified full viewing key (`uview…`) of the
+  account holding the address.
+- When `ivk` is `true`, the unified incoming viewing key (`uivk…`) of
+  the account holding the address, for either address kind. Note that
+  a UIVK grants incoming viewing capability for every pool in the
+  account, even when `zaddr` is a Sapling address.
+
 ## `z_getaccount`
 
 Returns details about the given account.

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -886,12 +886,10 @@ async fn data_requests<C: Chain>(
                     }
 
                     info!("Getting status of {txid}");
-                    let status = chain_view
-                        .get_transaction_status(txid)
-                        .await
-                        .map_err(SyncError::Chain)?;
-
-                    db_data.set_transaction_status(txid, status)?;
+                    match chain_view.get_transaction_status(txid).await {
+                        Ok(status) => db_data.set_transaction_status(txid, status)?,
+                        Err(e) => warn!("Failed to get status of {txid} (will retry): {e}"),
+                    }
                 }
                 TransactionDataRequest::Enhancement(txid) => {
                     if txid.is_null() {
@@ -899,23 +897,25 @@ async fn data_requests<C: Chain>(
                     }
 
                     info!("Enhancing {txid}");
-                    if let Some(tx) = chain_view
-                        .get_transaction(txid)
-                        .await
-                        .map_err(SyncError::Chain)?
-                    {
-                        // TODO: Route individual-transaction scanning through the batch
-                        // decryptor (`Handle::queue_tx`) once a single-tx store path
-                        // exists. See zcash/zallet#477.
-                        decrypt_and_store_transaction(
-                            params,
-                            db_data,
-                            tx.inner(),
-                            tx.mined_height(),
-                        )?;
-                    } else {
-                        db_data
-                            .set_transaction_status(txid, TransactionStatus::TxidNotRecognized)?;
+                    match chain_view.get_transaction(txid).await {
+                        Ok(Some(tx)) => {
+                            // TODO: Route individual-transaction scanning through the batch
+                            // decryptor (`Handle::queue_tx`) once a single-tx store path
+                            // exists. See zcash/zallet#477.
+                            decrypt_and_store_transaction(
+                                params,
+                                db_data,
+                                tx.inner(),
+                                tx.mined_height(),
+                            )?;
+                        }
+                        Ok(None) => {
+                            db_data.set_transaction_status(
+                                txid,
+                                TransactionStatus::TxidNotRecognized,
+                            )?;
+                        }
+                        Err(e) => warn!("Failed to enhance {txid} (will retry): {e}"),
                     }
                 }
                 // With `spend-index`, spend detection uses `GetSpendingTx` (below) and any

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -888,6 +888,9 @@ async fn data_requests<C: Chain>(
                     info!("Getting status of {txid}");
                     match chain_view.get_transaction_status(txid).await {
                         Ok(status) => db_data.set_transaction_status(txid, status)?,
+                        // Invalid data from the chain source indicates a bug, corruption,
+                        // or a version mismatch; retrying cannot help.
+                        Err(e @ ChainError::InvalidData(_)) => return Err(SyncError::Chain(e)),
                         Err(e) => warn!("Failed to get status of {txid} (will retry): {e}"),
                     }
                 }
@@ -915,6 +918,9 @@ async fn data_requests<C: Chain>(
                                 TransactionStatus::TxidNotRecognized,
                             )?;
                         }
+                        // Invalid data from the chain source indicates a bug, corruption,
+                        // or a version mismatch; retrying cannot help.
+                        Err(e @ ChainError::InvalidData(_)) => return Err(SyncError::Chain(e)),
                         Err(e) => warn!("Failed to enhance {txid} (will retry): {e}"),
                     }
                 }


### PR DESCRIPTION
Fixes zcash/zallet#599.

When servicing a `GetStatus`/`Enhancement` transaction data request fails with a backend error — e.g. the transaction was reorged away and the validator answers `RPC -5: No such mempool or main chain transaction` — the data-requests sync task exits and takes the whole wallet process down. The request is regenerated from the wallet database on every startup, so one stale request crash-loops the wallet until systemd gives up (`start-limit-hit`).

This change logs the failure and leaves the request for a later sync iteration instead, matching how `TransactionsInvolvingAddress` servicing errors are already handled. Once the chain index catches up with the reorg, the request resolves through the existing `None → TxidNotRecognized` path. Wallet database errors still abort as before.

Tested with `cargo check -p zallet-core` and `cargo fmt`; the failure mode was reproduced live on testnet (v0.1.0-beta.1, zebrad 6.0.0) — details in the linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
