### PR TITLE
rpc-cli: answer `help` locally without a wallet or running server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- `zallet rpc help` is now answered locally instead of being sent to the
+  wallet's JSON-RPC server, so it no longer requires a config file, an
+  initialized wallet, or a running `zallet start`. The command argument may
+  now be passed bare (`zallet rpc help getwalletinfo`) in addition to the
+  JSON-quoted form.
+
 ## [0.1.0-beta.1] - 2026-07-12
 
 ### Added

--- a/zallet-core/src/commands/rpc_cli.rs
+++ b/zallet-core/src/commands/rpc_cli.rs
@@ -41,6 +41,26 @@ macro_rules! wlnfl {
 
 impl AsyncRunnable for RpcCliCmd {
     async fn run(&self) -> Result<(), Error> {
+        // `help` is generated from static method metadata, so answer it locally
+        // instead of requiring a wallet with a running JSON-RPC server.
+        #[cfg(zallet_build = "wallet")]
+        if self.command == "help" {
+            let command = match self.params.as_slice() {
+                [] => None,
+                [command] => Some(
+                    serde_json::from_str::<String>(command).unwrap_or_else(|_| command.clone()),
+                ),
+                [_, param, ..] => {
+                    return Err(RpcCliError::InvalidParameter(param.clone()).into());
+                }
+            };
+            print!(
+                "{}",
+                crate::components::json_rpc::methods::help::text(command.as_deref())
+            );
+            return Ok(());
+        }
+
         let config = APP.config();
 
         let timeout = Duration::from_secs(match self.timeout {

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -39,7 +39,7 @@ mod get_raw_transaction;
 mod get_wallet_info;
 mod get_wallet_status;
 #[cfg(zallet_build = "wallet")]
-mod help;
+pub(crate) mod help;
 #[cfg(zallet_build = "wallet")]
 mod import_key;
 mod list_accounts;

--- a/zallet-core/src/components/json_rpc/methods/help.rs
+++ b/zallet-core/src/components/json_rpc/methods/help.rs
@@ -16,7 +16,11 @@ pub(crate) struct ResultType(String);
 pub(super) const PARAM_COMMAND_DESC: &str = "The command to get help on.";
 
 pub(crate) fn call(command: Option<&str>) -> Response {
-    Ok(ResultType(if let Some(command) = command {
+    Ok(ResultType(text(command)))
+}
+
+pub(crate) fn text(command: Option<&str>) -> String {
+    if let Some(command) = command {
         match METHODS.get(command) {
             None => format!("help: unknown command: {command}\n"),
             Some(method) => format!("{command}\n\n{}", method.description),
@@ -31,5 +35,5 @@ pub(crate) fn call(command: Option<&str>) -> Response {
             ret.push('\n');
         }
         ret
-    }))
+    }
 }


### PR DESCRIPTION
Closes #550.

The `help` RPC response is generated entirely from static method metadata (the `METHODS` map in `openrpc.rs`), so `zallet rpc help` can print it directly instead of requiring a config file, an initialized wallet, and a running JSON-RPC server just to list the available commands.

Changes:
- Split the text generation out of the `help` RPC handler into `help::text()`; the RPC `call()` now wraps it, so server-side behavior is unchanged and the CLI output is guaranteed to match it.
- `RpcCliCmd::run` short-circuits `help` before reading credentials or building the HTTP client, guarded with `#[cfg(zallet_build = "wallet")]` to match the cfg on the `help` module.
- The command argument may now be passed bare (`zallet rpc help getwalletinfo`) in addition to the JSON-quoted form the HTTP path requires; extra parameters still error as before.

Verified against a freshly created empty datadir (no config, no wallet, no server): `rpc help`, `rpc help getwalletinfo` (bare and quoted), unknown-command, and too-many-params paths all behave, with no cookie warning or connection error.