### PR TITLE
book: Fix backend name in installation guide and stale book URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ behavior as documented in the code of conduct.
 ## I Have a Question
 
 > If you want to ask a question, please ensure that you have read the available
-> documentation. Documentation is published to the [Zallet Book](https://zcash.github.io/wallet).
+> documentation. Documentation is published to the [Zallet Book](https://zcash.github.io/zallet/).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/zcash/zallet/issues)
 that might help you. In case you have found a suitable issue and still need

--- a/book/book.toml
+++ b/book/book.toml
@@ -5,5 +5,5 @@ src = "src"
 title = "The Zallet Book"
 
 [output.html]
-site-url = "/wallet/"
+site-url = "/zallet/"
 git-repository-url = "https://github.com/zcash/zallet/tree/main/book"

--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -19,13 +19,13 @@ workspace, so the two can track different `zebra` releases), and the `zallet` co
 a small launcher that runs whichever backend your config file names:
 
 ```toml
-# zallet.toml — the default if the key is absent is "zebra-state"
+# zallet.toml — the default if the key is absent is "zebra"
 backend = "zaino"
 ```
 
 | Backend | Default | Platform | Reaches the chain via | Requires | Regtest |
 |---------|:-------:|----------|-----------------------|----------|:-------:|
-| `zebra-state` | Yes | Linux only | co-located `zebrad`'s state database (`ReadStateService`) | `zebrad` built with the `indexer` feature + `[indexer.read_state_service]` config + shared state dir | No |
+| `zebra` | Yes | Linux only | co-located `zebrad`'s state database (`ReadStateService`) | `zebrad` built with the `indexer` feature + `[indexer.read_state_service]` config + shared state dir | No |
 | `zaino` | No | Linux, macOS, Windows | co-located `zebrad`'s JSON-RPC endpoint (optionally reads state directly when `[indexer.read_state_service]` is set) | co-located `zebrad` JSON-RPC endpoint | Yes |
 
 The **`zebra` backend** is the default. It reads finalized chain state directly from
@@ -63,7 +63,7 @@ Each backend is its own package in its own cargo workspace, so you install the o
 want by name (plus the launcher, if you want config-driven dispatch):
 
 ```
-# The zebra-state backend (Linux only)
+# The zebra backend (Linux only, reads zebrad's state database)
 cargo install --locked --git https://github.com/zcash/zallet.git zallet-zebra
 
 # The zaino backend


### PR DESCRIPTION
## Summary

- Corrects the installation guide's backend naming: it claimed the default `backend` config value is `"zebra-state"` and used that name in the comparison table and examples. The launcher's `DEFAULT_BACKEND` is `"zebra"` (`zallet/src/main.rs:36`), the zebra backend registers `ChainFactory::NAME = "zebra"` (`backends/zebra/src/chain.rs:141`), and dispatch maps config value `foo` → `zallet-foo`, so `backend = "zebra-state"` would attempt to exec a nonexistent `zallet-zebra-state`. Literal error-message quotes and references to the `zebra-state` *crate* are left unchanged.
- Sets `book/book.toml` `site-url` to `/zallet/`, matching where the book actually deploys (https://zcash.github.io/zallet/ — `/wallet/` 404s), fixing generated 404-page link resolution.
- Fixes the CONTRIBUTING.md link to the book, which pointed at the 404ing `/wallet` URL.

Closes #611. Part of #600.

## Test plan

- [x] `mdbook build` succeeds
- [x] Verified https://zcash.github.io/zallet/ returns 200 and https://zcash.github.io/wallet/ returns 404
- [x] Verified backend dispatch behavior in `zallet/src/main.rs` (`backend_binary_name`, `DEFAULT_BACKEND`) and backend self-validation in `zallet-core/src/application.rs`

## AI disclosure

Written with AI assistance (Claude Fable 5, via Claude Code); `Co-Authored-By` metadata is on the commit. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
