### PR TITLE
book: zcashd migration guide, omitted-RPC guidance, and RPC status matrix

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
   - [repair](cli/repair/README.md)
     - [truncate-wallet](cli/repair/truncate-wallet.md)
 - [Migrating from `zcashd`](zcashd/README.md)
+  - [JSON-RPC method status](zcashd/rpc_status.md)
   - [JSON-RPC altered semantics](zcashd/json_rpc.md)
 
 # Security

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -1,3 +1,95 @@
 # Migrating from `zcashd`
 
-TODO: Document how to migrate from `zcashd` to Zallet.
+`zcashd` was a single process that acted as both a Zcash full node and a wallet. Its
+replacement is a stack of separate components: [`zebrad`] provides the full node, and
+Zallet provides the wallet. Migrating therefore has two halves: replacing the node, and
+migrating the wallet. This page covers the wallet half, and links out to the node parts
+you need.
+
+[`zebrad`]: https://zebra.zfnd.org/
+
+> **⚠️ Keep your `zcashd` data.** Do not delete `wallet.dat` (or the `zcashd` datadir)
+> after migrating. The migration reports anything it cannot represent in a Zallet wallet
+> rather than migrating it, and that key material then exists only in `wallet.dat`.
+
+## Migration steps
+
+1. **Run a `zebrad` node.** Zallet reads chain data from `zebrad` via one of its two
+   [chain backends](../guide/installation/README.md#choosing-a-chain-backend); the
+   backend you choose determines how `zebrad` needs to be built and configured.
+
+2. **Install Zallet.** See [Installation](../guide/installation/README.md).
+
+3. **Create a Zallet config from your `zcash.conf`:**
+
+   ```
+   $ zallet migrate-zcash-conf --zcashd-datadir /path/to/zcashd/datadir -o /path/to/zallet/datadir/zallet.toml
+   ```
+
+   Wallet-relevant options are translated to their `zallet.toml` equivalents; options
+   that only affect the node are ignored, and wallet options that cannot be migrated
+   produce warnings. Note that `rpcuser` / `rpcpassword` are **not** migrated: Zallet's
+   JSON-RPC interface uses [cookie authentication](../cli/rpc.md#authentication) by
+   default, and you can add password credentials with
+   [`zallet add-rpc-user`](../cli/add-rpc-user.md).
+
+   > [Reference](../cli/migrate-zcash-conf.md)
+
+4. **Initialize wallet encryption.** Zallet encrypts key material with an
+   [age](https://age-encryption.org/) identity that you create before importing any
+   keys; see [Wallet setup](../guide/setup.md#initialize-the-wallet-encryption).
+
+5. **Migrate your `wallet.dat`:**
+
+   ```
+   $ zallet migrate-zcashd-wallet --zcashd-datadir /path/to/zcashd/datadir
+   ```
+
+   This imports the wallet's key material and creates corresponding Zallet accounts. If
+   you have several `wallet.dat` files, run it once per file (subsequent runs need
+   `--allow-multiple-wallet-imports`); each wallet becomes a distinct set of accounts.
+
+   > [Reference](../cli/migrate-zcashd-wallet.md)
+
+6. **Start Zallet and let it sync:**
+
+   ```
+   $ zallet start
+   ```
+
+   Transaction history is recovered by scanning the chain, so the wallet needs to sync
+   before balances are complete. Use `zallet rpc getwalletstatus` to observe sync
+   progress, then verify your balances against `zcashd` before decommissioning it.
+
+7. **Update your RPC clients.** Zallet implements a subset of the `zcashd` wallet
+   JSON-RPC methods, some with [altered semantics](json_rpc.md), and some `zcashd`
+   methods are [intentionally omitted](json_rpc.md#omitted-rpc-methods). The
+   [`zallet rpc`](../cli/rpc.md) command replaces `zcash-cli`.
+
+## What is migrated
+
+- Mnemonic seeds and the keys derived from them. Accounts are re-created following the
+  structure of the `zcashd` wallet.
+- Standalone (imported) Sapling spending keys and transparent keys.
+- Transparent watch-only entries that include their public key or redeem script.
+- Account birthdays, so that chain scanning starts from the right height.
+
+## What is not migrated
+
+The migration reports these (with counts) instead of importing them:
+
+- **Sprout spending keys and funds.** Zallet does not support the Sprout pool. Move any
+  Sprout funds (e.g. to Sapling, using `zcashd`'s migration or a Sprout-capable tool)
+  *before* retiring `zcashd`.
+- Address book entries.
+- Watch-only entries recorded without their public key or redeem script, and entries
+  with uncompressed public keys.
+- Regtest wallets (not currently supported).
+
+## Back up the migrated wallet
+
+After migration, a mnemonic backup alone is **not** sufficient: imported keys exist only
+in the wallet database. Keep secure copies of the wallet database (`wallet.db`), the age
+encryption identity file, *and* your mnemonic phrase(s) — and keep the original
+`wallet.dat`. See the warning in the
+[`migrate-zcashd-wallet` reference](../cli/migrate-zcashd-wallet.md) for details.

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -63,7 +63,8 @@ you need.
 
 7. **Update your RPC clients.** Zallet implements a subset of the `zcashd` wallet
    JSON-RPC methods, some with [altered semantics](json_rpc.md), and some `zcashd`
-   methods are [intentionally omitted](json_rpc.md#omitted-rpc-methods). The
+   methods are [intentionally omitted](json_rpc.md#omitted-rpc-methods). Check
+   every method you use against the [method status matrix](rpc_status.md). The
    [`zallet rpc`](../cli/rpc.md) command replaces `zcash-cli`.
 
 ## What is migrated

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -156,7 +156,7 @@ methods have been updated to replace them.
 | `settxfee`             | Nothing; [ZIP 317] fees are always used |
 | `signrawtransaction`   | [To-be-implemented methods for working with PCZTs][pczts] |
 | `z_importwallet`       | `z_importkey` per key, or the [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) command for a whole `zcashd` wallet |
-| `z_getbalance`         | `z_getbalanceforaccount`, `z_getbalanceforviewingkey`, `getbalance` |
+| `z_getbalance`         | `z_getbalanceforaccount` |
 | `z_getmigrationstatus` | Nothing; see [note](#z_getmigrationstatus-and-z_setmigration) |
 | `z_getnewaddress`      | `z_getnewaccount`, `z_getaddressforaccount` |
 | `z_listaddresses`      | `listaddresses` |

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -146,25 +146,65 @@ methods have been updated to replace them.
 | Omitted RPC method     | Use this instead |
 |------------------------|------------------|
 | `createrawtransaction` | [To-be-implemented methods for working with PCZTs][pczts] |
+| `encryptwallet`        | Nothing; see [note](#encryptwallet) |
 | `fundrawtransaction`   | [To-be-implemented methods for working with PCZTs][pczts] |
 | `getnewaddress`        | `z_getnewaccount`, `z_getaddressforaccount` |
-| `getrawchangeaddress`  |
-| `keypoolrefill`        |
-| `importpubkey`         |
-| `importwallet`         |
-| `settxfee`             |
+| `getrawchangeaddress`  | Nothing; see [note](#getrawchangeaddress) |
+| `keypoolrefill`        | Nothing; see [note](#keypoolrefill) |
+| `importpubkey`         | `z_importaddress` |
+| `importwallet`         | `z_importkey` per key, or the [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) command for a whole `zcashd` wallet |
+| `settxfee`             | Nothing; [ZIP 317] fees are always used |
 | `signrawtransaction`   | [To-be-implemented methods for working with PCZTs][pczts] |
-| `z_importwallet`       |
+| `z_importwallet`       | `z_importkey` per key, or the [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) command for a whole `zcashd` wallet |
 | `z_getbalance`         | `z_getbalanceforaccount`, `z_getbalanceforviewingkey`, `getbalance` |
-| `z_getmigrationstatus` |
+| `z_getmigrationstatus` | Nothing; see [note](#z_getmigrationstatus-and-z_setmigration) |
 | `z_getnewaddress`      | `z_getnewaccount`, `z_getaddressforaccount` |
 | `z_listaddresses`      | `listaddresses` |
-| `z_setmigration`       |
+| `z_setmigration`       | Nothing; see [note](#z_getmigrationstatus-and-z_setmigration) |
+| `zcbenchmark`          | Nothing; see [note](#zcbenchmark) |
 
-The `z_getmigrationstatus` and `z_setmigration` methods configured and reported
-on the automatic Sprout-to-Sapling fund migration. Zallet does not support
-Sprout, so there is nothing to migrate and no equivalent method is provided. If
-you still hold Sprout funds, migrate them out of the Sprout pool before
-transitioning your wallet to Zallet.
+### `encryptwallet`
+
+In `zcashd`, wallet encryption was disabled (running with an encrypted wallet
+was never fully supported), so this method always failed. In Zallet, key
+material is always encrypted: an [age](https://age-encryption.org/) encryption
+identity is created when the wallet is [set up](../guide/setup.md#initialize-the-wallet-encryption),
+before any keys exist. To require a passphrase at runtime, use a
+passphrase-encrypted identity; the `walletpassphrase` and `walletlock` methods
+then unlock and re-lock the key store.
+
+### `getrawchangeaddress`
+
+Zallet derives change addresses internally when it builds a transaction, and
+never exposes them for external use. Workflows that used
+`getrawchangeaddress` together with the raw-transaction methods will be served
+by the [to-be-implemented PCZT methods][pczts], which handle change as part of
+transaction proposal.
+
+### `keypoolrefill`
+
+The `zcashd` key pool was a reserve of pre-generated keys that had to be
+topped up so that backups stayed complete. Zallet has no key pool: all
+addresses are derived on demand from a seed via [ZIP 32], so there is nothing
+to refill. Note that a mnemonic backup covers derived keys but not standalone
+imported keys; see the
+[`migrate-zcashd-wallet` reference](../cli/migrate-zcashd-wallet.md) for
+what a complete backup requires.
+
+### `z_getmigrationstatus` and `z_setmigration`
+
+These methods configured and reported on the automatic Sprout-to-Sapling fund
+migration. Zallet does not support Sprout, so there is nothing to migrate and
+no equivalent method is provided. If you still hold Sprout funds, migrate them
+out of the Sprout pool before transitioning your wallet to Zallet.
+
+### `zcbenchmark`
+
+`zcbenchmark` ran micro-benchmarks of `zcashd`'s own internals (such as proof
+creation and validation). It measured `zcashd` code that Zallet does not
+contain, so there is nothing equivalent for Zallet to measure and no
+replacement is planned.
 
 [pczts]: https://github.com/zcash/zallet/issues/99
+[ZIP 32]: https://zips.z.cash/zip-0032
+[ZIP 317]: https://zips.z.cash/zip-0317

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -1,0 +1,101 @@
+# JSON-RPC method status
+
+This page lists every wallet JSON-RPC method that `zcashd` provided, and its
+status in Zallet. Use it to inventory your RPC usage before migrating.
+
+Statuses:
+
+- **Implemented** — available in Zallet with `zcashd`-compatible semantics.
+- **Implemented (altered)** — available, but with [altered semantics](json_rpc.md).
+- **Not yet implemented** — intentionally absent so far; implementation is
+  tracked in the linked issue. Whether each of these ships will be decided
+  during the beta phase ([#287]).
+- **Not planned** — will not be implemented; the Notes column says what to use
+  instead.
+- **Omitted** — intentionally not implemented; see the
+  [omitted methods](json_rpc.md#omitted-rpc-methods) table for replacements.
+
+[#287]: https://github.com/zcash/zallet/issues/287
+
+| `zcashd` method | Status | Notes |
+|---|---|---|
+| `addmultisigaddress` | Not yet implemented | [#48](https://github.com/zcash/zallet/issues/48) |
+| `backupwallet` | Not yet implemented | [#49](https://github.com/zcash/zallet/issues/49); robust backup is tracked in [#195](https://github.com/zcash/zallet/issues/195) |
+| `dumpprivkey` | Not yet implemented | [#50](https://github.com/zcash/zallet/issues/50) |
+| `encryptwallet` | Omitted | [Note](json_rpc.md#encryptwallet): key material is always encrypted |
+| `getbalance` | Not yet implemented | [#51](https://github.com/zcash/zallet/issues/51) |
+| `getnewaddress` | Omitted | Use `z_getnewaccount` + `z_getaddressforaccount` |
+| `getrawchangeaddress` | Omitted | [Note](json_rpc.md#getrawchangeaddress): change is handled internally |
+| `getreceivedbyaddress` | Not yet implemented | [#52](https://github.com/zcash/zallet/issues/52) |
+| `gettransaction` | Not planned | Superseded by `z_viewtransaction`, which now includes its top-level fields ([altered semantics](json_rpc.md#z_viewtransaction)) |
+| `getunconfirmedbalance` | Not yet implemented | [#54](https://github.com/zcash/zallet/issues/54) |
+| `getwalletinfo` | Implemented | |
+| `importaddress` | Not yet implemented | [#56](https://github.com/zcash/zallet/issues/56); if you have the public key or redeem script, `z_importaddress` covers this today |
+| `importprivkey` | Not yet implemented | [#57](https://github.com/zcash/zallet/issues/57) |
+| `importpubkey` | Omitted | Use `z_importaddress` |
+| `importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) |
+| `keypoolrefill` | Omitted | [Note](json_rpc.md#keypoolrefill): no key pool exists |
+| `listaddresses` | Implemented (altered) | [Changes](json_rpc.md#listaddresses) |
+| `listaddressgroupings` | Not yet implemented | [#59](https://github.com/zcash/zallet/issues/59) |
+| `listlockunspent` | Not yet implemented | [#60](https://github.com/zcash/zallet/issues/60) |
+| `listreceivedbyaddress` | Not yet implemented | [#61](https://github.com/zcash/zallet/issues/61) |
+| `listsinceblock` | Not yet implemented | [#62](https://github.com/zcash/zallet/issues/62) |
+| `listtransactions` | Not yet implemented | [#63](https://github.com/zcash/zallet/issues/63); Zallet provides the account-scoped `z_listtransactions` |
+| `listunspent` | Not planned | Subsumed by `z_listunspent`, which now includes transparent outputs ([changes](json_rpc.md#z_listunspent), [#64](https://github.com/zcash/zallet/issues/64)) |
+| `lockunspent` | Not yet implemented | [#65](https://github.com/zcash/zallet/issues/65) |
+| `sendmany` | Not yet implemented | [#66](https://github.com/zcash/zallet/issues/66) |
+| `sendtoaddress` | Not planned | Use `z_sendmany` (or `z_sendfromaccount` once implemented, [#217](https://github.com/zcash/zallet/issues/217)); see [#67](https://github.com/zcash/zallet/issues/67) |
+| `settxfee` | Omitted | [ZIP 317](https://zips.z.cash/zip-0317) fees are always used |
+| `signmessage` | Not yet implemented | [#68](https://github.com/zcash/zallet/issues/68) |
+| `walletconfirmbackup` | Not yet implemented | No direct tracking issue; related to [#201](https://github.com/zcash/zallet/issues/201) |
+| `z_converttex` | Implemented | |
+| `z_exportkey` | Implemented | |
+| `z_exportviewingkey` | Not yet implemented | [#70](https://github.com/zcash/zallet/issues/70) |
+| `z_exportwallet` | Not yet implemented | [#71](https://github.com/zcash/zallet/issues/71) |
+| `z_getaddressforaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getaddressforaccount) |
+| `z_getbalance` | Omitted | Use `z_getbalanceforaccount` |
+| `z_getbalanceforaccount` | Implemented | |
+| `z_getbalanceforviewingkey` | Not planned | Use `z_getbalanceforaccount` ([#74](https://github.com/zcash/zallet/issues/74)) |
+| `z_getmigrationstatus` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support |
+| `z_getnewaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getnewaccount) |
+| `z_getnewaddress` | Omitted | Use `z_getnewaccount` + `z_getaddressforaccount` |
+| `z_getnotescount` | Implemented | |
+| `z_getoperationresult` | Implemented | |
+| `z_getoperationstatus` | Implemented | |
+| `z_gettotalbalance` | Implemented | Prefer the account-scoped `z_getbalanceforaccount` / `z_getbalances` ([#324](https://github.com/zcash/zallet/issues/324)) |
+| `z_importkey` | Implemented | |
+| `z_importviewingkey` | Not yet implemented | [#80](https://github.com/zcash/zallet/issues/80) |
+| `z_importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md); reconsideration tracked in [#81](https://github.com/zcash/zallet/issues/81) |
+| `z_listaccounts` | Implemented (altered) | [Changes](json_rpc.md#z_listaccounts) |
+| `z_listaddresses` | Omitted | Use `listaddresses` |
+| `z_listoperationids` | Implemented | |
+| `z_listreceivedbyaddress` | Not yet implemented | [#84](https://github.com/zcash/zallet/issues/84) |
+| `z_listunifiedreceivers` | Implemented | |
+| `z_listunspent` | Implemented (altered) | [Changes](json_rpc.md#z_listunspent) |
+| `z_mergetoaddress` | Not yet implemented | [#87](https://github.com/zcash/zallet/issues/87) |
+| `z_sendmany` | Implemented (altered) | [Changes](json_rpc.md#z_sendmany) |
+| `z_setmigration` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support |
+| `z_shieldcoinbase` | Implemented | |
+| `z_viewtransaction` | Implemented (altered) | [Changes](json_rpc.md#z_viewtransaction) |
+| `zcbenchmark` | Omitted | [Note](json_rpc.md#zcbenchmark) |
+| `zcsamplejoinsplit` | Omitted | Sprout-specific benchmarking helper; no Sprout support |
+
+## Methods Zallet adds
+
+Zallet also provides methods that `zcashd`'s wallet did not have:
+
+- `getwalletstatus` — wallet and sync status.
+- `z_getaccount` — details for a single account.
+- `z_getbalances` — balances for all accounts.
+- `z_importaddress` — import a transparent P2PKH public key or P2SH redeem
+  script into an account.
+- `z_listtransactions` — account-scoped transaction listing.
+- `z_recoveraccounts` — re-create accounts from existing seeds.
+- `rpc.discover` — an [OpenRPC](https://open-rpc.org/) description of the full
+  interface.
+
+Zallet additionally implements these methods that lived outside `zcashd`'s
+wallet category: `getrawtransaction` (with
+[altered semantics](json_rpc.md#getrawtransaction)), `decoderawtransaction`,
+`decodescript`, `validateaddress`, `verifymessage`, `help`, and `stop`, plus
+the wallet encryption methods `walletlock` and `walletpassphrase`.

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -20,21 +20,22 @@ Statuses:
 
 | `zcashd` method | Status | Notes |
 |---|---|---|
-| `addmultisigaddress` | Not yet implemented | [#48](https://github.com/zcash/zallet/issues/48) |
+| `addmultisigaddress` | Not yet implemented | Blocked on P2SH support in `zcash_client_sqlite` ([#48](https://github.com/zcash/zallet/issues/48), [librustzcash#1370](https://github.com/zcash/librustzcash/issues/1370)) |
 | `backupwallet` | Not planned | Not planned as an RPC; may become a CLI command ([#49](https://github.com/zcash/zallet/issues/49)); robust backup is tracked in [#195](https://github.com/zcash/zallet/issues/195) |
 | `dumpprivkey` | Not planned | [#50](https://github.com/zcash/zallet/issues/50) |
+| `dumpwallet` | Not planned | Already removed from `zcashd` itself ([zcash#5513](https://github.com/zcash/zcash/issues/5513)); a [ZeWIF](https://github.com/zcash/zewif) export is planned instead ([#71](https://github.com/zcash/zallet/issues/71)) |
 | `encryptwallet` | Omitted | [Note](json_rpc.md#encryptwallet): key material is always encrypted |
 | `getbalance` | Not planned | Use `z_getbalanceforaccount` ([#51](https://github.com/zcash/zallet/issues/51)) |
 | `getnewaddress` | Omitted | Use `z_getnewaccount` + `z_getaddressforaccount` |
 | `getrawchangeaddress` | Omitted | [Note](json_rpc.md#getrawchangeaddress): change is handled internally |
 | `getreceivedbyaddress` | Not yet implemented | [#52](https://github.com/zcash/zallet/issues/52) |
-| `gettransaction` | Not planned | Superseded by `z_viewtransaction`, which now includes its top-level fields ([altered semantics](json_rpc.md#z_viewtransaction)) |
+| `gettransaction` | Not planned | Superseded by `z_viewtransaction`, which now includes its top-level fields ([altered semantics](json_rpc.md#z_viewtransaction)); `gettransaction` cannot represent partially-shielded transactions correctly |
 | `getunconfirmedbalance` | Not yet implemented | [#54](https://github.com/zcash/zallet/issues/54) |
-| `getwalletinfo` | Implemented | |
-| `importaddress` | Not yet implemented | [#56](https://github.com/zcash/zallet/issues/56); if you have the public key or redeem script, `z_importaddress` covers this today |
+| `getwalletinfo` | Implemented (partial) | Balance fields will not be populated — use dedicated balance methods ([#55](https://github.com/zcash/zallet/issues/55)); most other fields are currently placeholders, and only `unlocked_until` is meaningful |
+| `importaddress` | Not yet implemented | Planned to import into the legacy transparent account ([#56](https://github.com/zcash/zallet/issues/56)); if you have the public key or redeem script, `z_importaddress` covers this today |
 | `importprivkey` | Not yet implemented | [#57](https://github.com/zcash/zallet/issues/57) |
 | `importpubkey` | Omitted | Use `z_importaddress` |
-| `importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) |
+| `importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md); a CLI import may be considered ([#81](https://github.com/zcash/zallet/issues/81)) |
 | `keypoolrefill` | Omitted | [Note](json_rpc.md#keypoolrefill): no key pool exists |
 | `listaddresses` | Implemented (altered) | [Changes](json_rpc.md#listaddresses) |
 | `listaddressgroupings` | Not planned | [#59](https://github.com/zcash/zallet/issues/59) |
@@ -51,21 +52,21 @@ Statuses:
 | `walletconfirmbackup` | Not planned | Internal `zcashd` method not intended to be called directly (related: [#201](https://github.com/zcash/zallet/issues/201)) |
 | `z_converttex` | Implemented | |
 | `z_exportkey` | Implemented | |
-| `z_exportviewingkey` | Not yet implemented | [#70](https://github.com/zcash/zallet/issues/70) |
+| `z_exportviewingkey` | Not yet implemented | Planned as UFVK/UIVK export ([#70](https://github.com/zcash/zallet/issues/70)) |
 | `z_exportwallet` | Not yet implemented | Planned as a [ZeWIF](https://github.com/zcash/zewif) export, likely a CLI operation rather than an RPC ([#71](https://github.com/zcash/zallet/issues/71)) |
 | `z_getaddressforaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getaddressforaccount) |
 | `z_getbalance` | Omitted | Use `z_getbalanceforaccount` |
 | `z_getbalanceforaccount` | Implemented | |
-| `z_getbalanceforviewingkey` | Not planned | Use `z_getbalanceforaccount` ([#74](https://github.com/zcash/zallet/issues/74)) |
+| `z_getbalanceforviewingkey` | Not planned | Imported viewing keys get accounts with UUIDs, so `z_getbalanceforaccount` covers them ([#74](https://github.com/zcash/zallet/issues/74)) |
 | `z_getmigrationstatus` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support; may be revisited for a future pool migration ([#481](https://github.com/zcash/zallet/issues/481)) |
 | `z_getnewaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getnewaccount) |
 | `z_getnewaddress` | Omitted | Use `z_getnewaccount` + `z_getaddressforaccount` |
 | `z_getnotescount` | Implemented | |
 | `z_getoperationresult` | Implemented | |
 | `z_getoperationstatus` | Implemented | |
-| `z_gettotalbalance` | Implemented (deprecated) | Use the account-scoped `z_getbalanceforaccount` / `z_getbalances` instead ([#324](https://github.com/zcash/zallet/issues/324)) |
+| `z_gettotalbalance` | Implemented (deprecated) | `include_watchonly = false` is not yet honored; use the account-scoped `z_getbalanceforaccount` / `z_getbalances` instead ([#324](https://github.com/zcash/zallet/issues/324)) |
 | `z_importkey` | Implemented (altered) | Sapling extended spending keys only |
-| `z_importviewingkey` | Not yet implemented | [#80](https://github.com/zcash/zallet/issues/80) |
+| `z_importviewingkey` | Not yet implemented | Planned for Sapling keys, UFVKs, and UIVKs ([#80](https://github.com/zcash/zallet/issues/80)) |
 | `z_importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md); reconsideration tracked in [#81](https://github.com/zcash/zallet/issues/81) |
 | `z_listaccounts` | Implemented (altered) | [Changes](json_rpc.md#z_listaccounts) |
 | `z_listaddresses` | Omitted | Use `listaddresses` |

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -10,8 +10,9 @@ Statuses:
 - **Not yet implemented** — intentionally absent so far; implementation is
   tracked in the linked issue. Whether each of these ships will be decided
   during the beta phase ([#287]).
-- **Not planned** — will not be implemented; the Notes column says what to use
-  instead.
+- **Not planned** — not intended to be implemented; the Notes column says what
+  to use instead. These reflect current team intent and may be revisited
+  during the beta phase ([#287]).
 - **Omitted** — intentionally not implemented; see the
   [omitted methods](json_rpc.md#omitted-rpc-methods) table for replacements.
 
@@ -20,10 +21,10 @@ Statuses:
 | `zcashd` method | Status | Notes |
 |---|---|---|
 | `addmultisigaddress` | Not yet implemented | [#48](https://github.com/zcash/zallet/issues/48) |
-| `backupwallet` | Not yet implemented | [#49](https://github.com/zcash/zallet/issues/49); robust backup is tracked in [#195](https://github.com/zcash/zallet/issues/195) |
-| `dumpprivkey` | Not yet implemented | [#50](https://github.com/zcash/zallet/issues/50) |
+| `backupwallet` | Not planned | Not planned as an RPC; may become a CLI command ([#49](https://github.com/zcash/zallet/issues/49)); robust backup is tracked in [#195](https://github.com/zcash/zallet/issues/195) |
+| `dumpprivkey` | Not planned | [#50](https://github.com/zcash/zallet/issues/50) |
 | `encryptwallet` | Omitted | [Note](json_rpc.md#encryptwallet): key material is always encrypted |
-| `getbalance` | Not yet implemented | [#51](https://github.com/zcash/zallet/issues/51) |
+| `getbalance` | Not planned | Use `z_getbalanceforaccount` ([#51](https://github.com/zcash/zallet/issues/51)) |
 | `getnewaddress` | Omitted | Use `z_getnewaccount` + `z_getaddressforaccount` |
 | `getrawchangeaddress` | Omitted | [Note](json_rpc.md#getrawchangeaddress): change is handled internally |
 | `getreceivedbyaddress` | Not yet implemented | [#52](https://github.com/zcash/zallet/issues/52) |
@@ -36,34 +37,34 @@ Statuses:
 | `importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) |
 | `keypoolrefill` | Omitted | [Note](json_rpc.md#keypoolrefill): no key pool exists |
 | `listaddresses` | Implemented (altered) | [Changes](json_rpc.md#listaddresses) |
-| `listaddressgroupings` | Not yet implemented | [#59](https://github.com/zcash/zallet/issues/59) |
-| `listlockunspent` | Not yet implemented | [#60](https://github.com/zcash/zallet/issues/60) |
+| `listaddressgroupings` | Not planned | [#59](https://github.com/zcash/zallet/issues/59) |
+| `listlockunspent` | Not yet implemented | Planned with modified semantics ([#60](https://github.com/zcash/zallet/issues/60)) |
 | `listreceivedbyaddress` | Not yet implemented | [#61](https://github.com/zcash/zallet/issues/61) |
 | `listsinceblock` | Not yet implemented | [#62](https://github.com/zcash/zallet/issues/62) |
-| `listtransactions` | Not yet implemented | [#63](https://github.com/zcash/zallet/issues/63); Zallet provides the account-scoped `z_listtransactions` |
+| `listtransactions` | Not yet implemented | Provided today in modified, account-scoped form as `z_listtransactions` ([#63](https://github.com/zcash/zallet/issues/63)) |
 | `listunspent` | Not planned | Subsumed by `z_listunspent`, which now includes transparent outputs ([changes](json_rpc.md#z_listunspent), [#64](https://github.com/zcash/zallet/issues/64)) |
-| `lockunspent` | Not yet implemented | [#65](https://github.com/zcash/zallet/issues/65) |
-| `sendmany` | Not yet implemented | [#66](https://github.com/zcash/zallet/issues/66) |
-| `sendtoaddress` | Not planned | Use `z_sendmany` (or `z_sendfromaccount` once implemented, [#217](https://github.com/zcash/zallet/issues/217)); see [#67](https://github.com/zcash/zallet/issues/67) |
+| `lockunspent` | Not yet implemented | Planned with modified semantics ([#65](https://github.com/zcash/zallet/issues/65)) |
+| `sendmany` | Not planned | Use `z_sendmany`, or `z_sendfromaccount` once implemented ([#66](https://github.com/zcash/zallet/issues/66), [#217](https://github.com/zcash/zallet/issues/217)) |
+| `sendtoaddress` | Not planned | Use `z_sendfromaccount` once implemented ([#217](https://github.com/zcash/zallet/issues/217)); `z_sendmany` covers most uses today ([#67](https://github.com/zcash/zallet/issues/67)) |
 | `settxfee` | Omitted | [ZIP 317](https://zips.z.cash/zip-0317) fees are always used |
 | `signmessage` | Not yet implemented | [#68](https://github.com/zcash/zallet/issues/68) |
-| `walletconfirmbackup` | Not yet implemented | No direct tracking issue; related to [#201](https://github.com/zcash/zallet/issues/201) |
+| `walletconfirmbackup` | Not planned | Internal `zcashd` method not intended to be called directly (related: [#201](https://github.com/zcash/zallet/issues/201)) |
 | `z_converttex` | Implemented | |
 | `z_exportkey` | Implemented | |
 | `z_exportviewingkey` | Not yet implemented | [#70](https://github.com/zcash/zallet/issues/70) |
-| `z_exportwallet` | Not yet implemented | [#71](https://github.com/zcash/zallet/issues/71) |
+| `z_exportwallet` | Not yet implemented | Planned as a [ZeWIF](https://github.com/zcash/zewif) export, likely a CLI operation rather than an RPC ([#71](https://github.com/zcash/zallet/issues/71)) |
 | `z_getaddressforaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getaddressforaccount) |
 | `z_getbalance` | Omitted | Use `z_getbalanceforaccount` |
 | `z_getbalanceforaccount` | Implemented | |
 | `z_getbalanceforviewingkey` | Not planned | Use `z_getbalanceforaccount` ([#74](https://github.com/zcash/zallet/issues/74)) |
-| `z_getmigrationstatus` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support |
+| `z_getmigrationstatus` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support; may be revisited for a future pool migration ([#481](https://github.com/zcash/zallet/issues/481)) |
 | `z_getnewaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getnewaccount) |
 | `z_getnewaddress` | Omitted | Use `z_getnewaccount` + `z_getaddressforaccount` |
 | `z_getnotescount` | Implemented | |
 | `z_getoperationresult` | Implemented | |
 | `z_getoperationstatus` | Implemented | |
-| `z_gettotalbalance` | Implemented | Prefer the account-scoped `z_getbalanceforaccount` / `z_getbalances` ([#324](https://github.com/zcash/zallet/issues/324)) |
-| `z_importkey` | Implemented | |
+| `z_gettotalbalance` | Implemented (deprecated) | Use the account-scoped `z_getbalanceforaccount` / `z_getbalances` instead ([#324](https://github.com/zcash/zallet/issues/324)) |
+| `z_importkey` | Implemented (altered) | Sapling extended spending keys only |
 | `z_importviewingkey` | Not yet implemented | [#80](https://github.com/zcash/zallet/issues/80) |
 | `z_importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md); reconsideration tracked in [#81](https://github.com/zcash/zallet/issues/81) |
 | `z_listaccounts` | Implemented (altered) | [Changes](json_rpc.md#z_listaccounts) |
@@ -74,7 +75,7 @@ Statuses:
 | `z_listunspent` | Implemented (altered) | [Changes](json_rpc.md#z_listunspent) |
 | `z_mergetoaddress` | Not yet implemented | [#87](https://github.com/zcash/zallet/issues/87) |
 | `z_sendmany` | Implemented (altered) | [Changes](json_rpc.md#z_sendmany) |
-| `z_setmigration` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support |
+| `z_setmigration` | Omitted | [Note](json_rpc.md#z_getmigrationstatus-and-z_setmigration): no Sprout support; may be revisited for a future pool migration ([#481](https://github.com/zcash/zallet/issues/481)) |
 | `z_shieldcoinbase` | Implemented | |
 | `z_viewtransaction` | Implemented (altered) | [Changes](json_rpc.md#z_viewtransaction) |
 | `zcbenchmark` | Omitted | [Note](json_rpc.md#zcbenchmark) |


### PR DESCRIPTION
## Summary

Two commits (discrete semantic changes):

**1. Migration guide + omitted-RPC guidance**
- Replaces the TODO stub at `book/src/zcashd/README.md` with a strategy-level migration guide: node replacement, `migrate-zcash-conf`, wallet encryption setup, `migrate-zcashd-wallet`, sync verification, and RPC client updates — linking to the existing CLI reference pages instead of duplicating them, with explicit "what is / is not migrated" and post-migration backup sections.
- Fills the empty "Use this instead" cells of the omitted JSON-RPC methods table in `book/src/zcashd/json_rpc.md`, adds `encryptwallet` and `zcbenchmark` rows, and adds short per-method notes explaining each replacement (or why none exists), linking ZIP 32 / ZIP 317 on zips.z.cash.

**2. + 3. JSON-RPC method status matrix** (`book/src/zcashd/rpc_status.md`)
- All 60 `zcashd` wallet-category RPCs with their Zallet status: implemented / implemented-with-altered-semantics / not-yet-implemented (with tracking issue) / not-planned (with replacement) / omitted — plus the methods Zallet adds.
- Statuses derived from the implemented method set in `zallet-core/src/components/json_rpc/methods.rs`, the omitted-methods table, per-method tracking issues, maintainer closure comments, and (third commit) the [zcashd RPC usage survey spreadsheet](https://docs.google.com/spreadsheets/d/1UJxH1cowexGqadU32Uei5Qak6jGhXjb18-T_QBPmDAA) recording per-method team intent (Full/Modified/Not planned/TBD/Deprecated). Where the survey is stale against the code (`z_exportkey`, `z_getnotescount`, `decoderawtransaction`, `decodescript` implemented; `getwalletinfo` reports transparent balances), the code wins.

All behavioral claims were verified against the code: launcher dispatch and `DEFAULT_BACKEND` (`zallet/src/main.rs`), `migrate-zcash-conf`'s ignore-list containing `rpcuser`/`rpcpassword` (`zallet-core/src/commands/migrate_zcash_conf.rs`, cf. #306), and `z_importaddress` accepting pubkeys and redeem scripts (`zallet-core/src/components/json_rpc/methods.rs`).

Part of #182 and #600.
Closes #323, #325, #326, #328, #329, #332, #602.

## Test plan

- [x] `mdbook build` succeeds
- [x] All intra-book links and anchors used by the new content verified against the built HTML

## AI disclosure

Written with AI assistance (Claude Fable 5, via Claude Code); `Co-Authored-By` metadata is on the commits. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)