### PR TITLE
Make age recipient initialization atomic

### DIFF
--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -410,31 +410,51 @@ impl KeyStore {
         &self,
         recipient_strings: Vec<String>,
     ) -> Result<(), Error> {
-        // If the wallet has any existing recipients, fail (we would instead need to
-        // re-encrypt the wallet).
-        if !self.maybe_encryptor().await?.is_empty() {
-            return Err(ErrorKind::Generic
-                .context(fl!("err-keystore-already-initialized"))
-                .into());
-        }
-
         let now = ::time::OffsetDateTime::now_utc();
 
         self.with_db_mut(|conn, _| {
-            let mut stmt = conn
-                .prepare(
-                    "INSERT INTO ext_zallet_keystore_age_recipients
-                    VALUES (:recipient, :added)",
-                )
+            // Use an explicit transaction so the emptiness check and the inserts are
+            // atomic: either every recipient is committed or none are. This prevents a
+            // partial write (e.g. from a disk-full or I/O error mid-loop) from committing
+            // an incomplete recipient set that the one-shot guard below would then refuse
+            // to ever repair.
+            let tx = conn
+                .transaction()
                 .map_err(|e| ErrorKind::Generic.context(e))?;
 
-            for recipient in recipient_strings {
-                stmt.execute(named_params! {
-                    ":recipient": recipient,
-                    ":added": now,
-                })
+            // If the wallet has any existing recipients, fail (we would instead need to
+            // re-encrypt the wallet).
+            let existing_recipients: i64 = tx
+                .query_row(
+                    "SELECT COUNT(*) FROM ext_zallet_keystore_age_recipients",
+                    [],
+                    |row| row.get(0),
+                )
                 .map_err(|e| ErrorKind::Generic.context(e))?;
+            if existing_recipients != 0 {
+                return Err(ErrorKind::Generic
+                    .context(fl!("err-keystore-already-initialized"))
+                    .into());
             }
+
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT INTO ext_zallet_keystore_age_recipients
+                        VALUES (:recipient, :added)",
+                    )
+                    .map_err(|e| ErrorKind::Generic.context(e))?;
+
+                for recipient in recipient_strings {
+                    stmt.execute(named_params! {
+                        ":recipient": recipient,
+                        ":added": now,
+                    })
+                    .map_err(|e| ErrorKind::Generic.context(e))?;
+                }
+            }
+
+            tx.commit().map_err(|e| ErrorKind::Generic.context(e))?;
 
             Ok(())
         })


### PR DESCRIPTION
`initialize_recipients` previously inserted age recipients in a loop with no transaction, so each INSERT autocommitted. A failure partway through (disk full, I/O error, crash) could commit a partial recipient set, after which the one-shot emptiness guard would refuse every retry, permanently wedging wallet initialization with key material encrypted to an incomplete set of recipients.

Wrap the emptiness guard and the insert loop in a single explicit transaction, following the pattern used by
`store_encrypted_standalone_transparent_keys`. The guard is now an in-transaction `SELECT COUNT(*)` on the recipients table (equivalent to the previous `maybe_encryptor().is_empty()` check, which used a separate connection and could not participate in the transaction), which also closes the check-then-insert race.

Closes https://github.com/zcash/zallet/issues/616
[COR-1579](https://linear.app/zodl/issue/COR-1579)