### PR TITLE
zallet-core: add zcash_ironwood_migration_backend dependency scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ be considered breaking changes.
   integrators no longer need a `getrawtransaction` round-trip per UTXO to
   distinguish coinbase from spendable-to-transparent funds.
 - `zallet_core::migrate`, an integration point that wires in the
-  backend-agnostic Orchard-to-Ironwood value-pool migration engine
-  (`zcash_ironwood_migration_backend`). The engine is still evolving upstream
-  and is pinned to a librustzcash feature branch, so this is currently a
-  scaffold that re-exports the engine and adds no migration behaviour yet.
+  backend-agnostic value-pool migration engine (`zcash_pool_migration_backend`).
+  It re-exports the engine and provides `SpendableSnapshot`, Zallet's
+  implementation of the engine's `MigrationBackend` trait for the planning
+  slice. The engine is still evolving upstream and is pinned to a librustzcash
+  feature branch, so only the planning path is wired; committing a migration
+  (building, signing, and persisting the PCZTs) awaits later engine slices.
 - A generic pool-to-pool migration JSON-RPC surface (wallet build): the
   `z_startpoolmigration`, `z_getpoolmigrationstatus`, `z_advancepoolmigration`,
   `z_cancelpoolmigration`, and `z_listpoolmigrations` methods. The surface is
@@ -34,6 +36,13 @@ be considered breaking changes.
   methods are currently a scaffold: they validate their inputs (pool parsing, the
   supported-pair table, and network-upgrade activation) but the migration engine
   is not yet wired in, so they return a "not implemented yet" error.
+- `z_previewpoolmigration` (wallet build), the fully-wired planning preview of
+  the pool-migration surface. It enumerates the account's spendable source-pool
+  notes and runs the engine's `plan_migration` to return the proposed plan for
+  user consent (ZIP 318): the funding notes and their crossing denominations,
+  each note's transfer broadcast height and expiry, the note-preparation
+  transaction summary, and the residual left in the source pool. It is
+  read-only; nothing is built, proved, or broadcast.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ be considered breaking changes.
   methods are currently a scaffold: they validate their inputs (pool parsing, the
   supported-pair table, and network-upgrade activation) but the migration engine
   is not yet wired in, so they return a "not implemented yet" error.
+- An external-signer surface for the pool migration (wallet build), so a
+  hardware or offline signer can sign a migration's transactions out of band:
+  `z_startpoolmigration` takes an `external_signer` flag that builds the
+  preparation unsigned and returns its PCZTs; `z_buildpoolmigrationtransfers`
+  builds the phase-2 transfers unsigned once the preparation is mined;
+  `z_applypoolmigrationsignature` applies a signed PCZT to its transaction
+  (moving it to signed, after which `z_advancepoolmigration` proves and
+  broadcasts it unchanged); and `z_signpoolmigrationpczt` signs a migration PCZT
+  with the account's spend key for offline / air-gapped signing. Building still
+  runs in process (it needs only the viewing key and witnesses); only the
+  signature is external.
 - `z_previewpoolmigration` (wallet build), the fully-wired planning preview of
   the pool-migration surface. It enumerates the account's spendable source-pool
   notes and runs the engine's `plan_migration` to return the proposed plan for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ be considered breaking changes.
   (`zcash_ironwood_migration_backend`). The engine is still evolving upstream
   and is pinned to a librustzcash feature branch, so this is currently a
   scaffold that re-exports the engine and adds no migration behaviour yet.
+- A generic pool-to-pool migration JSON-RPC surface (wallet build): the
+  `z_startpoolmigration`, `z_getpoolmigrationstatus`, `z_advancepoolmigration`,
+  `z_cancelpoolmigration`, and `z_listpoolmigrations` methods. The surface is
+  parameterised by a `from_pool`/`to_pool` pair rather than hardcoding a
+  specific migration; a single supported-migrations table maps each pool pair to
+  the network upgrade that enables it (Orchard to Ironwood requires NU6.3). These
+  methods are currently a scaffold: they validate their inputs (pool parsing, the
+  supported-pair table, and network-upgrade activation) but the migration engine
+  is not yet wired in, so they return a "not implemented yet" error.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ be considered breaking changes.
   indicating coinbase origin (mirroring `zcashd`'s `listunspent`), so
   integrators no longer need a `getrawtransaction` round-trip per UTXO to
   distinguish coinbase from spendable-to-transparent funds.
+- `zallet_core::migrate`, an integration point that wires in the
+  backend-agnostic Orchard-to-Ironwood value-pool migration engine
+  (`zcash_ironwood_migration_backend`). The engine is still evolving upstream
+  and is pinned to a librustzcash feature branch, so this is currently a
+  scaffold that re-exports the engine and adds no migration behaviour yet.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.8.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5855,7 +5855,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5905,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "hex",
@@ -5995,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6041,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "getset",
@@ -6090,7 +6090,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "document-features",
@@ -6218,7 +6218,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bip32",
  "bs58",
@@ -6397,7 +6397,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1098,6 +1099,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,16 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
-dependencies = [
- "blake2b_simd",
- "corez",
-]
-
-[[package]]
-name = "equihash"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1348,15 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3025,8 +3043,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",
@@ -3151,6 +3168,34 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.8.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.0",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_script",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -4148,6 +4193,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5697,6 +5770,7 @@ dependencies = [
  "nonempty",
  "once_cell",
  "orchard 0.15.0",
+ "pczt",
  "phf",
  "proptest",
  "quote",
@@ -5733,19 +5807,19 @@ dependencies = [
  "which",
  "x25519-dalek",
  "xdg 2.5.2",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_ironwood_migration_backend",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -5760,41 +5834,28 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "f4jumble",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
 ]
 
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "bech32 0.11.1",
- "bs58",
- "corez",
- "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5829,14 +5890,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -5844,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5877,14 +5938,15 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zip32",
 ]
@@ -5892,31 +5954,11 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "corez",
  "hex",
  "nonempty",
-]
-
-[[package]]
-name = "zcash_encoding"
-version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "corez",
- "hex",
- "nonempty",
-]
-
-[[package]]
-name = "zcash_ironwood_migration_backend"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "rand_core 0.6.4",
- "zcash_primitives 0.29.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -5944,7 +5986,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zip32",
@@ -5953,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5975,10 +6017,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zeroize",
  "zip32",
 ]
@@ -5997,6 +6039,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.0",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,7 +6068,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -6019,7 +6080,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol 0.9.0",
  "zcash_script",
@@ -6029,14 +6090,14 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -6049,45 +6110,17 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard 0.15.0",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2 0.10.9",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_note_encryption",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_script",
- "zcash_transparent 0.9.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6103,7 +6136,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -6116,29 +6149,19 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
 ]
 
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "corez",
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "corez",
- "hex",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -6185,7 +6208,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
@@ -6195,7 +6218,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bip32",
  "bs58",
@@ -6208,31 +6231,9 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_script",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "bip32",
- "bs58",
- "corez",
- "getset",
- "hex",
- "nonempty",
- "ripemd 0.1.3",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6370,7 +6371,7 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_keys 0.14.0",
  "zcash_primitives 0.28.0",
  "zcash_protocol 0.9.0",
@@ -6396,13 +6397,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1349,14 @@ dependencies = [
 name = "f4jumble"
 version = "0.1.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
 dependencies = [
  "blake2b_simd",
 ]
@@ -5716,18 +5733,19 @@ dependencies = [
  "which",
  "x25519-dalek",
  "xdg 2.5.2",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_ironwood_migration_backend",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -5742,8 +5760,8 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
 ]
 
@@ -5755,9 +5773,22 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "bech32 0.11.1",
+ "bs58",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -5798,14 +5829,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0",
- "zcash_encoding",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
  "zip321",
 ]
@@ -5846,14 +5877,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zewif",
  "zip32",
 ]
@@ -5866,6 +5897,26 @@ dependencies = [
  "corez",
  "hex",
  "nonempty",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "corez",
+ "hex",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_ironwood_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "rand_core 0.6.4",
+ "zcash_primitives 0.29.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -5893,7 +5944,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zip32",
@@ -5924,10 +5975,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
  "zip32",
 ]
@@ -5956,7 +6007,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -5968,7 +6019,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
  "zcash_protocol 0.9.0",
  "zcash_script",
@@ -5985,7 +6036,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -5998,11 +6049,39 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard 0.15.0",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_script",
+ "zcash_transparent 0.9.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6024,7 +6103,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6037,7 +6116,7 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6049,7 +6128,17 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "corez",
+ "hex",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6096,7 +6185,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
@@ -6119,9 +6208,31 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6259,7 +6370,7 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.14.0",
  "zcash_primitives 0.28.0",
  "zcash_protocol 0.9.0",
@@ -6290,8 +6401,8 @@ dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
- "zcash_address 0.13.0",
- "zcash_protocol 0.10.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,11 +161,15 @@ bip32 = "0.2"
 # pool-agnostic `zcash_pool_migration_backend`).
 #
 # Pinned to a specific commit (not a bare branch) that carries the engine API
-# this integration uses: the `MigrationBackend` trait (spendable notes, chain
-# tip, and the store/load/update persistence methods) and `engine::plan_migration`,
-# which backs the preview RPC. Bump the rev when the integration needs a newer
-# engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "df6e0b6e9c61e9b8490813a27683801beb1f25c6" }
+# this integration uses: the `MigrationBackend` trait (spendable notes + chain
+# tip), the `PoolMigrationRead`/`PoolMigrationWrite` store traits, the
+# `WalletMigration` wallet-backed adapter (the `wallet` feature), and
+# `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
+# when the integration needs a newer engine API.
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755", features = ["wallet"] }
+# The SQLite store for the migration (the pool_migrations tables + the
+# PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755" }
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }
@@ -177,19 +181,24 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-# Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+# Pinned to the prove/pool-migration-transfer branch of librustzcash: the
+# pool-migration engine plus its Orchard/Ironwood transfer and preparation
+# proving. The repo is a workspace, so pinning the crates we depend on pulls
+# their path-dep siblings from git while their crates.io copies remain; pinning
+# the whole stack to one rev avoids duplicating it. Replace with the crates.io
+# releases once they ship.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ bip32 = "0.2"
 
 # Backend-agnostic value-pool migration engine (Orchard -> Ironwood, NU6.3).
 # This crate is not yet published to crates.io; it lives on the
-# `feat/pool-migration-engine` branch of librustzcash while its API is still
+# `prove/pool-migration-transfer` branch of librustzcash while its API is still
 # evolving (it was `zcash_ironwood_migration_backend`, renamed upstream to the
 # pool-agnostic `zcash_pool_migration_backend`).
 #
@@ -164,15 +164,18 @@ bip32 = "0.2"
 # this integration uses: the `MigrationBackend` trait (spendable notes + chain
 # tip), the `PoolMigrationRead`/`PoolMigrationWrite` store traits, the
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
-# `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
-# when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f6dbc06b9311689ede149f883bb427805e590a42", features = ["wallet"] }
-# The SQLite store for the migration (the pool_migrations tables + the
-# PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f6dbc06b9311689ede149f883bb427805e590a42" }
+# `engine::{plan_migration, commit_preparation}` (a single pass now builds every
+# preparation layer AND every transfer). Bump the rev when the integration needs
+# a newer engine API.
+#
+# The migration's SQLite store (the pool_migrations tables + the
+# PoolMigrationRead/Write impls over the wallet database) is no longer a separate
+# crate: it now lives in `zcash_client_sqlite::pool_migration::orchard_ironwood`
+# (pinned to the same rev via the `[patch.crates-io]` block below).
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8", features = ["wallet"] }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "f6dbc06b9311689ede149f883bb427805e590a42", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8", features = [
     "prover",
     "tx-extractor",
     "orchard",
@@ -206,6 +209,10 @@ zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba9
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+# The pinned librustzcash rev builds against the git `orchard` (the NU6.3 / Ironwood deferred-anchor
+# builder API: `Builder::new_with_anchor_deferred`, `add_spend_unwitnessed`), not the crates.io
+# release; patch it to the same rev librustzcash pins.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,13 +166,13 @@ bip32 = "0.2"
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
 # `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
 # when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "009e7c58841cc60148a822049ac4cb7d1f737ca7", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "760774cd8e0d7e418315fceca6296afb36493c0b", features = ["wallet"] }
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "009e7c58841cc60148a822049ac4cb7d1f737ca7" }
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "760774cd8e0d7e418315fceca6296afb36493c0b" }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "009e7c58841cc60148a822049ac4cb7d1f737ca7", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "760774cd8e0d7e418315fceca6296afb36493c0b", features = [
     "prover",
     "tx-extractor",
     "orchard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,13 @@ zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
 
+# Orchard -> Ironwood value-pool migration engine. This crate is not yet
+# published to crates.io; it lives only on the `feat/ironwood-denominations`
+# branch of librustzcash while its API is still evolving, so it is pinned to
+# that branch rather than to a released version like the crates above. Repoint
+# at a released crates.io version once one is published.
+zcash_ironwood_migration_backend = { git = "https://github.com/zcash/librustzcash", branch = "feat/ironwood-denominations" }
+
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }
 zewif-zcashd = { version = "0.1.0-rc.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ bip32 = "0.2"
 # tip, and the store/load/update persistence methods) and `engine::plan_migration`,
 # which backs the preview RPC. Bump the rev when the integration needs a newer
 # engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "df6e0b6e9c61e9b8490813a27683801beb1f25c6" }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "df6e0b6e9c61e9b8490813a27683801beb1f25c6" }
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,10 +172,10 @@ bip32 = "0.2"
 # PoolMigrationRead/Write impls over the wallet database) is no longer a separate
 # crate: it now lives in `zcash_client_sqlite::pool_migration::orchard_ironwood`
 # (pinned to the same rev via the `[patch.crates-io]` block below).
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525", features = ["wallet"] }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525", features = [
     "prover",
     "tx-extractor",
     "orchard",
@@ -197,18 +197,18 @@ tonic = "0.14"
 # their path-dep siblings from git while their crates.io copies remain; pinning
 # the whole stack to one rev avoids duplicating it. Replace with the crates.io
 # releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
 # The pinned librustzcash rev builds against the git `orchard` (the NU6.3 / Ironwood deferred-anchor
 # builder API: `Builder::new_with_anchor_deferred`, `add_spend_unwitnessed`), not the crates.io
 # release; patch it to the same rev librustzcash pins.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ bip32 = "0.2"
 # tip, and the store/load/update persistence methods) and `engine::plan_migration`,
 # which backs the preview RPC. Bump the rev when the integration needs a newer
 # engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "38cd00d5fcc636408dd7add4ee3176e363eb8fc4" }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "df6e0b6e9c61e9b8490813a27683801beb1f25c6" }
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,13 @@ zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.gi
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
 zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755" }
+# PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
+# them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755", features = [
+    "prover",
+    "tx-extractor",
+    "orchard",
+] }
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,12 +154,26 @@ zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
 
-# Orchard -> Ironwood value-pool migration engine. This crate is not yet
-# published to crates.io; it lives only on the `feat/ironwood-denominations`
-# branch of librustzcash while its API is still evolving, so it is pinned to
-# that branch rather than to a released version like the crates above. Repoint
-# at a released crates.io version once one is published.
-zcash_ironwood_migration_backend = { git = "https://github.com/zcash/librustzcash", branch = "feat/ironwood-denominations" }
+# Backend-agnostic value-pool migration engine (Orchard -> Ironwood, NU6.3).
+# This crate is not yet published to crates.io; it lives only on the
+# `feat/pool-migration-engine` branch of librustzcash while its API is still
+# evolving (it was `zcash_ironwood_migration_backend`, renamed upstream to a
+# pool-agnostic name).
+#
+# LOCAL DEVELOPMENT ONLY: this is pinned to the checked-out worktree via a
+# relative path, so zallet builds against the exact engine revision under
+# development. This path is NOT portable and MUST NOT be pushed.
+#
+# BEFORE PUSHING: replace the path with a git dependency pinned to a specific
+# commit (not a bare branch), e.g.
+#   zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "<commit>" }
+# PREREQUISITE: the pinned commit must be the one that introduces the current
+# engine API (the 5-method `MigrationBackend` trait with the store/load/update
+# persistence methods, plus `engine::plan_migration`). As of this writing that
+# is local commit 7e9214aaef, which is NOT yet on any remote; the remote tip of
+# `feat/pool-migration-engine` (3f0c5777) predates it and would not compile
+# against this integration. Push the engine commit first, then pin its rev here.
+zcash_pool_migration_backend = { path = "../librustzcash-pool-migration-types/zcash_pool_migration_backend" }
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,13 +166,13 @@ bip32 = "0.2"
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
 # `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
 # when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "009e7c58841cc60148a822049ac4cb7d1f737ca7", features = ["wallet"] }
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755" }
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "009e7c58841cc60148a822049ac4cb7d1f737ca7" }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "0efd29ef08011038d1c3692c8ef2b29785154755", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "009e7c58841cc60148a822049ac4cb7d1f737ca7", features = [
     "prover",
     "tx-extractor",
     "orchard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,13 +166,13 @@ bip32 = "0.2"
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
 # `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
 # when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "760774cd8e0d7e418315fceca6296afb36493c0b", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "49c1a13e293728d00b3985828fcc3e6b70f3a762", features = ["wallet"] }
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "760774cd8e0d7e418315fceca6296afb36493c0b" }
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "49c1a13e293728d00b3985828fcc3e6b70f3a762" }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "760774cd8e0d7e418315fceca6296afb36493c0b", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "49c1a13e293728d00b3985828fcc3e6b70f3a762", features = [
     "prover",
     "tx-extractor",
     "orchard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,13 +166,13 @@ bip32 = "0.2"
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
 # `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
 # when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "49c1a13e293728d00b3985828fcc3e6b70f3a762", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "022278a5c25b548fd8ce512fb9d89b8f1c637024", features = ["wallet"] }
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "49c1a13e293728d00b3985828fcc3e6b70f3a762" }
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "022278a5c25b548fd8ce512fb9d89b8f1c637024" }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "49c1a13e293728d00b3985828fcc3e6b70f3a762", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "022278a5c25b548fd8ce512fb9d89b8f1c637024", features = [
     "prover",
     "tx-extractor",
     "orchard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,13 +166,13 @@ bip32 = "0.2"
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
 # `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
 # when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "022278a5c25b548fd8ce512fb9d89b8f1c637024", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d272e41166559515743d54a1a78ace9d71c9e973", features = ["wallet"] }
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "022278a5c25b548fd8ce512fb9d89b8f1c637024" }
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d272e41166559515743d54a1a78ace9d71c9e973" }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "022278a5c25b548fd8ce512fb9d89b8f1c637024", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "d272e41166559515743d54a1a78ace9d71c9e973", features = [
     "prover",
     "tx-extractor",
     "orchard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,25 +155,17 @@ zip32 = "0.2"
 bip32 = "0.2"
 
 # Backend-agnostic value-pool migration engine (Orchard -> Ironwood, NU6.3).
-# This crate is not yet published to crates.io; it lives only on the
+# This crate is not yet published to crates.io; it lives on the
 # `feat/pool-migration-engine` branch of librustzcash while its API is still
-# evolving (it was `zcash_ironwood_migration_backend`, renamed upstream to a
-# pool-agnostic name).
+# evolving (it was `zcash_ironwood_migration_backend`, renamed upstream to the
+# pool-agnostic `zcash_pool_migration_backend`).
 #
-# LOCAL DEVELOPMENT ONLY: this is pinned to the checked-out worktree via a
-# relative path, so zallet builds against the exact engine revision under
-# development. This path is NOT portable and MUST NOT be pushed.
-#
-# BEFORE PUSHING: replace the path with a git dependency pinned to a specific
-# commit (not a bare branch), e.g.
-#   zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "<commit>" }
-# PREREQUISITE: the pinned commit must be the one that introduces the current
-# engine API (the 5-method `MigrationBackend` trait with the store/load/update
-# persistence methods, plus `engine::plan_migration`). As of this writing that
-# is local commit 7e9214aaef, which is NOT yet on any remote; the remote tip of
-# `feat/pool-migration-engine` (3f0c5777) predates it and would not compile
-# against this integration. Push the engine commit first, then pin its rev here.
-zcash_pool_migration_backend = { path = "../librustzcash-pool-migration-types/zcash_pool_migration_backend" }
+# Pinned to a specific commit (not a bare branch) that carries the engine API
+# this integration uses: the `MigrationBackend` trait (spendable notes, chain
+# tip, and the store/load/update persistence methods) and `engine::plan_migration`,
+# which backs the preview RPC. Bump the rev when the integration needs a newer
+# engine API.
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "38cd00d5fcc636408dd7add4ee3176e363eb8fc4" }
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,13 +166,13 @@ bip32 = "0.2"
 # `WalletMigration` wallet-backed adapter (the `wallet` feature), and
 # `engine::{plan_migration, commit_preparation, commit_transfers}`. Bump the rev
 # when the integration needs a newer engine API.
-zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d272e41166559515743d54a1a78ace9d71c9e973", features = ["wallet"] }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f6dbc06b9311689ede149f883bb427805e590a42", features = ["wallet"] }
 # The SQLite store for the migration (the pool_migrations tables + the
 # PoolMigrationRead/Write impls over the wallet database). Same rev as the engine.
-zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d272e41166559515743d54a1a78ace9d71c9e973" }
+zcash_pool_migration_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f6dbc06b9311689ede149f883bb427805e590a42" }
 # PCZT roles used to prove and extract the migration's pre-signed transactions before broadcasting
 # them (z_advancepoolmigration). Same rev as the engine, which produces the pre-signed PCZTs.
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "d272e41166559515743d54a1a78ace9d71c9e973", features = [
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "f6dbc06b9311689ede149f883bb427805e590a42", features = [
     "prover",
     "tx-extractor",
     "orchard",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,20 +1523,11 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
  "corez",
  "document-features",
-]
-
-[[package]]
-name = "equihash"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "blake2b_simd",
- "corez",
 ]
 
 [[package]]
@@ -1568,15 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3562,8 +3545,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",
@@ -3716,6 +3698,34 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.8.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty 0.11.0",
+ "orchard 0.15.0",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_script",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -6887,11 +6897,11 @@ dependencies = [
  "zaino-common",
  "zaino-fetch",
  "zaino-proto",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6935,6 +6945,7 @@ dependencies = [
  "nix 0.29.0",
  "nonempty 0.11.0",
  "orchard 0.15.0",
+ "pczt",
  "phf",
  "quote",
  "rand 0.8.7",
@@ -6968,19 +6979,19 @@ dependencies = [
  "which",
  "x25519-dalek",
  "xdg 2.5.2",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_ironwood_migration_backend",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -7007,9 +7018,9 @@ dependencies = [
  "zallet-core",
  "zcash_client_backend",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -7024,41 +7035,28 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "f4jumble",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
 ]
 
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "bech32 0.11.1",
- "bs58",
- "corez",
- "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7093,14 +7091,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -7108,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7141,14 +7139,15 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zip32",
 ]
@@ -7156,17 +7155,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
-dependencies = [
- "corez",
- "hex",
- "nonempty 0.11.0",
-]
-
-[[package]]
-name = "zcash_encoding"
-version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "corez",
  "hex",
@@ -7182,16 +7171,6 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "primitive-types 0.12.2",
-]
-
-[[package]]
-name = "zcash_ironwood_migration_backend"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "rand_core 0.6.4",
- "zcash_primitives 0.29.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -7219,7 +7198,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zip32",
@@ -7228,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7250,10 +7229,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zeroize",
  "zip32",
 ]
@@ -7272,6 +7251,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.0",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7282,7 +7280,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -7294,7 +7292,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol 0.9.0",
  "zcash_script",
@@ -7304,14 +7302,14 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -7324,45 +7322,17 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty 0.11.0",
- "orchard 0.15.0",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2 0.10.9",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_note_encryption",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_script",
- "zcash_transparent 0.9.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7378,7 +7348,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -7391,29 +7361,19 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
 ]
 
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "corez",
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "corez",
- "hex",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -7460,7 +7420,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
@@ -7470,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bip32",
  "bs58",
@@ -7483,31 +7443,9 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_script",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "bip32",
- "bs58",
- "corez",
- "getset",
- "hex",
- "nonempty 0.11.0",
- "ripemd 0.1.3",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7532,7 +7470,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "futures",
  "group",
  "halo2_proofs",
@@ -7567,14 +7505,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -7609,11 +7547,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7720,13 +7658,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7744,7 +7682,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.7",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
  "zcash_script",
  "zebra-chain",
 ]
@@ -7920,7 +7858,7 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_keys 0.14.0",
  "zcash_primitives 0.28.0",
  "zcash_protocol 0.9.0",
@@ -7946,13 +7884,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.8.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7043,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7056,7 +7056,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7106,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7155,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "hex",
@@ -7207,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7253,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "getset",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7332,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7367,7 +7367,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "document-features",
@@ -7430,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bip32",
  "bs58",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1531,6 +1531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1569,14 @@ dependencies = [
 name = "f4jumble"
 version = "0.1.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6870,11 +6887,11 @@ dependencies = [
  "zaino-common",
  "zaino-fetch",
  "zaino-proto",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6951,18 +6968,19 @@ dependencies = [
  "which",
  "x25519-dalek",
  "xdg 2.5.2",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_ironwood_migration_backend",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6989,9 +7007,9 @@ dependencies = [
  "zallet-core",
  "zcash_client_backend",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -7006,8 +7024,8 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
 ]
 
@@ -7019,9 +7037,22 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "bech32 0.11.1",
+ "bs58",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -7062,14 +7093,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0",
- "zcash_encoding",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
  "zip321",
 ]
@@ -7110,14 +7141,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zewif",
  "zip32",
 ]
@@ -7133,6 +7164,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "corez",
+ "hex",
+ "nonempty 0.11.0",
+]
+
+[[package]]
 name = "zcash_history"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7141,6 +7182,16 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "primitive-types 0.12.2",
+]
+
+[[package]]
+name = "zcash_ironwood_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "rand_core 0.6.4",
+ "zcash_primitives 0.29.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -7168,7 +7219,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zip32",
@@ -7199,10 +7250,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
  "zip32",
 ]
@@ -7231,7 +7282,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -7243,7 +7294,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
  "zcash_protocol 0.9.0",
  "zcash_script",
@@ -7260,7 +7311,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -7273,11 +7324,39 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty 0.11.0",
+ "orchard 0.15.0",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_script",
+ "zcash_transparent 0.9.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -7299,7 +7378,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7312,7 +7391,7 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7324,7 +7403,17 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "corez",
+ "hex",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -7371,7 +7460,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
@@ -7394,9 +7483,31 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "getset",
+ "hex",
+ "nonempty 0.11.0",
+ "ripemd 0.1.3",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7421,7 +7532,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
@@ -7456,14 +7567,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.13.0",
- "zcash_encoding",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7498,11 +7609,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7609,13 +7720,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7633,7 +7744,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.7",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
  "zebra-chain",
 ]
@@ -7809,7 +7920,7 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.14.0",
  "zcash_primitives 0.28.0",
  "zcash_protocol 0.9.0",
@@ -7840,8 +7951,8 @@ dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
- "zcash_address 0.13.0",
- "zcash_protocol 0.10.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -90,6 +90,7 @@ zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba9
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
 # which surfaces the Ironwood (NU6.3) note commitment treestate from

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -72,19 +72,24 @@ once_cell = "1.2"
 tempfile = "3"
 
 [patch.crates-io]
-# Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+# Pinned to the prove/pool-migration-transfer branch of librustzcash: the
+# pool-migration engine plus its Orchard/Ironwood transfer and preparation
+# proving. The repo is a workspace, so pinning the crates we depend on pulls
+# their path-dep siblings from git while their crates.io copies remain; pinning
+# the whole stack to one rev avoids duplicating it. Replace with the crates.io
+# releases once they ship.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
 # which surfaces the Ironwood (NU6.3) note commitment treestate from

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -78,18 +78,18 @@ tempfile = "3"
 # their path-dep siblings from git while their crates.io copies remain; pinning
 # the whole stack to one rev avoids duplicating it. Replace with the crates.io
 # releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),

--- a/backends/zaino/supply-chain/config.toml
+++ b/backends/zaino/supply-chain/config.toml
@@ -458,13 +458,28 @@ criteria = "safe-to-deploy"
 version = "0.13.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.darling]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.darling_core]]
 version = "0.13.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.darling_core]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.darling_macro]]
 version = "0.20.11"
 criteria = "safe-to-deploy"
+
+[[exemptions.darling_macro]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.dashmap]]
 version = "6.2.1"
@@ -1602,9 +1617,19 @@ criteria = "safe-to-deploy"
 version = "3.17.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde_with]]
+version = "3.21.0"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.serde_with_macros]]
 version = "3.17.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.serde_with_macros]]
+version = "3.21.0"
+criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.serdect]]
 version = "0.2.0"

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1438,6 +1438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1476,14 @@ dependencies = [
 name = "f4jumble"
 version = "0.1.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6527,18 +6544,19 @@ dependencies = [
  "which",
  "x25519-dalek",
  "xdg 2.5.2",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_ironwood_migration_backend",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6568,9 +6586,9 @@ dependencies = [
  "trycmd",
  "zallet-core",
  "zcash_client_backend",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6585,8 +6603,8 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
 ]
 
@@ -6598,9 +6616,22 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "bech32 0.11.1",
+ "bs58",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6641,14 +6672,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0",
- "zcash_encoding",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
  "zip321",
 ]
@@ -6689,14 +6720,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zewif",
  "zip32",
 ]
@@ -6712,6 +6743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "corez",
+ "hex",
+ "nonempty",
+]
+
+[[package]]
 name = "zcash_history"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6720,6 +6761,16 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "primitive-types",
+]
+
+[[package]]
+name = "zcash_ironwood_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "rand_core 0.6.4",
+ "zcash_primitives 0.29.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6747,7 +6798,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zip32",
@@ -6778,10 +6829,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
  "zip32",
 ]
@@ -6810,7 +6861,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -6822,7 +6873,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
  "zcash_protocol 0.9.0",
  "zcash_script",
@@ -6839,7 +6890,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -6852,11 +6903,39 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard 0.15.0",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_script",
+ "zcash_transparent 0.9.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6878,7 +6957,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6891,7 +6970,7 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6903,7 +6982,17 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "corez",
+ "hex",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6950,7 +7039,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
@@ -6973,9 +7062,31 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0",
- "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7000,7 +7111,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
@@ -7035,14 +7146,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.13.0",
- "zcash_encoding",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7077,11 +7188,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7188,13 +7299,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address 0.13.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7212,7 +7323,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.7",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
  "zebra-chain",
 ]
@@ -7388,7 +7499,7 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.14.0",
  "zcash_primitives 0.28.0",
  "zcash_protocol 0.9.0",
@@ -7419,8 +7530,8 @@ dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
- "zcash_address 0.13.0",
- "zcash_protocol 0.10.0",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.8.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6685,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "hex",
@@ -6786,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6832,7 +6832,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "getset",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6911,7 +6911,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "corez",
  "document-features",
@@ -7009,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "bip32",
  "bs58",
@@ -7463,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0ab556bf07aae48a7547af2565ccd08c06262525#0ab556bf07aae48a7547af2565ccd08c06262525"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,20 +1430,11 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
  "corez",
  "document-features",
-]
-
-[[package]]
-name = "equihash"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "blake2b_simd",
- "corez",
 ]
 
 [[package]]
@@ -1475,15 +1466,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3368,8 +3351,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",
@@ -3532,6 +3514,34 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.8.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.0",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_script",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -6511,6 +6521,7 @@ dependencies = [
  "nix 0.29.0",
  "nonempty",
  "orchard 0.15.0",
+ "pczt",
  "phf",
  "quote",
  "rand 0.8.7",
@@ -6544,19 +6555,19 @@ dependencies = [
  "which",
  "x25519-dalek",
  "xdg 2.5.2",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_ironwood_migration_backend",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6586,9 +6597,9 @@ dependencies = [
  "trycmd",
  "zallet-core",
  "zcash_client_backend",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6603,41 +6614,28 @@ dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "f4jumble",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
 ]
 
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "bech32 0.11.1",
- "bs58",
- "corez",
- "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6672,14 +6670,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -6687,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6720,14 +6718,15 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zewif",
  "zip32",
 ]
@@ -6735,17 +6734,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
-dependencies = [
- "corez",
- "hex",
- "nonempty",
-]
-
-[[package]]
-name = "zcash_encoding"
-version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "corez",
  "hex",
@@ -6761,16 +6750,6 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "primitive-types",
-]
-
-[[package]]
-name = "zcash_ironwood_migration_backend"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "rand_core 0.6.4",
- "zcash_primitives 0.29.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
 ]
 
 [[package]]
@@ -6798,7 +6777,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zip32",
@@ -6807,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6829,10 +6808,10 @@ dependencies = [
  "secrecy 0.8.0",
  "subtle",
  "tracing",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zeroize",
  "zip32",
 ]
@@ -6851,6 +6830,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.0",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6861,7 +6859,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -6873,7 +6871,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol 0.9.0",
  "zcash_script",
@@ -6883,14 +6881,14 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -6903,45 +6901,17 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard 0.15.0",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2 0.10.9",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_note_encryption",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_script",
- "zcash_transparent 0.9.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6957,7 +6927,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -6970,29 +6940,19 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
 ]
 
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "corez",
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "corez",
- "hex",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -7039,7 +6999,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
@@ -7049,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "bip32",
  "bs58",
@@ -7062,31 +7022,9 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_script",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations#8e017849573f45890623bd2a41bff2b634c3f835"
-dependencies = [
- "bip32",
- "bs58",
- "corez",
- "getset",
- "hex",
- "nonempty",
- "ripemd 0.1.3",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
- "zcash_protocol 0.10.0 (git+https://github.com/zcash/librustzcash?branch=feat%2Fironwood-denominations)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7111,7 +7049,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "futures",
  "group",
  "halo2_proofs",
@@ -7146,14 +7084,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -7188,11 +7126,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7299,13 +7237,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
  "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.9.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7323,7 +7261,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.7",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.29.0",
  "zcash_script",
  "zebra-chain",
 ]
@@ -7499,7 +7437,7 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zcash_address 0.12.0",
- "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_keys 0.14.0",
  "zcash_primitives 0.28.0",
  "zcash_protocol 0.9.0",
@@ -7525,13 +7463,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=00ba902c0b756329857036fed4dc9db20ed72bd8#00ba902c0b756329857036fed4dc9db20ed72bd8"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -75,19 +75,24 @@ rpc-cli = ["zallet-core/rpc-cli"]
 tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
-# Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+# Pinned to the prove/pool-migration-transfer branch of librustzcash: the
+# pool-migration engine plus its Orchard/Ironwood transfer and preparation
+# proving. The repo is a workspace, so pinning the crates we depend on pulls
+# their path-dep siblings from git while their crates.io copies remain; pinning
+# the whole stack to one rev avoids duplicating it. Replace with the crates.io
+# releases once they ship.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -93,6 +93,7 @@ zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba9
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
 zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -81,18 +81,18 @@ tokio-console = ["zallet-core/tokio-console"]
 # their path-dep siblings from git while their crates.io copies remain; pinning
 # the whole stack to one rev avoids duplicating it. Replace with the crates.io
 # releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "00ba902c0b756329857036fed4dc9db20ed72bd8" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0ab556bf07aae48a7547af2565ccd08c06262525" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 [lints.rust]

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -135,6 +135,43 @@ one step per call, so a caller polls it.
 - `migration_id` (string, required): The identifier returned by
   `z_startpoolmigration`.
 
+## `z_applypoolmigrationsignature`
+
+*Only available in wallet builds of Zallet.*
+
+Applies an externally-signed PCZT to a migration transaction.
+
+Stores the signed PCZT an external (hardware or offline) signer returned against the
+migration transaction it was built for, moving that transaction from awaiting-signature
+to signed so z_advancepoolmigration can prove and broadcast it. The PCZT is matched to
+its transaction by the id returned alongside the unsigned PCZT.
+
+#### Arguments
+- `migration_id` (string, required): The identifier returned by
+  `z_startpoolmigration`.
+- `transaction_id` (numeric, required): The id of the migration transaction the signed
+  PCZT is for, from the `unsigned_transactions` list.
+- `pczt` (string, required): The signed migration PCZT, base64 encoded.
+
+## `z_buildpoolmigrationtransfers`
+
+*Only available in wallet builds of Zallet.*
+
+Builds a migration's phase-2 transfers UNSIGNED, for an external signer.
+
+The external-signer counterpart of the transfer building that z_advancepoolmigration
+does in process: it detects newly mined preparation transactions and, once the whole
+preparation is mined, builds the transfers but leaves them unsigned, returning their
+PCZTs in `unsigned_transactions` to sign on the device and apply back with
+z_applypoolmigrationsignature. An external migration uses this rather than
+z_advancepoolmigration for the preparation-to-transfers step.
+
+#### Arguments
+- `account` (string or numeric, required): The UUID or ZIP 32 index of the account
+  whose migration transfers to build.
+- `migration_id` (string, required): The identifier returned by
+  `z_startpoolmigration`.
+
 ## `z_cancelpoolmigration`
 
 *Only available in wallet builds of Zallet.*
@@ -678,6 +715,23 @@ An object matching `zcashd`'s `z_shieldcoinbase` shape:
 - `shieldingValue` (numeric, ZEC): Total value being shielded.
 - `opid` (string): Operation id.
 
+## `z_signpoolmigrationpczt`
+
+*Only available in wallet builds of Zallet.*
+
+Signs a migration PCZT with the account's spend authorization.
+
+For offline / air-gapped signing, and the software stand-in for on-device signing: it
+takes an unsigned migration PCZT (from z_startpoolmigration with external_signer, or
+z_buildpoolmigrationtransfers), adds only the account's Orchard spend-authorization
+signature, and returns the signed PCZT to apply with z_applypoolmigrationsignature. It
+does not prove, extract, or broadcast. A hardware wallet signs on the device instead.
+
+#### Arguments
+- `account` (string or numeric, required): The UUID or ZIP 32 index of the account
+  whose spend key signs the PCZT.
+- `pczt` (string, required): The unsigned migration PCZT, base64 encoded.
+
 ## `z_startpoolmigration`
 
 *Only available in wallet builds of Zallet.*
@@ -698,6 +752,11 @@ migration; proving and broadcasting happen later via z_advancepoolmigration.
 - `from_pool` (string, required): The value pool to migrate funds from
   ("sapling", "orchard", or "ironwood").
 - `to_pool` (string, required): The value pool to migrate funds to.
+- `external_signer` (boolean, optional, default=false): When true, build the
+  preparation transactions UNSIGNED for an external (hardware or offline) signer
+  and return their PCZTs in `unsigned_transactions`, to sign on the device and
+  apply back with `z_applypoolmigrationsignature`. When false (the default) the
+  preparation is pre-signed in process.
 
 ## `z_viewtransaction`
 

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -119,6 +119,35 @@ that require the availability of private keys, such as sending funds.
 Issuing the `walletpassphrase` command while the wallet is already unlocked will
 set a new unlock time that overrides the old one.
 
+## `z_advancepoolmigration`
+
+*Only available in wallet builds of Zallet.*
+
+Advances a previously-scheduled pool migration by one step.
+
+Detects newly mined transactions, proves and broadcasts the next due pre-signed
+transaction, and once the preparation is mined builds the phase-2 transfers. Advances
+one step per call, so a caller polls it.
+
+#### Arguments
+- `account` (string or numeric, required): The UUID or ZIP 32 index of the account
+  whose migration to advance.
+- `migration_id` (string, required): The identifier returned by
+  `z_startpoolmigration`.
+
+## `z_cancelpoolmigration`
+
+*Only available in wallet builds of Zallet.*
+
+Cancels a previously-scheduled pool migration.
+
+NOTE: This is currently a scaffold. The identifier is validated, but the migration
+engine is not yet wired in, so the call returns a "not implemented yet" error.
+
+#### Arguments
+- `migration_id` (string, required): The identifier returned by
+  `z_startpoolmigration`.
+
 ## `z_converttex`
 
 Converts a transparent P2PKH Zcash address to a TEX address.
@@ -306,6 +335,19 @@ The operation will remain in memory.
 - `operationid` (array, optional) A list of operation ids we are interested in.
   If not provided, examine all operations known to the node.
 
+## `z_getpoolmigrationstatus`
+
+*Only available in wallet builds of Zallet.*
+
+Returns the status of a previously-scheduled pool migration.
+
+NOTE: This is currently a scaffold. The identifier is validated, but the migration
+engine is not yet wired in, so the call returns a "not implemented yet" error.
+
+#### Arguments
+- `migration_id` (string, required): The identifier returned by
+  `z_startpoolmigration`.
+
 ## `z_gettotalbalance`
 
 *Only available in wallet builds of Zallet.*
@@ -375,6 +417,15 @@ Returns the list of operation ids currently known to the wallet.
 #### Arguments
 - `status` (string, optional) Filter result by the operation's state e.g. "success".
 
+## `z_listpoolmigrations`
+
+*Only available in wallet builds of Zallet.*
+
+Lists the pool migrations known to the wallet.
+
+NOTE: This is currently a scaffold. The migration engine is not yet wired in, so
+the call returns a "not implemented yet" error.
+
 ## `z_listtransactions`
 
 Returns a list of the wallet's transactions, optionally filtered by account and block
@@ -438,6 +489,30 @@ returned, even though they are not immediately spendable.
   aware of. -1 can be used as in other RPC calls to indicate the current height (including
   the mempool), but this does not support negative values in general. A “future” height will
   fall back to the current height.
+
+## `z_previewpoolmigration`
+
+*Only available in wallet builds of Zallet.*
+
+Previews the migration plan for migrating an account's balance between two value
+pools, without scheduling or broadcasting anything.
+
+Enumerates the account's spendable notes in `from_pool` and runs the migration
+engine's planning slice to show how the balance would be decomposed into the
+self-funding notes that cross the turnstile (the crossing denominations and their
+transfer schedule), the note-preparation transactions that would mint them, and
+the residual left behind. This is a read-only planning preview: unlike the rest of
+the migration surface it is fully wired, because it only plans and does not build,
+prove, or broadcast any transaction.
+
+#### Arguments
+- `account` (string or numeric, required): Either the UUID or the ZIP 32 account
+  index of the account, as returned by `z_getnewaccount`.
+- `from_pool` (string, required): The value pool to migrate funds from
+  ("sapling", "orchard", or "ironwood").
+- `to_pool` (string, required): The value pool to migrate funds to.
+- `minconf` (numeric, optional, default=1): Only include source-pool notes
+  confirmed at least this many times.
 
 ## `z_recoveraccounts`
 
@@ -602,6 +677,27 @@ An object matching `zcashd`'s `z_shieldcoinbase` shape:
   shielded by this operation.
 - `shieldingValue` (numeric, ZEC): Total value being shielded.
 - `opid` (string): Operation id.
+
+## `z_startpoolmigration`
+
+*Only available in wallet builds of Zallet.*
+
+Schedules a migration of shielded funds from one value pool to another.
+
+The migration is generic pool-to-pool: the supported pool pairs, and the network
+upgrade that enables each one, are declared in a single table (migrating from the
+Orchard pool to the Ironwood pool requires NU6.3). The pool pair is validated
+against that table and the enabling upgrade is required to be active.
+
+Builds and pre-signs the note-preparation transactions and persists the committed
+migration; proving and broadcasting happen later via z_advancepoolmigration.
+
+#### Arguments
+- `account` (string or numeric, required): Either the UUID or the ZIP 32 account index
+  of the account whose balance to migrate.
+- `from_pool` (string, required): The value pool to migrate funds from
+  ("sapling", "orchard", or "ironwood").
+- `to_pool` (string, required): The value pool to migrate funds to.
 
 ## `z_viewtransaction`
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -394,6 +394,21 @@ criteria = "safe-to-deploy"
 version = "0.8.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.darling]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.darling_core]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.darling_macro]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.deadpool]]
 version = "0.12.3"
 criteria = "safe-to-deploy"
@@ -1261,6 +1276,16 @@ criteria = "safe-to-deploy"
 [[exemptions.serde_spanned]]
 version = "1.1.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.serde_with]]
+version = "3.21.0"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.serde_with_macros]]
+version = "3.21.0"
+criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.serdect]]
 version = "0.2.0"

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -125,6 +125,7 @@ zcash_client_sqlite = { workspace = true, features = [
     "transparent-inputs",
 ] }
 zcash_pool_migration_backend.workspace = true
+zcash_pool_migration_sqlite.workspace = true
 zcash_note_encryption.workspace = true
 zip32.workspace = true
 

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -126,6 +126,7 @@ zcash_client_sqlite = { workspace = true, features = [
 ] }
 zcash_pool_migration_backend.workspace = true
 zcash_pool_migration_sqlite.workspace = true
+pczt.workspace = true
 zcash_note_encryption.workspace = true
 zip32.workspace = true
 

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -124,7 +124,7 @@ zcash_client_sqlite = { workspace = true, features = [
     "orchard",
     "transparent-inputs",
 ] }
-zcash_ironwood_migration_backend.workspace = true
+zcash_pool_migration_backend.workspace = true
 zcash_note_encryption.workspace = true
 zip32.workspace = true
 

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -125,7 +125,6 @@ zcash_client_sqlite = { workspace = true, features = [
     "transparent-inputs",
 ] }
 zcash_pool_migration_backend.workspace = true
-zcash_pool_migration_sqlite.workspace = true
 pczt.workspace = true
 zcash_note_encryption.workspace = true
 zip32.workspace = true

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -124,6 +124,7 @@ zcash_client_sqlite = { workspace = true, features = [
     "orchard",
     "transparent-inputs",
 ] }
+zcash_ironwood_migration_backend.workspace = true
 zcash_note_encryption.workspace = true
 zip32.workspace = true
 

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -65,6 +65,8 @@ mod openrpc;
 #[cfg(zallet_build = "wallet")]
 mod pool_migration;
 #[cfg(zallet_build = "wallet")]
+mod preview_pool_migration;
+#[cfg(zallet_build = "wallet")]
 mod recover_accounts;
 #[cfg(zallet_build = "wallet")]
 mod start_pool_migration;
@@ -773,6 +775,36 @@ pub(crate) trait WalletRpc {
         to_pool: String,
     ) -> start_pool_migration::Response;
 
+    /// Previews the note-split plan for migrating an account's balance between two value
+    /// pools, without scheduling or broadcasting anything.
+    ///
+    /// Reads the account's spendable balance in `from_pool` and runs the note-split
+    /// planner to show how it would be decomposed into the self-funding notes that cross
+    /// the turnstile (the crossing denominations, the residual left behind, and the
+    /// reserved prep fee). This is a read-only planning preview: unlike the rest of the
+    /// migration surface it is fully wired, because it only plans and does not build,
+    /// prove, or broadcast any transaction.
+    ///
+    /// # Arguments
+    /// - `account` (string or numeric, required): Either the UUID or the ZIP 32 account
+    ///   index of the account, as returned by `z_getnewaccount`.
+    /// - `from_pool` (string, required): The value pool to migrate funds from
+    ///   ("sapling", "orchard", or "ironwood").
+    /// - `to_pool` (string, required): The value pool to migrate funds to.
+    /// - `minconf` (numeric, optional, default=1): Only include outputs in transactions
+    ///   confirmed at least this many times.
+    /// - `strategy` (string, optional, default="randomized"): The denomination strategy
+    ///   to preview ("randomized" or "canonical").
+    #[method(name = "z_previewpoolmigration")]
+    async fn preview_pool_migration(
+        &self,
+        account: JsonValue,
+        from_pool: String,
+        to_pool: String,
+        minconf: Option<u32>,
+        strategy: Option<String>,
+    ) -> preview_pool_migration::Response;
+
     /// Returns the status of a previously-scheduled pool migration.
     ///
     /// NOTE: This is currently a scaffold. The identifier is validated, but the migration
@@ -1246,6 +1278,26 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         to_pool: String,
     ) -> start_pool_migration::Response {
         start_pool_migration::call(self.wallet().await?.as_ref(), &from_pool, &to_pool)
+    }
+
+    async fn preview_pool_migration(
+        &self,
+        account: JsonValue,
+        from_pool: String,
+        to_pool: String,
+        minconf: Option<u32>,
+        strategy: Option<String>,
+    ) -> preview_pool_migration::Response {
+        preview_pool_migration::call(
+            self.wallet().await?.as_ref(),
+            &self.keystore,
+            account,
+            &from_pool,
+            &to_pool,
+            minconf,
+            strategy,
+        )
+        .await
     }
 
     async fn get_pool_migration_status(

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -822,15 +822,19 @@ pub(crate) trait WalletRpc {
 
     /// Advances a previously-scheduled pool migration by one step.
     ///
-    /// NOTE: This is currently a scaffold. The identifier is validated, but the migration
-    /// engine is not yet wired in, so the call returns a "not implemented yet" error.
+    /// Detects newly mined transactions, proves and broadcasts the next due pre-signed
+    /// transaction, and once the preparation is mined builds the phase-2 transfers. Advances
+    /// one step per call, so a caller polls it.
     ///
     /// # Arguments
+    /// - `account` (string or numeric, required): The UUID or ZIP 32 index of the account
+    ///   whose migration to advance.
     /// - `migration_id` (string, required): The identifier returned by
     ///   `z_startpoolmigration`.
     #[method(name = "z_advancepoolmigration")]
     async fn advance_pool_migration(
         &self,
+        account: JsonValue,
         migration_id: String,
     ) -> advance_pool_migration::Response;
 
@@ -1316,9 +1320,17 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
 
     async fn advance_pool_migration(
         &self,
+        account: JsonValue,
         migration_id: String,
     ) -> advance_pool_migration::Response {
-        advance_pool_migration::call(self.wallet().await?.as_ref(), &migration_id)
+        advance_pool_migration::call(
+            self.wallet().await?.as_ref(),
+            &self.keystore,
+            self.chain().await?,
+            account,
+            &migration_id,
+        )
+        .await
     }
 
     async fn cancel_pool_migration(&self, migration_id: String) -> cancel_pool_migration::Response {

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -775,14 +775,15 @@ pub(crate) trait WalletRpc {
         to_pool: String,
     ) -> start_pool_migration::Response;
 
-    /// Previews the note-split plan for migrating an account's balance between two value
+    /// Previews the migration plan for migrating an account's balance between two value
     /// pools, without scheduling or broadcasting anything.
     ///
-    /// Reads the account's spendable balance in `from_pool` and runs the note-split
-    /// planner to show how it would be decomposed into the self-funding notes that cross
-    /// the turnstile (the crossing denominations, the residual left behind, and the
-    /// reserved prep fee). This is a read-only planning preview: unlike the rest of the
-    /// migration surface it is fully wired, because it only plans and does not build,
+    /// Enumerates the account's spendable notes in `from_pool` and runs the migration
+    /// engine's planning slice to show how the balance would be decomposed into the
+    /// self-funding notes that cross the turnstile (the crossing denominations and their
+    /// transfer schedule), the note-preparation transactions that would mint them, and
+    /// the residual left behind. This is a read-only planning preview: unlike the rest of
+    /// the migration surface it is fully wired, because it only plans and does not build,
     /// prove, or broadcast any transaction.
     ///
     /// # Arguments
@@ -791,10 +792,8 @@ pub(crate) trait WalletRpc {
     /// - `from_pool` (string, required): The value pool to migrate funds from
     ///   ("sapling", "orchard", or "ironwood").
     /// - `to_pool` (string, required): The value pool to migrate funds to.
-    /// - `minconf` (numeric, optional, default=1): Only include outputs in transactions
+    /// - `minconf` (numeric, optional, default=1): Only include source-pool notes
     ///   confirmed at least this many times.
-    /// - `strategy` (string, optional, default="randomized"): The denomination strategy
-    ///   to preview ("randomized" or "canonical").
     #[method(name = "z_previewpoolmigration")]
     async fn preview_pool_migration(
         &self,
@@ -802,7 +801,6 @@ pub(crate) trait WalletRpc {
         from_pool: String,
         to_pool: String,
         minconf: Option<u32>,
-        strategy: Option<String>,
     ) -> preview_pool_migration::Response;
 
     /// Returns the status of a previously-scheduled pool migration.
@@ -1286,7 +1284,6 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         from_pool: String,
         to_pool: String,
         minconf: Option<u32>,
-        strategy: Option<String>,
     ) -> preview_pool_migration::Response {
         preview_pool_migration::call(
             self.wallet().await?.as_ref(),
@@ -1295,7 +1292,6 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             &from_pool,
             &to_pool,
             minconf,
-            strategy,
         )
         .await
     }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -22,6 +22,10 @@ use {
 #[cfg(zallet_build = "wallet")]
 mod advance_pool_migration;
 #[cfg(zallet_build = "wallet")]
+mod apply_pool_migration_signature;
+#[cfg(zallet_build = "wallet")]
+mod build_pool_migration_transfers;
+#[cfg(zallet_build = "wallet")]
 mod cancel_pool_migration;
 mod convert_tex;
 mod decode_raw_transaction;
@@ -68,6 +72,8 @@ mod pool_migration;
 mod preview_pool_migration;
 #[cfg(zallet_build = "wallet")]
 mod recover_accounts;
+#[cfg(zallet_build = "wallet")]
+mod sign_pool_migration_pczt;
 #[cfg(zallet_build = "wallet")]
 mod start_pool_migration;
 mod stop;
@@ -770,12 +776,18 @@ pub(crate) trait WalletRpc {
     /// - `from_pool` (string, required): The value pool to migrate funds from
     ///   ("sapling", "orchard", or "ironwood").
     /// - `to_pool` (string, required): The value pool to migrate funds to.
+    /// - `external_signer` (boolean, optional, default=false): When true, build the
+    ///   preparation transactions UNSIGNED for an external (hardware or offline) signer
+    ///   and return their PCZTs in `unsigned_transactions`, to sign on the device and
+    ///   apply back with `z_applypoolmigrationsignature`. When false (the default) the
+    ///   preparation is pre-signed in process.
     #[method(name = "z_startpoolmigration")]
     async fn start_pool_migration(
         &self,
         account: JsonValue,
         from_pool: String,
         to_pool: String,
+        external_signer: Option<bool>,
     ) -> start_pool_migration::Response;
 
     /// Previews the migration plan for migrating an account's balance between two value
@@ -837,6 +849,67 @@ pub(crate) trait WalletRpc {
         account: JsonValue,
         migration_id: String,
     ) -> advance_pool_migration::Response;
+
+    /// Builds a migration's phase-2 transfers UNSIGNED, for an external signer.
+    ///
+    /// The external-signer counterpart of the transfer building that z_advancepoolmigration
+    /// does in process: it detects newly mined preparation transactions and, once the whole
+    /// preparation is mined, builds the transfers but leaves them unsigned, returning their
+    /// PCZTs in `unsigned_transactions` to sign on the device and apply back with
+    /// z_applypoolmigrationsignature. An external migration uses this rather than
+    /// z_advancepoolmigration for the preparation-to-transfers step.
+    ///
+    /// # Arguments
+    /// - `account` (string or numeric, required): The UUID or ZIP 32 index of the account
+    ///   whose migration transfers to build.
+    /// - `migration_id` (string, required): The identifier returned by
+    ///   `z_startpoolmigration`.
+    #[method(name = "z_buildpoolmigrationtransfers")]
+    async fn build_pool_migration_transfers(
+        &self,
+        account: JsonValue,
+        migration_id: String,
+    ) -> build_pool_migration_transfers::Response;
+
+    /// Signs a migration PCZT with the account's spend authorization.
+    ///
+    /// For offline / air-gapped signing, and the software stand-in for on-device signing: it
+    /// takes an unsigned migration PCZT (from z_startpoolmigration with external_signer, or
+    /// z_buildpoolmigrationtransfers), adds only the account's Orchard spend-authorization
+    /// signature, and returns the signed PCZT to apply with z_applypoolmigrationsignature. It
+    /// does not prove, extract, or broadcast. A hardware wallet signs on the device instead.
+    ///
+    /// # Arguments
+    /// - `account` (string or numeric, required): The UUID or ZIP 32 index of the account
+    ///   whose spend key signs the PCZT.
+    /// - `pczt` (string, required): The unsigned migration PCZT, base64 encoded.
+    #[method(name = "z_signpoolmigrationpczt")]
+    async fn sign_pool_migration_pczt(
+        &self,
+        account: JsonValue,
+        pczt: String,
+    ) -> sign_pool_migration_pczt::Response;
+
+    /// Applies an externally-signed PCZT to a migration transaction.
+    ///
+    /// Stores the signed PCZT an external (hardware or offline) signer returned against the
+    /// migration transaction it was built for, moving that transaction from awaiting-signature
+    /// to signed so z_advancepoolmigration can prove and broadcast it. The PCZT is matched to
+    /// its transaction by the id returned alongside the unsigned PCZT.
+    ///
+    /// # Arguments
+    /// - `migration_id` (string, required): The identifier returned by
+    ///   `z_startpoolmigration`.
+    /// - `transaction_id` (numeric, required): The id of the migration transaction the signed
+    ///   PCZT is for, from the `unsigned_transactions` list.
+    /// - `pczt` (string, required): The signed migration PCZT, base64 encoded.
+    #[method(name = "z_applypoolmigrationsignature")]
+    async fn apply_pool_migration_signature(
+        &self,
+        migration_id: String,
+        transaction_id: u32,
+        pczt: String,
+    ) -> apply_pool_migration_signature::Response;
 
     /// Cancels a previously-scheduled pool migration.
     ///
@@ -1282,6 +1355,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         account: JsonValue,
         from_pool: String,
         to_pool: String,
+        external_signer: Option<bool>,
     ) -> start_pool_migration::Response {
         start_pool_migration::call(
             self.wallet().await?.as_ref(),
@@ -1289,6 +1363,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             account,
             &from_pool,
             &to_pool,
+            external_signer,
         )
         .await
     }
@@ -1329,6 +1404,49 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             self.chain().await?,
             account,
             &migration_id,
+        )
+        .await
+    }
+
+    async fn build_pool_migration_transfers(
+        &self,
+        account: JsonValue,
+        migration_id: String,
+    ) -> build_pool_migration_transfers::Response {
+        build_pool_migration_transfers::call(
+            self.wallet().await?.as_ref(),
+            &self.keystore,
+            account,
+            &migration_id,
+        )
+        .await
+    }
+
+    async fn sign_pool_migration_pczt(
+        &self,
+        account: JsonValue,
+        pczt: String,
+    ) -> sign_pool_migration_pczt::Response {
+        sign_pool_migration_pczt::call(
+            self.wallet().await?.as_ref(),
+            &self.keystore,
+            account,
+            &pczt,
+        )
+        .await
+    }
+
+    async fn apply_pool_migration_signature(
+        &self,
+        migration_id: String,
+        transaction_id: u32,
+        pczt: String,
+    ) -> apply_pool_migration_signature::Response {
+        apply_pool_migration_signature::call(
+            self.wallet().await?.as_ref(),
+            &migration_id,
+            transaction_id,
+            &pczt,
         )
         .await
     }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -19,6 +19,10 @@ use {
     tokio::sync::RwLock,
 };
 
+#[cfg(zallet_build = "wallet")]
+mod advance_pool_migration;
+#[cfg(zallet_build = "wallet")]
+mod cancel_pool_migration;
 mod convert_tex;
 mod decode_raw_transaction;
 mod decode_script;
@@ -34,6 +38,8 @@ mod get_new_account;
 mod get_notes_count;
 #[cfg(zallet_build = "wallet")]
 mod get_operation;
+#[cfg(zallet_build = "wallet")]
+mod get_pool_migration_status;
 mod get_raw_transaction;
 #[cfg(zallet_build = "wallet")]
 mod get_wallet_info;
@@ -46,6 +52,8 @@ mod list_accounts;
 mod list_addresses;
 #[cfg(zallet_build = "wallet")]
 mod list_operation_ids;
+#[cfg(zallet_build = "wallet")]
+mod list_pool_migrations;
 mod list_transactions;
 mod list_unified_receivers;
 #[cfg(zallet_build = "wallet")]
@@ -55,7 +63,11 @@ mod lock_wallet;
 #[cfg(zallet_build = "wallet")]
 mod openrpc;
 #[cfg(zallet_build = "wallet")]
+mod pool_migration;
+#[cfg(zallet_build = "wallet")]
 mod recover_accounts;
+#[cfg(zallet_build = "wallet")]
+mod start_pool_migration;
 mod stop;
 #[cfg(zallet_build = "wallet")]
 mod unlock_wallet;
@@ -739,6 +751,73 @@ pub(crate) trait WalletRpc {
         zaddr: &str,
         ivk: Option<bool>,
     ) -> z_export_viewing_key::Response;
+
+    /// Schedules a migration of shielded funds from one value pool to another.
+    ///
+    /// The migration is generic pool-to-pool: the supported pool pairs, and the network
+    /// upgrade that enables each one, are declared in a single table (migrating from the
+    /// Orchard pool to the Ironwood pool requires NU6.3). The pool pair is validated
+    /// against that table and the enabling upgrade is required to be active.
+    ///
+    /// NOTE: This is currently a scaffold. Inputs are validated, but the migration engine
+    /// is not yet wired in, so the call returns a "not implemented yet" error.
+    ///
+    /// # Arguments
+    /// - `from_pool` (string, required): The value pool to migrate funds from
+    ///   ("sapling", "orchard", or "ironwood").
+    /// - `to_pool` (string, required): The value pool to migrate funds to.
+    #[method(name = "z_startpoolmigration")]
+    async fn start_pool_migration(
+        &self,
+        from_pool: String,
+        to_pool: String,
+    ) -> start_pool_migration::Response;
+
+    /// Returns the status of a previously-scheduled pool migration.
+    ///
+    /// NOTE: This is currently a scaffold. The identifier is validated, but the migration
+    /// engine is not yet wired in, so the call returns a "not implemented yet" error.
+    ///
+    /// # Arguments
+    /// - `migration_id` (string, required): The identifier returned by
+    ///   `z_startpoolmigration`.
+    #[method(name = "z_getpoolmigrationstatus")]
+    async fn get_pool_migration_status(
+        &self,
+        migration_id: String,
+    ) -> get_pool_migration_status::Response;
+
+    /// Advances a previously-scheduled pool migration by one step.
+    ///
+    /// NOTE: This is currently a scaffold. The identifier is validated, but the migration
+    /// engine is not yet wired in, so the call returns a "not implemented yet" error.
+    ///
+    /// # Arguments
+    /// - `migration_id` (string, required): The identifier returned by
+    ///   `z_startpoolmigration`.
+    #[method(name = "z_advancepoolmigration")]
+    async fn advance_pool_migration(
+        &self,
+        migration_id: String,
+    ) -> advance_pool_migration::Response;
+
+    /// Cancels a previously-scheduled pool migration.
+    ///
+    /// NOTE: This is currently a scaffold. The identifier is validated, but the migration
+    /// engine is not yet wired in, so the call returns a "not implemented yet" error.
+    ///
+    /// # Arguments
+    /// - `migration_id` (string, required): The identifier returned by
+    ///   `z_startpoolmigration`.
+    #[method(name = "z_cancelpoolmigration")]
+    async fn cancel_pool_migration(&self, migration_id: String) -> cancel_pool_migration::Response;
+
+    /// Lists the pool migrations known to the wallet.
+    ///
+    /// NOTE: This is currently a scaffold. The migration engine is not yet wired in, so
+    /// the call returns a "not implemented yet" error.
+    #[method(name = "z_listpoolmigrations")]
+    async fn list_pool_migrations(&self) -> list_pool_migrations::Response;
 }
 
 pub(crate) struct RpcImpl<C: Chain> {
@@ -1159,5 +1238,35 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         ivk: Option<bool>,
     ) -> z_export_viewing_key::Response {
         z_export_viewing_key::call(self.wallet().await?.as_ref(), &self.keystore, zaddr, ivk).await
+    }
+
+    async fn start_pool_migration(
+        &self,
+        from_pool: String,
+        to_pool: String,
+    ) -> start_pool_migration::Response {
+        start_pool_migration::call(self.wallet().await?.as_ref(), &from_pool, &to_pool)
+    }
+
+    async fn get_pool_migration_status(
+        &self,
+        migration_id: String,
+    ) -> get_pool_migration_status::Response {
+        get_pool_migration_status::call(&migration_id)
+    }
+
+    async fn advance_pool_migration(
+        &self,
+        migration_id: String,
+    ) -> advance_pool_migration::Response {
+        advance_pool_migration::call(&migration_id)
+    }
+
+    async fn cancel_pool_migration(&self, migration_id: String) -> cancel_pool_migration::Response {
+        cancel_pool_migration::call(&migration_id)
+    }
+
+    async fn list_pool_migrations(&self) -> list_pool_migrations::Response {
+        list_pool_migrations::call()
     }
 }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -761,16 +761,19 @@ pub(crate) trait WalletRpc {
     /// Orchard pool to the Ironwood pool requires NU6.3). The pool pair is validated
     /// against that table and the enabling upgrade is required to be active.
     ///
-    /// NOTE: This is currently a scaffold. Inputs are validated, but the migration engine
-    /// is not yet wired in, so the call returns a "not implemented yet" error.
+    /// Builds and pre-signs the note-preparation transactions and persists the committed
+    /// migration; proving and broadcasting happen later via z_advancepoolmigration.
     ///
     /// # Arguments
+    /// - `account` (string or numeric, required): Either the UUID or the ZIP 32 account index
+    ///   of the account whose balance to migrate.
     /// - `from_pool` (string, required): The value pool to migrate funds from
     ///   ("sapling", "orchard", or "ironwood").
     /// - `to_pool` (string, required): The value pool to migrate funds to.
     #[method(name = "z_startpoolmigration")]
     async fn start_pool_migration(
         &self,
+        account: JsonValue,
         from_pool: String,
         to_pool: String,
     ) -> start_pool_migration::Response;
@@ -1272,10 +1275,18 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
 
     async fn start_pool_migration(
         &self,
+        account: JsonValue,
         from_pool: String,
         to_pool: String,
     ) -> start_pool_migration::Response {
-        start_pool_migration::call(self.wallet().await?.as_ref(), &from_pool, &to_pool)
+        start_pool_migration::call(
+            self.wallet().await?.as_ref(),
+            &self.keystore,
+            account,
+            &from_pool,
+            &to_pool,
+        )
+        .await
     }
 
     async fn preview_pool_migration(
@@ -1300,21 +1311,21 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         &self,
         migration_id: String,
     ) -> get_pool_migration_status::Response {
-        get_pool_migration_status::call(&migration_id)
+        get_pool_migration_status::call(self.wallet().await?.as_ref(), &migration_id)
     }
 
     async fn advance_pool_migration(
         &self,
         migration_id: String,
     ) -> advance_pool_migration::Response {
-        advance_pool_migration::call(&migration_id)
+        advance_pool_migration::call(self.wallet().await?.as_ref(), &migration_id)
     }
 
     async fn cancel_pool_migration(&self, migration_id: String) -> cancel_pool_migration::Response {
-        cancel_pool_migration::call(&migration_id)
+        cancel_pool_migration::call(self.wallet().await?.as_ref(), &migration_id)
     }
 
     async fn list_pool_migrations(&self) -> list_pool_migrations::Response {
-        list_pool_migrations::call()
+        list_pool_migrations::call(self.wallet().await?.as_ref())
     }
 }

--- a/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
@@ -1,11 +1,23 @@
-//! `z_advancepoolmigration`: advance a pool migration by one step (scaffold).
+//! `z_advancepoolmigration`: advance a pool migration by one step.
+//!
+//! Advancing drives a committed migration forward: proving and broadcasting the next due pre-signed
+//! transaction, and (once its preparation is mined) building the phase-2 transfers. Proving and
+//! broadcasting is not yet wired into Zallet (it needs the `pczt` prover and an Orchard proving
+//! key), so for a migration that still has work to do this reports that it is committed and awaiting
+//! that step; a finished or cancelled migration reports its terminal phase.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
+use zcash_pool_migration_backend::engine::MigrationStatus;
 
-use super::pool_migration::{MigrationPhase, not_implemented, validate_migration_id};
+use super::pool_migration::{
+    MIGRATION_ID, MigrationPhase, no_such_migration, validate_migration_id,
+};
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::migrate::load_migration;
 
 /// Response to a `z_advancepoolmigration` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -14,10 +26,6 @@ pub(crate) type ResultType = AdvancePoolMigration;
 pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
 
 /// The result of advancing a pool migration by one step.
-///
-/// Describes the response shape for when the migration engine is wired in; the scaffold
-/// validates inputs and then returns a not-implemented error rather than constructing
-/// this value.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct AdvancePoolMigration {
     /// Opaque identifier for the migration.
@@ -26,7 +34,28 @@ pub(crate) struct AdvancePoolMigration {
     phase: MigrationPhase,
 }
 
-pub(crate) fn call(migration_id: &str) -> Response {
+pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
     validate_migration_id(migration_id)?;
-    not_implemented("z_advancepoolmigration")
+    if migration_id != MIGRATION_ID {
+        return Err(no_such_migration());
+    }
+    let state = wallet
+        .with_raw_mut(|conn, _| load_migration(conn))
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(no_such_migration)?;
+
+    match state.status {
+        // A finished or cancelled migration has nothing left to advance.
+        MigrationStatus::Complete | MigrationStatus::Failed => Ok(AdvancePoolMigration {
+            migration_id: MIGRATION_ID.to_string(),
+            phase: MigrationPhase::from_status(state.status),
+        }),
+        // Making on-chain progress requires proving and broadcasting the pre-signed transactions,
+        // which is not yet wired into Zallet (it needs the pczt prover and an Orchard proving key).
+        _ => Err(LegacyCode::Misc.with_message(format!(
+            "advancing a pool migration (proving and broadcasting its pre-signed transactions) is \
+             not yet wired; the migration is committed with {} transactions ready",
+            state.transactions.len(),
+        ))),
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
@@ -1,0 +1,32 @@
+//! `z_advancepoolmigration`: advance a pool migration by one step (scaffold).
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use super::pool_migration::{MigrationPhase, not_implemented, validate_migration_id};
+
+/// Response to a `z_advancepoolmigration` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = AdvancePoolMigration;
+
+pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
+
+/// The result of advancing a pool migration by one step.
+///
+/// Describes the response shape for when the migration engine is wired in; the scaffold
+/// validates inputs and then returns a not-implemented error rather than constructing
+/// this value.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct AdvancePoolMigration {
+    /// Opaque identifier for the migration.
+    migration_id: String,
+    /// The migration's lifecycle phase after advancing.
+    phase: MigrationPhase,
+}
+
+pub(crate) fn call(migration_id: &str) -> Response {
+    validate_migration_id(migration_id)?;
+    not_implemented("z_advancepoolmigration")
+}

--- a/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
@@ -87,7 +87,7 @@ pub(crate) async fn call<C: Chain>(
 
     Ok(AdvancePoolMigration {
         migration_id: MIGRATION_ID.to_string(),
-        phase: MigrationPhase::from_status(state.status),
+        phase: MigrationPhase::from_status(state.status()),
         progress: migration_progress(&state),
         status: message,
     })

--- a/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
@@ -1,28 +1,36 @@
 //! `z_advancepoolmigration`: advance a pool migration by one step.
 //!
-//! Advancing drives a committed migration forward: proving and broadcasting the next due pre-signed
-//! transaction, and (once its preparation is mined) building the phase-2 transfers. Proving and
-//! broadcasting is not yet wired into Zallet (it needs the `pczt` prover and an Orchard proving
-//! key), so for a migration that still has work to do this reports that it is committed and awaiting
-//! that step; a finished or cancelled migration reports its terminal phase.
+//! Advancing drives a committed migration forward one step per call (so a caller polls it): it
+//! detects newly mined transactions, proves and broadcasts the next due pre-signed transaction, and
+//! once the preparation is mined builds the phase-2 transfers. Proving is done against the migration's
+//! Orchard circuit; broadcasting sends the extracted transaction to the mempool.
 
 use documented::Documented;
-use jsonrpsee::core::RpcResult;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use jsonrpsee::types::ErrorObjectOwned;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_pool_migration_backend::engine::MigrationStatus;
+use zcash_client_backend::data_api::WalletRead;
 
 use super::pool_migration::{
-    MIGRATION_ID, MigrationPhase, no_such_migration, validate_migration_id,
+    MIGRATION_ID, MigrationPhase, MigrationProgress, decrypt_account_usk, map_commit_failure,
+    migration_progress, no_such_migration, validate_migration_id,
 };
+use crate::components::chain::Chain;
 use crate::components::database::DbConnection;
 use crate::components::json_rpc::server::LegacyCode;
-use crate::migrate::load_migration;
+use crate::components::json_rpc::utils::parse_account_parameter;
+use crate::components::keystore::KeyStore;
+use crate::migrate::{
+    AdvanceError, AdvanceOutcome, advance_blocking, record_broadcast, transaction_txid_bytes,
+};
 
 /// Response to a `z_advancepoolmigration` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = AdvancePoolMigration;
 
+pub(super) const PARAM_ACCOUNT_DESC: &str =
+    "Either the UUID or ZIP 32 account index of the account whose migration to advance.";
 pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
 
 /// The result of advancing a pool migration by one step.
@@ -32,30 +40,68 @@ pub(crate) struct AdvancePoolMigration {
     migration_id: String,
     /// The migration's lifecycle phase after advancing.
     phase: MigrationPhase,
+    /// The migration's progress after advancing.
+    progress: MigrationProgress,
+    /// A short description of what this step did.
+    status: String,
 }
 
-pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
+/// Maps an advance failure to an RPC error.
+fn map_advance_error(err: AdvanceError) -> ErrorObjectOwned {
+    match err {
+        AdvanceError::NoMigration => no_such_migration(),
+        AdvanceError::Store(message) => LegacyCode::Database.with_message(message),
+        AdvanceError::Commit(failure) => map_commit_failure(failure),
+        AdvanceError::Prove(e) => LegacyCode::Misc.with_message(e.to_string()),
+    }
+}
+
+pub(crate) async fn call<C: Chain>(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    chain: C,
+    account: JsonValue,
+    migration_id: &str,
+) -> Response {
     validate_migration_id(migration_id)?;
     if migration_id != MIGRATION_ID {
         return Err(no_such_migration());
     }
-    let state = wallet
-        .with_raw_mut(|conn, _| load_migration(conn))
-        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-        .ok_or_else(no_such_migration)?;
+    let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+    // Decrypt the spending key before the blocking section (the phase-2 transfers are signed there).
+    let usk = decrypt_account_usk(wallet, keystore, account_id).await?;
 
-    match state.status {
-        // A finished or cancelled migration has nothing left to advance.
-        MigrationStatus::Complete | MigrationStatus::Failed => Ok(AdvancePoolMigration {
-            migration_id: MIGRATION_ID.to_string(),
-            phase: MigrationPhase::from_status(state.status),
-        }),
-        // Making on-chain progress requires proving and broadcasting the pre-signed transactions,
-        // which is not yet wired into Zallet (it needs the pczt prover and an Orchard proving key).
-        _ => Err(LegacyCode::Misc.with_message(format!(
-            "advancing a pool migration (proving and broadcasting its pre-signed transactions) is \
-             not yet wired; the migration is committed with {} transactions ready",
-            state.transactions.len(),
-        ))),
+    let chain_height = wallet
+        .chain_height()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+    let tip = u32::from(chain_height);
+
+    // Blocking: load the migration, detect newly mined transactions, and decide + build the next
+    // transaction to broadcast (or build the transfers, or report what it is waiting for).
+    let AdvanceOutcome {
+        mut state,
+        to_broadcast,
+        message,
+    } = wallet
+        .with_raw_mut(|conn, network| advance_blocking(conn, network, account_id, usk, tip))
+        .map_err(map_advance_error)?;
+
+    // Broadcast the built transaction (async), then record its broadcast and persist.
+    if let Some((tx, tx_id)) = to_broadcast {
+        chain.broadcast_transaction(&tx).await.map_err(|e| {
+            LegacyCode::Misc.with_message(format!("broadcasting the transaction failed: {e}"))
+        })?;
+        let txid = transaction_txid_bytes(&tx);
+        wallet
+            .with_raw_mut(|conn, _| record_broadcast(conn, &mut state, tx_id, txid))
+            .map_err(map_advance_error)?;
     }
+
+    Ok(AdvancePoolMigration {
+        migration_id: MIGRATION_ID.to_string(),
+        phase: MigrationPhase::from_status(state.status),
+        progress: migration_progress(&state),
+        status: message,
+    })
 }

--- a/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/advance_pool_migration.rs
@@ -7,13 +7,12 @@
 
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
-use jsonrpsee::types::ErrorObjectOwned;
 use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_client_backend::data_api::WalletRead;
 
 use super::pool_migration::{
-    MIGRATION_ID, MigrationPhase, MigrationProgress, decrypt_account_usk, map_commit_failure,
+    MIGRATION_ID, MigrationPhase, MigrationProgress, decrypt_account_usk, map_advance_error,
     migration_progress, no_such_migration, validate_migration_id,
 };
 use crate::components::chain::Chain;
@@ -21,9 +20,7 @@ use crate::components::database::DbConnection;
 use crate::components::json_rpc::server::LegacyCode;
 use crate::components::json_rpc::utils::parse_account_parameter;
 use crate::components::keystore::KeyStore;
-use crate::migrate::{
-    AdvanceError, AdvanceOutcome, advance_blocking, record_broadcast, transaction_txid_bytes,
-};
+use crate::migrate::{AdvanceOutcome, advance_blocking, record_broadcast, transaction_txid_bytes};
 
 /// Response to a `z_advancepoolmigration` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -44,16 +41,6 @@ pub(crate) struct AdvancePoolMigration {
     progress: MigrationProgress,
     /// A short description of what this step did.
     status: String,
-}
-
-/// Maps an advance failure to an RPC error.
-fn map_advance_error(err: AdvanceError) -> ErrorObjectOwned {
-    match err {
-        AdvanceError::NoMigration => no_such_migration(),
-        AdvanceError::Store(message) => LegacyCode::Database.with_message(message),
-        AdvanceError::Commit(failure) => map_commit_failure(failure),
-        AdvanceError::Prove(e) => LegacyCode::Misc.with_message(e.to_string()),
-    }
 }
 
 pub(crate) async fn call<C: Chain>(

--- a/zallet-core/src/components/json_rpc/methods/apply_pool_migration_signature.rs
+++ b/zallet-core/src/components/json_rpc/methods/apply_pool_migration_signature.rs
@@ -62,7 +62,7 @@ pub(crate) async fn call(
         let mut state = load_migration(conn)
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
             .ok_or_else(no_such_migration)?;
-        if !state.apply_signature(MigrationTxId(transaction_id), bytes) {
+        if !state.apply_signature(MigrationTxId::new(transaction_id), bytes) {
             return Err(LegacyCode::InvalidParameter
                 .with_static("no migration transaction with that id is awaiting a signature"));
         }
@@ -73,7 +73,7 @@ pub(crate) async fn call(
 
     Ok(ApplyPoolMigrationSignature {
         migration_id: MIGRATION_ID.to_string(),
-        phase: MigrationPhase::from_status(state.status),
+        phase: MigrationPhase::from_status(state.status()),
         progress: migration_progress(&state),
         status: "applied the external signature".to_string(),
     })

--- a/zallet-core/src/components/json_rpc/methods/apply_pool_migration_signature.rs
+++ b/zallet-core/src/components/json_rpc/methods/apply_pool_migration_signature.rs
@@ -1,0 +1,80 @@
+//! `z_applypoolmigrationsignature`: apply an externally-signed PCZT to a migration transaction.
+//!
+//! Stores the signed PCZT an external (hardware or offline) signer returned against the migration
+//! transaction it was built for, moving that transaction from `AwaitingSignature` to `Signed` so
+//! `z_advancepoolmigration` can prove and broadcast it. The PCZT is matched to its transaction by the
+//! id that `z_startpoolmigration` (with `external_signer`) or `z_buildpoolmigrationtransfers` returned
+//! alongside the unsigned PCZT.
+
+use base64ct::{Base64, Encoding};
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::types::ErrorObjectOwned;
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_pool_migration_backend::engine::MigrationTxId;
+
+use super::pool_migration::{
+    MIGRATION_ID, MigrationPhase, MigrationProgress, migration_progress, no_such_migration,
+    validate_migration_id,
+};
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::migrate::{load_migration, persist_migration};
+
+/// Response to a `z_applypoolmigrationsignature` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = ApplyPoolMigrationSignature;
+
+pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
+pub(super) const PARAM_TRANSACTION_ID_DESC: &str = "The id of the migration transaction the signed PCZT is for, from the unsigned_transactions list.";
+pub(super) const PARAM_PCZT_DESC: &str = "The signed migration PCZT, base64 encoded (from an external signer or z_signpoolmigrationpczt).";
+
+/// The result of applying an external signature to a migration transaction.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct ApplyPoolMigrationSignature {
+    /// Opaque identifier for the migration.
+    migration_id: String,
+    /// The migration's lifecycle phase after applying the signature.
+    phase: MigrationPhase,
+    /// The migration's progress after applying the signature.
+    progress: MigrationProgress,
+    /// A short description of what this step did.
+    status: String,
+}
+
+pub(crate) async fn call(
+    wallet: &DbConnection,
+    migration_id: &str,
+    transaction_id: u32,
+    pczt: &str,
+) -> Response {
+    validate_migration_id(migration_id)?;
+    if migration_id != MIGRATION_ID {
+        return Err(no_such_migration());
+    }
+    let bytes = Base64::decode_vec(pczt)
+        .map_err(|_| LegacyCode::InvalidParameter.with_static("Malformed base64 PCZT"))?;
+
+    // Load the migration, apply the signed PCZT to its transaction, and persist. The load and the
+    // store write run on one connection, sequentially.
+    let state = wallet.with_raw_mut(|conn, _| -> Result<_, ErrorObjectOwned> {
+        let mut state = load_migration(conn)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .ok_or_else(no_such_migration)?;
+        if !state.apply_signature(MigrationTxId(transaction_id), bytes) {
+            return Err(LegacyCode::InvalidParameter
+                .with_static("no migration transaction with that id is awaiting a signature"));
+        }
+        persist_migration(conn, &state)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+        Ok(state)
+    })?;
+
+    Ok(ApplyPoolMigrationSignature {
+        migration_id: MIGRATION_ID.to_string(),
+        phase: MigrationPhase::from_status(state.status),
+        progress: migration_progress(&state),
+        status: "applied the external signature".to_string(),
+    })
+}

--- a/zallet-core/src/components/json_rpc/methods/build_pool_migration_transfers.rs
+++ b/zallet-core/src/components/json_rpc/methods/build_pool_migration_transfers.rs
@@ -16,8 +16,8 @@ use zcash_client_backend::data_api::WalletRead;
 
 use super::pool_migration::{
     MIGRATION_ID, MigrationPhase, MigrationProgress, UnsignedMigrationTransaction,
-    decrypt_account_usk, encode_unsigned, map_advance_error, migration_progress, no_such_migration,
-    validate_migration_id,
+    decrypt_account_usk, encode_unsigned_pairs, map_advance_error, migration_progress,
+    no_such_migration, validate_migration_id,
 };
 use crate::components::database::DbConnection;
 use crate::components::json_rpc::server::LegacyCode;
@@ -79,9 +79,9 @@ pub(crate) async fn call(
 
     Ok(BuildPoolMigrationTransfers {
         migration_id: MIGRATION_ID.to_string(),
-        phase: MigrationPhase::from_status(state.status),
+        phase: MigrationPhase::from_status(state.status()),
         progress: migration_progress(&state),
-        unsigned_transactions: encode_unsigned(unsigned),
+        unsigned_transactions: encode_unsigned_pairs(unsigned)?,
         status: message,
     })
 }

--- a/zallet-core/src/components/json_rpc/methods/build_pool_migration_transfers.rs
+++ b/zallet-core/src/components/json_rpc/methods/build_pool_migration_transfers.rs
@@ -1,0 +1,87 @@
+//! `z_buildpoolmigrationtransfers`: build a migration's phase-2 transfers UNSIGNED, for an external
+//! signer.
+//!
+//! The external-signer counterpart of the in-process transfer building that `z_advancepoolmigration`
+//! performs: it detects newly mined preparation transactions and, once the whole preparation is mined,
+//! builds the transfer transactions but leaves them UNSIGNED, returning their PCZTs to sign on the
+//! device (applied back with `z_applypoolmigrationsignature`). Nothing is proved or broadcast here. An
+//! external migration uses this rather than `z_advancepoolmigration` for the preparation-to-transfers
+//! step, so the wallet never signs the transfers in process.
+
+use documented::Documented;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_client_backend::data_api::WalletRead;
+
+use super::pool_migration::{
+    MIGRATION_ID, MigrationPhase, MigrationProgress, UnsignedMigrationTransaction,
+    decrypt_account_usk, encode_unsigned, map_advance_error, migration_progress, no_such_migration,
+    validate_migration_id,
+};
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::components::json_rpc::utils::parse_account_parameter;
+use crate::components::keystore::KeyStore;
+use crate::migrate::build_transfers_unsigned_blocking;
+
+/// Response to a `z_buildpoolmigrationtransfers` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = BuildPoolMigrationTransfers;
+
+pub(super) const PARAM_ACCOUNT_DESC: &str =
+    "Either the UUID or ZIP 32 account index of the account whose migration transfers to build.";
+pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
+
+/// The result of building a migration's transfers for an external signer.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct BuildPoolMigrationTransfers {
+    /// Opaque identifier for the migration.
+    migration_id: String,
+    /// The migration's lifecycle phase after building.
+    phase: MigrationPhase,
+    /// The migration's progress after building.
+    progress: MigrationProgress,
+    /// The unsigned transfer PCZTs to sign externally. Empty until the whole preparation is mined; a
+    /// non-empty list means the transfers were built and are awaiting signatures.
+    unsigned_transactions: Vec<UnsignedMigrationTransaction>,
+    /// A short description of what this step did.
+    status: String,
+}
+
+pub(crate) async fn call(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account: JsonValue,
+    migration_id: &str,
+) -> Response {
+    validate_migration_id(migration_id)?;
+    if migration_id != MIGRATION_ID {
+        return Err(no_such_migration());
+    }
+    let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+    // The key builds the transfer PCZTs (viewing key and witnesses); it does not sign them.
+    let usk = decrypt_account_usk(wallet, keystore, account_id).await?;
+
+    let chain_height = wallet
+        .chain_height()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+    let tip = u32::from(chain_height);
+
+    // Blocking: detect newly mined preparation transactions and, if the preparation is fully mined,
+    // build the transfers unsigned and persist the migration.
+    let (state, unsigned, message) = wallet
+        .with_raw_mut(|conn, network| {
+            build_transfers_unsigned_blocking(conn, network, account_id, usk, tip)
+        })
+        .map_err(map_advance_error)?;
+
+    Ok(BuildPoolMigrationTransfers {
+        migration_id: MIGRATION_ID.to_string(),
+        phase: MigrationPhase::from_status(state.status),
+        progress: migration_progress(&state),
+        unsigned_transactions: encode_unsigned(unsigned),
+        status: message,
+    })
+}

--- a/zallet-core/src/components/json_rpc/methods/cancel_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/cancel_pool_migration.rs
@@ -1,0 +1,32 @@
+//! `z_cancelpoolmigration`: cancel a pool migration (scaffold).
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use super::pool_migration::{MigrationPhase, not_implemented, validate_migration_id};
+
+/// Response to a `z_cancelpoolmigration` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = CancelPoolMigration;
+
+pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
+
+/// The result of cancelling a pool migration.
+///
+/// Describes the response shape for when the migration engine is wired in; the scaffold
+/// validates inputs and then returns a not-implemented error rather than constructing
+/// this value.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct CancelPoolMigration {
+    /// Opaque identifier for the cancelled migration.
+    migration_id: String,
+    /// The migration's lifecycle phase after cancellation.
+    phase: MigrationPhase,
+}
+
+pub(crate) fn call(migration_id: &str) -> Response {
+    validate_migration_id(migration_id)?;
+    not_implemented("z_cancelpoolmigration")
+}

--- a/zallet-core/src/components/json_rpc/methods/cancel_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/cancel_pool_migration.rs
@@ -4,7 +4,7 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_pool_migration_backend::engine::MigrationStatus;
+use zcash_pool_migration_backend::engine::{MigrationState, MigrationStatus};
 
 use super::pool_migration::{
     MIGRATION_ID, MigrationPhase, no_such_migration, validate_migration_id,
@@ -38,13 +38,27 @@ pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
     // building or broadcasting anything further.
     let phase = wallet
         .with_raw_mut(
-            |conn, _| -> Result<Option<MigrationPhase>, zcash_pool_migration_sqlite::Error> {
-                let Some(mut state) = load_migration(conn)? else {
+            |conn,
+             _|
+             -> Result<
+                Option<MigrationPhase>,
+                zcash_client_sqlite::pool_migration::orchard_ironwood::Error,
+            > {
+                let Some(state) = load_migration(conn)? else {
                     return Ok(None);
                 };
-                state.status = MigrationStatus::Failed;
+                // Mark the migration cancelled. The engine models a cancelled migration as the
+                // terminal `Failed` status and exposes no cross-crate status setter, so rebuild the
+                // state from its parts with that status (its transactions are preserved, so any
+                // already-broadcast ones stay recorded).
+                let state = MigrationState::from_parts(
+                    MigrationStatus::Failed,
+                    state.note_split().clone(),
+                    state.preparation().clone(),
+                    state.transactions().to_vec(),
+                );
                 persist_migration(conn, &state)?;
-                Ok(Some(MigrationPhase::from_status(state.status)))
+                Ok(Some(MigrationPhase::from_status(state.status())))
             },
         )
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?

--- a/zallet-core/src/components/json_rpc/methods/cancel_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/cancel_pool_migration.rs
@@ -1,11 +1,17 @@
-//! `z_cancelpoolmigration`: cancel a pool migration (scaffold).
+//! `z_cancelpoolmigration`: cancel a pool migration.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
+use zcash_pool_migration_backend::engine::MigrationStatus;
 
-use super::pool_migration::{MigrationPhase, not_implemented, validate_migration_id};
+use super::pool_migration::{
+    MIGRATION_ID, MigrationPhase, no_such_migration, validate_migration_id,
+};
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::migrate::{load_migration, persist_migration};
 
 /// Response to a `z_cancelpoolmigration` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -14,10 +20,6 @@ pub(crate) type ResultType = CancelPoolMigration;
 pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
 
 /// The result of cancelling a pool migration.
-///
-/// Describes the response shape for when the migration engine is wired in; the scaffold
-/// validates inputs and then returns a not-implemented error rather than constructing
-/// this value.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct CancelPoolMigration {
     /// Opaque identifier for the cancelled migration.
@@ -26,7 +28,29 @@ pub(crate) struct CancelPoolMigration {
     phase: MigrationPhase,
 }
 
-pub(crate) fn call(migration_id: &str) -> Response {
+pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
     validate_migration_id(migration_id)?;
-    not_implemented("z_cancelpoolmigration")
+    if migration_id != MIGRATION_ID {
+        return Err(no_such_migration());
+    }
+    // Mark the stored migration as failed, which reports as the cancelled phase. Any preparation
+    // transactions already broadcast cannot be undone on chain; cancelling stops the migration from
+    // building or broadcasting anything further.
+    let phase = wallet
+        .with_raw_mut(
+            |conn, _| -> Result<Option<MigrationPhase>, zcash_pool_migration_sqlite::Error> {
+                let Some(mut state) = load_migration(conn)? else {
+                    return Ok(None);
+                };
+                state.status = MigrationStatus::Failed;
+                persist_migration(conn, &state)?;
+                Ok(Some(MigrationPhase::from_status(state.status)))
+            },
+        )
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(no_such_migration)?;
+    Ok(CancelPoolMigration {
+        migration_id: MIGRATION_ID.to_string(),
+        phase,
+    })
 }

--- a/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
@@ -1,0 +1,42 @@
+//! `z_getpoolmigrationstatus`: report the status of a pool migration (scaffold).
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use super::pool_migration::{
+    MigrationPhase, MigrationProgress, Pool, not_implemented, validate_migration_id,
+};
+
+/// Response to a `z_getpoolmigrationstatus` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = PoolMigrationStatus;
+
+pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
+
+/// The status of a pool migration.
+///
+/// Describes the response shape for when the migration engine is wired in; the scaffold
+/// validates inputs and then returns a not-implemented error rather than constructing
+/// this value.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct PoolMigrationStatus {
+    /// Opaque identifier for the migration.
+    migration_id: String,
+    /// The value pool funds are being migrated from.
+    from_pool: Pool,
+    /// The value pool funds are being migrated to.
+    to_pool: Pool,
+    /// The network upgrade that enables this migration (for example `"Nu6.3"`).
+    enabling_upgrade: String,
+    /// The migration's current lifecycle phase.
+    phase: MigrationPhase,
+    /// The migration's progress so far.
+    progress: MigrationProgress,
+}
+
+pub(crate) fn call(migration_id: &str) -> Response {
+    validate_migration_id(migration_id)?;
+    not_implemented("z_getpoolmigrationstatus")
+}

--- a/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
@@ -5,10 +5,12 @@ use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 
+use zcash_client_backend::data_api::WalletRead;
+
 use super::pool_migration::{
     MIGRATION_ENABLING_UPGRADE, MIGRATION_FROM_POOL, MIGRATION_ID, MIGRATION_TO_POOL,
-    MigrationPhase, MigrationProgress, Pool, migration_progress, no_such_migration,
-    validate_migration_id,
+    MigrationPhase, MigrationProgress, MigrationTransactionStatus, Pool, migration_progress,
+    migration_transactions, no_such_migration, validate_migration_id,
 };
 use crate::components::database::DbConnection;
 use crate::components::json_rpc::server::LegacyCode;
@@ -35,6 +37,11 @@ pub(crate) struct PoolMigrationStatus {
     phase: MigrationPhase,
     /// The migration's progress so far.
     progress: MigrationProgress,
+    /// Every transaction the migration comprises, with its lifecycle state and, for a transaction a
+    /// wallet can act on now, the next action (or what it is waiting on). This lets a wallet render
+    /// progress and drive signing/broadcasting deterministically from persisted state, which a
+    /// multi-layer migration on a mobile wallet requires.
+    transactions: Vec<MigrationTransactionStatus>,
 }
 
 pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
@@ -42,6 +49,13 @@ pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
     if migration_id != MIGRATION_ID {
         return Err(no_such_migration());
     }
+    // The height the next transaction would build at (tip + 1), used to decide which scheduled
+    // transactions are due. Before the wallet has synced a chain tip, treat nothing as due.
+    let target_height = wallet
+        .chain_height()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .map(|h| u32::from(h) + 1)
+        .unwrap_or(0);
     let state = wallet
         .with_raw_mut(|conn, _| load_migration(conn))
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
@@ -53,5 +67,6 @@ pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
         enabling_upgrade: MIGRATION_ENABLING_UPGRADE.to_string(),
         phase: MigrationPhase::from_status(state.status),
         progress: migration_progress(&state),
+        transactions: migration_transactions(&state, target_height),
     })
 }

--- a/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
@@ -1,4 +1,4 @@
-//! `z_getpoolmigrationstatus`: report the status of a pool migration (scaffold).
+//! `z_getpoolmigrationstatus`: report the status of a pool migration.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
@@ -6,8 +6,13 @@ use schemars::JsonSchema;
 use serde::Serialize;
 
 use super::pool_migration::{
-    MigrationPhase, MigrationProgress, Pool, not_implemented, validate_migration_id,
+    MIGRATION_ENABLING_UPGRADE, MIGRATION_FROM_POOL, MIGRATION_ID, MIGRATION_TO_POOL,
+    MigrationPhase, MigrationProgress, Pool, migration_progress, no_such_migration,
+    validate_migration_id,
 };
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::migrate::load_migration;
 
 /// Response to a `z_getpoolmigrationstatus` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -16,10 +21,6 @@ pub(crate) type ResultType = PoolMigrationStatus;
 pub(super) const PARAM_MIGRATION_ID_DESC: &str = "The identifier returned by z_startpoolmigration.";
 
 /// The status of a pool migration.
-///
-/// Describes the response shape for when the migration engine is wired in; the scaffold
-/// validates inputs and then returns a not-implemented error rather than constructing
-/// this value.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct PoolMigrationStatus {
     /// Opaque identifier for the migration.
@@ -36,7 +37,21 @@ pub(crate) struct PoolMigrationStatus {
     progress: MigrationProgress,
 }
 
-pub(crate) fn call(migration_id: &str) -> Response {
+pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
     validate_migration_id(migration_id)?;
-    not_implemented("z_getpoolmigrationstatus")
+    if migration_id != MIGRATION_ID {
+        return Err(no_such_migration());
+    }
+    let state = wallet
+        .with_raw_mut(|conn, _| load_migration(conn))
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(no_such_migration)?;
+    Ok(PoolMigrationStatus {
+        migration_id: MIGRATION_ID.to_string(),
+        from_pool: MIGRATION_FROM_POOL,
+        to_pool: MIGRATION_TO_POOL,
+        enabling_upgrade: MIGRATION_ENABLING_UPGRADE.to_string(),
+        phase: MigrationPhase::from_status(state.status),
+        progress: migration_progress(&state),
+    })
 }

--- a/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_pool_migration_status.rs
@@ -65,7 +65,7 @@ pub(crate) fn call(wallet: &DbConnection, migration_id: &str) -> Response {
         from_pool: MIGRATION_FROM_POOL,
         to_pool: MIGRATION_TO_POOL,
         enabling_upgrade: MIGRATION_ENABLING_UPGRADE.to_string(),
-        phase: MigrationPhase::from_status(state.status),
+        phase: MigrationPhase::from_status(state.status()),
         progress: migration_progress(&state),
         transactions: migration_transactions(&state, target_height),
     })

--- a/zallet-core/src/components/json_rpc/methods/list_pool_migrations.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_pool_migrations.rs
@@ -45,7 +45,7 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
                 migration_id: MIGRATION_ID.to_string(),
                 from_pool: MIGRATION_FROM_POOL,
                 to_pool: MIGRATION_TO_POOL,
-                phase: MigrationPhase::from_status(state.status),
+                phase: MigrationPhase::from_status(state.status()),
             }]
         })
         .unwrap_or_default();

--- a/zallet-core/src/components/json_rpc/methods/list_pool_migrations.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_pool_migrations.rs
@@ -1,19 +1,22 @@
-//! `z_listpoolmigrations`: list the migrations known to the wallet (scaffold).
+//! `z_listpoolmigrations`: list the migrations known to the wallet.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use super::pool_migration::{MigrationPhase, Pool, not_implemented};
+use super::pool_migration::{
+    MIGRATION_FROM_POOL, MIGRATION_ID, MIGRATION_TO_POOL, MigrationPhase, Pool,
+};
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::migrate::load_migration;
 
 /// Response to a `z_listpoolmigrations` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = PoolMigrationList;
 
 /// A single entry in the list of known migrations.
-///
-/// Describes the response shape for when the migration engine is wired in.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct PoolMigrationSummary {
     /// Opaque identifier for the migration.
@@ -27,15 +30,24 @@ pub(crate) struct PoolMigrationSummary {
 }
 
 /// The list of migrations known to the wallet.
-///
-/// Describes the response shape for when the migration engine is wired in; the scaffold
-/// returns a not-implemented error rather than constructing this value.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct PoolMigrationList {
-    /// Every migration the wallet is tracking.
+    /// Every migration the wallet is tracking (at most one at a time).
     migrations: Vec<PoolMigrationSummary>,
 }
 
-pub(crate) fn call() -> Response {
-    not_implemented("z_listpoolmigrations")
+pub(crate) fn call(wallet: &DbConnection) -> Response {
+    let migrations = wallet
+        .with_raw_mut(|conn, _| load_migration(conn))
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .map(|state| {
+            vec![PoolMigrationSummary {
+                migration_id: MIGRATION_ID.to_string(),
+                from_pool: MIGRATION_FROM_POOL,
+                to_pool: MIGRATION_TO_POOL,
+                phase: MigrationPhase::from_status(state.status),
+            }]
+        })
+        .unwrap_or_default();
+    Ok(PoolMigrationList { migrations })
 }

--- a/zallet-core/src/components/json_rpc/methods/list_pool_migrations.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_pool_migrations.rs
@@ -1,0 +1,41 @@
+//! `z_listpoolmigrations`: list the migrations known to the wallet (scaffold).
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use super::pool_migration::{MigrationPhase, Pool, not_implemented};
+
+/// Response to a `z_listpoolmigrations` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = PoolMigrationList;
+
+/// A single entry in the list of known migrations.
+///
+/// Describes the response shape for when the migration engine is wired in.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct PoolMigrationSummary {
+    /// Opaque identifier for the migration.
+    migration_id: String,
+    /// The value pool funds are being migrated from.
+    from_pool: Pool,
+    /// The value pool funds are being migrated to.
+    to_pool: Pool,
+    /// The migration's current lifecycle phase.
+    phase: MigrationPhase,
+}
+
+/// The list of migrations known to the wallet.
+///
+/// Describes the response shape for when the migration engine is wired in; the scaffold
+/// returns a not-implemented error rather than constructing this value.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct PoolMigrationList {
+    /// Every migration the wallet is tracking.
+    migrations: Vec<PoolMigrationSummary>,
+}
+
+pub(crate) fn call() -> Response {
+    not_implemented("z_listpoolmigrations")
+}

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -23,7 +23,10 @@ use zcash_client_backend::data_api::{Account, WalletRead};
 use zcash_client_sqlite::AccountUuid;
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
-    MigrationState, MigrationStatus, MigrationTxId, MigrationTxKind, MigrationTxState,
+    MigrationState, MigrationStatus, MigrationTxKind, MigrationTxState,
+};
+use zcash_pool_migration_backend::state::{
+    Blocker, NextAction, TransactionStatus as EngineTransactionStatus,
 };
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
@@ -347,102 +350,66 @@ pub(crate) struct MigrationTransactionStatus {
     mined_height: Option<u32>,
 }
 
-/// Whether every id in `deps` names a transaction that is mined in `state`.
-fn deps_all_mined(state: &MigrationState, deps: &[MigrationTxId]) -> bool {
-    deps.iter().all(|d| {
-        state
-            .transactions
-            .iter()
-            .find(|t| t.id == *d)
-            .is_some_and(|t| matches!(t.state, MigrationTxState::Mined { .. }))
-    })
+/// Maps one engine transaction status to the JSON-RPC shape: flattens the engine's `kind` into
+/// `layer`/`crossing`, maps the lifecycle and reason enums to their serde-friendly counterparts, and
+/// renders the txid as a big-endian hex string.
+fn to_rpc_status(es: EngineTransactionStatus) -> MigrationTransactionStatus {
+    let (kind, layer, crossing) = match es.kind {
+        MigrationTxKind::Preparation { layer, .. } => {
+            (MigrationTxRole::Preparation, Some(layer as u32), None)
+        }
+        MigrationTxKind::Transfer { crossing } => {
+            (MigrationTxRole::Transfer, None, Some(crossing as u32))
+        }
+    };
+    let state = match es.state {
+        MigrationTxState::Planned => MigrationTxLifecycle::Planned,
+        MigrationTxState::Signed => MigrationTxLifecycle::Signed,
+        MigrationTxState::Proved => MigrationTxLifecycle::Proved,
+        MigrationTxState::Broadcast { .. } => MigrationTxLifecycle::Broadcast,
+        MigrationTxState::Mined { .. } => MigrationTxLifecycle::Mined,
+        MigrationTxState::Expired => MigrationTxLifecycle::Expired,
+    };
+    let action = es.action.map(|a| match a {
+        NextAction::BuildAndSign => MigrationTxAction::BuildAndSign,
+        NextAction::ProveAndBroadcast => MigrationTxAction::ProveAndBroadcast,
+    });
+    let blocked_on = es.blocked_on.map(|b| match b {
+        Blocker::Dependencies => MigrationTxBlocker::Dependencies,
+        Blocker::Schedule => MigrationTxBlocker::Schedule,
+    });
+    let txid = es.txid.map(|mut bytes| {
+        bytes.reverse();
+        hex::encode(bytes)
+    });
+    MigrationTransactionStatus {
+        id: es.id.0,
+        kind,
+        layer,
+        crossing,
+        state,
+        depends_on: es.depends_on.iter().map(|d| d.0).collect(),
+        scheduled_height: es.scheduled_height,
+        ready: es.ready,
+        action,
+        blocked_on,
+        txid,
+        mined_height: es.mined_height,
+    }
 }
 
-/// Builds the per-transaction status view for a migration at `target_height` (the height the next
-/// transaction would build at, i.e. `chain_tip + 1`), so a wallet can render progress and decide,
-/// deterministically and from persisted state alone, the next transaction to sign or broadcast.
-///
-/// A transaction is `ready` when the wallet can act on it now: a `Planned` placeholder whose
-/// dependencies are all mined can be built and signed; a `Signed` transaction whose dependencies are
-/// mined and whose scheduled height has arrived can be proved and broadcast. Otherwise a waiting
-/// transaction reports what it is `blocked_on` (its dependencies, or the schedule).
+/// Builds the per-transaction status view for the RPC at `target_height` (the height the next
+/// transaction would build at, i.e. `chain_tip + 1`), by mapping the engine's shared
+/// `transaction_statuses` decision logic into the JSON-RPC shape. The engine owns the ready/blocked
+/// rules so a wallet (the mobile wallet, or zallet here) renders the same next-actions from state.
 pub(crate) fn migration_transactions(
     state: &MigrationState,
     target_height: u32,
 ) -> Vec<MigrationTransactionStatus> {
     state
-        .transactions
-        .iter()
-        .map(|t| {
-            let (kind, layer, crossing) = match t.kind {
-                MigrationTxKind::Preparation { layer, .. } => {
-                    (MigrationTxRole::Preparation, Some(layer as u32), None)
-                }
-                MigrationTxKind::Transfer { crossing } => {
-                    (MigrationTxRole::Transfer, None, Some(crossing as u32))
-                }
-            };
-            let deps_mined = deps_all_mined(state, &t.depends_on);
-            // `Planned`/`Expired` need building; `Signed`/`Proved` need broadcasting. In both cases a
-            // transaction is actionable only once its dependencies (the prior anchor bucket) are
-            // mined, and a broadcastable one only once it is also due.
-            let (lifecycle, ready, action, blocked_on) = match t.state {
-                MigrationTxState::Planned | MigrationTxState::Expired => {
-                    let lc = match t.state {
-                        MigrationTxState::Expired => MigrationTxLifecycle::Expired,
-                        _ => MigrationTxLifecycle::Planned,
-                    };
-                    if deps_mined {
-                        (lc, true, Some(MigrationTxAction::BuildAndSign), None)
-                    } else {
-                        (lc, false, None, Some(MigrationTxBlocker::Dependencies))
-                    }
-                }
-                MigrationTxState::Signed | MigrationTxState::Proved => {
-                    let lc = match t.state {
-                        MigrationTxState::Proved => MigrationTxLifecycle::Proved,
-                        _ => MigrationTxLifecycle::Signed,
-                    };
-                    if !deps_mined {
-                        (lc, false, None, Some(MigrationTxBlocker::Dependencies))
-                    } else if t.scheduled_height <= target_height {
-                        (lc, true, Some(MigrationTxAction::ProveAndBroadcast), None)
-                    } else {
-                        (lc, false, None, Some(MigrationTxBlocker::Schedule))
-                    }
-                }
-                MigrationTxState::Broadcast { .. } => {
-                    (MigrationTxLifecycle::Broadcast, false, None, None)
-                }
-                MigrationTxState::Mined { .. } => (MigrationTxLifecycle::Mined, false, None, None),
-            };
-            let txid = match t.state {
-                MigrationTxState::Broadcast { txid } => {
-                    let mut bytes = txid;
-                    bytes.reverse();
-                    Some(hex::encode(bytes))
-                }
-                _ => None,
-            };
-            let mined_height = match t.state {
-                MigrationTxState::Mined { height } => Some(height),
-                _ => None,
-            };
-            MigrationTransactionStatus {
-                id: t.id.0,
-                kind,
-                layer,
-                crossing,
-                state: lifecycle,
-                depends_on: t.depends_on.iter().map(|d| d.0).collect(),
-                scheduled_height: t.scheduled_height,
-                ready,
-                action,
-                blocked_on,
-                txid,
-                mined_height,
-            }
-        })
+        .transaction_statuses(target_height)
+        .into_iter()
+        .map(to_rpc_status)
         .collect()
 }
 

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -1,0 +1,256 @@
+//! Shared types and validation for the generic value-pool migration RPC surface.
+//!
+//! The migration surface is a pool-to-pool workflow (`z_startpoolmigration` and the
+//! companion status, advance, cancel, and list methods) spread across sibling method
+//! modules. This module holds what they share: the pool-agnostic [`Pool`] type, the
+//! [`SUPPORTED_MIGRATIONS`] table that is the single extension point for new pool
+//! pairs, the stubbed plan/progress/phase shapes, and the input validation.
+//!
+//! The surface is currently a SCAFFOLD. Each method validates its inputs (pool
+//! parsing, the supported-pair table, and network-upgrade activation), but the call
+//! into the migration engine returns [`not_implemented`] instead of doing any work.
+//! The engine (`zcash_ironwood_migration_backend`) is still evolving upstream, so
+//! nothing here depends on the shape of its final API.
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_client_backend::data_api::WalletRead;
+use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
+
+/// Wire name of the Sapling value pool.
+const POOL_NAME_SAPLING: &str = "sapling";
+/// Wire name of the Orchard value pool.
+const POOL_NAME_ORCHARD: &str = "orchard";
+/// Wire name of the Ironwood value pool.
+const POOL_NAME_IRONWOOD: &str = "ironwood";
+
+/// Message returned wherever the scaffold would call into the migration engine. Kept
+/// as a single constant so every method reports the boundary identically.
+const NOT_IMPLEMENTED_MESSAGE: &str =
+    "pool migration is not yet implemented; this RPC surface is currently a scaffold";
+
+/// A Zcash shielded value pool that can take part in a pool-to-pool migration.
+///
+/// Serialized as its lowercase wire name (`"sapling"`, `"orchard"`, `"ironwood"`). New
+/// pools are added here and, if they can be migrated, wired into
+/// [`SUPPORTED_MIGRATIONS`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Pool {
+    /// The Sapling shielded value pool.
+    Sapling,
+    /// The Orchard shielded value pool.
+    Orchard,
+    /// The Ironwood shielded value pool (NU6.3, ZIP 2005).
+    Ironwood,
+}
+
+impl Pool {
+    /// Returns the lowercase wire name of this pool.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Pool::Sapling => POOL_NAME_SAPLING,
+            Pool::Orchard => POOL_NAME_ORCHARD,
+            Pool::Ironwood => POOL_NAME_IRONWOOD,
+        }
+    }
+
+    /// Parses a pool from its wire name, returning an `InvalidParameter` RPC error for
+    /// any unrecognized value.
+    pub(crate) fn parse(label: &str, value: &str) -> RpcResult<Self> {
+        match value {
+            POOL_NAME_SAPLING => Ok(Pool::Sapling),
+            POOL_NAME_ORCHARD => Ok(Pool::Orchard),
+            POOL_NAME_IRONWOOD => Ok(Pool::Ironwood),
+            other => Err(LegacyCode::InvalidParameter.with_message(format!(
+                "{label}: unknown value pool {other:?}; expected one of \
+                 {POOL_NAME_SAPLING:?}, {POOL_NAME_ORCHARD:?}, {POOL_NAME_IRONWOOD:?}",
+            ))),
+        }
+    }
+}
+
+/// One supported pool-to-pool migration and the network upgrade that enables it.
+struct SupportedMigration {
+    /// The value pool funds are migrated from.
+    from: Pool,
+    /// The value pool funds are migrated to.
+    to: Pool,
+    /// The network upgrade that must be active for this migration to run.
+    enabling_upgrade: NetworkUpgrade,
+}
+
+/// The single source of truth for which pool-to-pool migrations exist and which
+/// network upgrade each one requires.
+///
+/// This is the one extension point for supporting new migrations: adding a pool pair
+/// here makes it selectable through the whole RPC surface. Migrating from the Orchard
+/// pool to the Ironwood pool requires NU6.3 (ZIP 2005).
+const SUPPORTED_MIGRATIONS: &[SupportedMigration] = &[SupportedMigration {
+    from: Pool::Orchard,
+    to: Pool::Ironwood,
+    enabling_upgrade: NetworkUpgrade::Nu6_3,
+}];
+
+/// Looks up a supported migration by its ordered pool pair.
+fn supported_migration(from: Pool, to: Pool) -> Option<&'static SupportedMigration> {
+    SUPPORTED_MIGRATIONS
+        .iter()
+        .find(|m| m.from == from && m.to == to)
+}
+
+/// Parses and validates a pool pair, returning the parsed pools and the network
+/// upgrade that enables the migration.
+///
+/// Validates that the pair is present in [`SUPPORTED_MIGRATIONS`] and that its enabling
+/// upgrade is active at the wallet's current chain height, returning an
+/// `InvalidParameter` RPC error otherwise.
+pub(crate) fn validate_pool_pair(
+    wallet: &DbConnection,
+    from_pool: &str,
+    to_pool: &str,
+) -> RpcResult<(Pool, Pool, NetworkUpgrade)> {
+    let from_pool = Pool::parse("from_pool", from_pool)?;
+    let to_pool = Pool::parse("to_pool", to_pool)?;
+
+    if from_pool == to_pool {
+        return Err(LegacyCode::InvalidParameter.with_message(format!(
+            "from_pool and to_pool must differ; both were {:?}",
+            from_pool.name(),
+        )));
+    }
+
+    let migration = supported_migration(from_pool, to_pool).ok_or_else(|| {
+        LegacyCode::InvalidParameter.with_message(format!(
+            "migrating from the {:?} pool to the {:?} pool is not supported",
+            from_pool.name(),
+            to_pool.name(),
+        ))
+    })?;
+
+    let params = wallet.params();
+    let activation = params.activation_height(migration.enabling_upgrade);
+
+    let chain_height = wallet
+        .chain_height()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+
+    match activation {
+        Some(height) if chain_height >= height => {
+            Ok((from_pool, to_pool, migration.enabling_upgrade))
+        }
+        _ => Err(LegacyCode::InvalidParameter.with_message(format!(
+            "migrating from the {:?} pool to the {:?} pool requires network upgrade {} \
+             to be active",
+            from_pool.name(),
+            to_pool.name(),
+            migration.enabling_upgrade,
+        ))),
+    }
+}
+
+/// Validates that a migration identifier is well-formed (currently just non-empty).
+pub(crate) fn validate_migration_id(migration_id: &str) -> RpcResult<()> {
+    if migration_id.trim().is_empty() {
+        return Err(LegacyCode::InvalidParameter.with_static("migration_id must not be empty"));
+    }
+    Ok(())
+}
+
+/// Returns the not-implemented placeholder for a method, reported wherever the scaffold
+/// would call the migration engine.
+pub(crate) fn not_implemented<T>(method: &str) -> RpcResult<T> {
+    Err(LegacyCode::Misc.with_message(format!("{method}: {NOT_IMPLEMENTED_MESSAGE}")))
+}
+
+/// The lifecycle phase of a pool migration.
+///
+/// Part of the not-yet-implemented response shapes: the variants are documented in the
+/// `rpc.discover` schema but are only constructed once the migration engine is wired
+/// in, so the scaffold does not build any of them yet.
+#[expect(
+    dead_code,
+    reason = "scaffold response shape; variants are constructed once the migration \
+              engine is wired in"
+)]
+#[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MigrationPhase {
+    /// The migration has been scheduled but no transactions have been created.
+    Scheduled,
+    /// The migration is creating and broadcasting transactions.
+    InProgress,
+    /// Every planned transaction has been mined.
+    Completed,
+    /// The migration was cancelled before completing.
+    Cancelled,
+}
+
+/// The plan produced when a migration is scheduled.
+///
+/// Stubbed in the current scaffold; the fields describe the intended shape only.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct MigrationPlan {
+    /// The number of transactions the migration is expected to require.
+    transaction_count: u32,
+}
+
+/// Progress of an in-flight migration.
+///
+/// Stubbed in the current scaffold; the fields describe the intended shape only.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct MigrationProgress {
+    /// The number of planned transactions that have been mined so far.
+    completed_transactions: u32,
+    /// The total number of transactions the migration requires.
+    total_transactions: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_round_trips_through_its_wire_name() {
+        for pool in [Pool::Sapling, Pool::Orchard, Pool::Ironwood] {
+            assert_eq!(Pool::parse("pool", pool.name()).unwrap(), pool);
+        }
+    }
+
+    #[test]
+    fn unknown_pool_is_rejected() {
+        assert!(Pool::parse("pool", "transparent").is_err());
+        assert!(Pool::parse("pool", "").is_err());
+    }
+
+    #[test]
+    fn every_supported_migration_has_distinct_pools() {
+        for migration in SUPPORTED_MIGRATIONS {
+            assert_ne!(migration.from, migration.to);
+        }
+    }
+
+    #[test]
+    fn orchard_to_ironwood_is_supported_and_requires_nu6_3() {
+        let migration = supported_migration(Pool::Orchard, Pool::Ironwood)
+            .expect("Orchard to Ironwood must be supported");
+        assert!(matches!(migration.enabling_upgrade, NetworkUpgrade::Nu6_3));
+    }
+
+    #[test]
+    fn unsupported_pairs_are_absent_from_the_table() {
+        assert!(supported_migration(Pool::Ironwood, Pool::Orchard).is_none());
+        assert!(supported_migration(Pool::Sapling, Pool::Orchard).is_none());
+    }
+
+    #[test]
+    fn blank_migration_id_is_rejected() {
+        assert!(validate_migration_id("   ").is_err());
+        assert!(validate_migration_id("m-1").is_ok());
+    }
+}

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -6,11 +6,16 @@
 //! [`SUPPORTED_MIGRATIONS`] table that is the single extension point for new pool
 //! pairs, the stubbed plan/progress/phase shapes, and the input validation.
 //!
-//! The surface is currently a SCAFFOLD. Each method validates its inputs (pool
+//! Most of the surface is currently a SCAFFOLD: `z_startpoolmigration` and the
+//! companion status, advance, cancel, and list methods validate their inputs (pool
 //! parsing, the supported-pair table, and network-upgrade activation), but the call
-//! into the migration engine returns [`not_implemented`] instead of doing any work.
-//! The engine (`zcash_ironwood_migration_backend`) is still evolving upstream, so
-//! nothing here depends on the shape of its final API.
+//! into the migration engine returns [`not_implemented`] instead of doing any work,
+//! because building, signing, scheduling, and persisting the migration transactions
+//! need engine slices that are still landing upstream. The exception is
+//! `z_previewpoolmigration` (see [`preview_pool_migration`](super::preview_pool_migration)),
+//! which is fully wired against the engine's planning slice. The engine crate
+//! (`zcash_pool_migration_backend`) is still evolving upstream, so nothing here
+//! depends on the shape of its final API beyond that planning entry point.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -4,27 +4,37 @@
 //! companion status, advance, cancel, and list methods) spread across sibling method
 //! modules. This module holds what they share: the pool-agnostic [`Pool`] type, the
 //! [`SUPPORTED_MIGRATIONS`] table that is the single extension point for new pool
-//! pairs, the stubbed plan/progress/phase shapes, and the input validation.
+//! pairs, the fixed migration identifier and pools, the plan/progress/phase response
+//! shapes and their mapping from the engine's state, and the input validation.
 //!
-//! Most of the surface is currently a SCAFFOLD: `z_startpoolmigration` and the
-//! companion status, advance, cancel, and list methods validate their inputs (pool
-//! parsing, the supported-pair table, and network-upgrade activation), but the call
-//! into the migration engine returns [`not_implemented`] instead of doing any work,
-//! because building, signing, scheduling, and persisting the migration transactions
-//! need engine slices that are still landing upstream. The exception is
-//! `z_previewpoolmigration` (see [`preview_pool_migration`](super::preview_pool_migration)),
-//! which is fully wired against the engine's planning slice. The engine crate
-//! (`zcash_pool_migration_backend`) is still evolving upstream, so nothing here
-//! depends on the shape of its final API beyond that planning entry point.
+//! `z_startpoolmigration` builds, pre-signs, and persists the migration; the status
+//! and list methods read the persisted state; cancel marks it cancelled. Proving and
+//! broadcasting the pre-signed transactions (`z_advancepoolmigration`) is the one step
+//! not yet wired into Zallet, because it needs the `pczt` prover and an Orchard proving
+//! key; until then a committed migration cannot make on-chain progress.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use jsonrpsee::types::ErrorObjectOwned;
 use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_client_backend::data_api::WalletRead;
+use zcash_pool_migration_backend::engine::{MigrationState, MigrationStatus, MigrationTxState};
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
+use crate::migrate::CommitFailure;
+
+/// The identifier of the wallet's pool migration. The store holds at most one migration at a time,
+/// so a single fixed identifier names it: `z_startpoolmigration` returns this, and the status,
+/// advance, and cancel methods accept it.
+pub(crate) const MIGRATION_ID: &str = "orchard-to-ironwood";
+
+/// The only supported migration is Orchard -> Ironwood, so a stored migration's pools and enabling
+/// upgrade are fixed rather than recorded per migration.
+pub(crate) const MIGRATION_FROM_POOL: Pool = Pool::Orchard;
+pub(crate) const MIGRATION_TO_POOL: Pool = Pool::Ironwood;
+pub(crate) const MIGRATION_ENABLING_UPGRADE: NetworkUpgrade = NetworkUpgrade::Nu6_3;
 
 /// Wire name of the Sapling value pool.
 const POOL_NAME_SAPLING: &str = "sapling";
@@ -32,11 +42,6 @@ const POOL_NAME_SAPLING: &str = "sapling";
 const POOL_NAME_ORCHARD: &str = "orchard";
 /// Wire name of the Ironwood value pool.
 const POOL_NAME_IRONWOOD: &str = "ironwood";
-
-/// Message returned wherever the scaffold would call into the migration engine. Kept
-/// as a single constant so every method reports the boundary identically.
-const NOT_IMPLEMENTED_MESSAGE: &str =
-    "pool migration is not yet implemented; this RPC surface is currently a scaffold";
 
 /// A Zcash shielded value pool that can take part in a pool-to-pool migration.
 ///
@@ -167,22 +172,7 @@ pub(crate) fn validate_migration_id(migration_id: &str) -> RpcResult<()> {
     Ok(())
 }
 
-/// Returns the not-implemented placeholder for a method, reported wherever the scaffold
-/// would call the migration engine.
-pub(crate) fn not_implemented<T>(method: &str) -> RpcResult<T> {
-    Err(LegacyCode::Misc.with_message(format!("{method}: {NOT_IMPLEMENTED_MESSAGE}")))
-}
-
 /// The lifecycle phase of a pool migration.
-///
-/// Part of the not-yet-implemented response shapes: the variants are documented in the
-/// `rpc.discover` schema but are only constructed once the migration engine is wired
-/// in, so the scaffold does not build any of them yet.
-#[expect(
-    dead_code,
-    reason = "scaffold response shape; variants are constructed once the migration \
-              engine is wired in"
-)]
 #[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum MigrationPhase {
@@ -194,6 +184,60 @@ pub(crate) enum MigrationPhase {
     Completed,
     /// The migration was cancelled before completing.
     Cancelled,
+}
+
+impl MigrationPhase {
+    /// The lifecycle phase corresponding to a stored migration's overall status.
+    pub(crate) fn from_status(status: MigrationStatus) -> Self {
+        match status {
+            MigrationStatus::Planning | MigrationStatus::Committed => MigrationPhase::Scheduled,
+            MigrationStatus::InProgress => MigrationPhase::InProgress,
+            MigrationStatus::Complete => MigrationPhase::Completed,
+            MigrationStatus::Failed => MigrationPhase::Cancelled,
+        }
+    }
+}
+
+/// Builds the response plan summary from the number of transactions a migration comprises.
+pub(crate) fn migration_plan(transaction_count: u32) -> MigrationPlan {
+    MigrationPlan { transaction_count }
+}
+
+/// Summarizes a migration's progress: how many of its transactions have been mined, out of the
+/// total the migration comprises.
+pub(crate) fn migration_progress(state: &MigrationState) -> MigrationProgress {
+    let total_transactions = state.transactions.len() as u32;
+    let completed_transactions = state
+        .transactions
+        .iter()
+        .filter(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+        .count() as u32;
+    MigrationProgress {
+        completed_transactions,
+        total_transactions,
+    }
+}
+
+/// The RPC error for a migration id that does not name the wallet's migration, or when no migration
+/// is stored.
+pub(crate) fn no_such_migration() -> ErrorObjectOwned {
+    LegacyCode::InvalidParameter.with_static("no such migration")
+}
+
+/// Maps a migration build/commit failure to an RPC error.
+pub(crate) fn map_commit_failure(failure: CommitFailure) -> ErrorObjectOwned {
+    match failure {
+        CommitFailure::NothingToMigrate => LegacyCode::InvalidParameter
+            .with_static("the account has no spendable source-pool balance to migrate"),
+        CommitFailure::UnsupportedMultiLayer => LegacyCode::InvalidParameter
+            .with_static("this balance needs multi-layer preparation, which is not yet supported"),
+        CommitFailure::NoMigrationInProgress => {
+            LegacyCode::InvalidParameter.with_static("no migration is in progress")
+        }
+        CommitFailure::AlreadyInProgress => LegacyCode::InvalidParameter
+            .with_static("a migration is already in progress; cancel it before starting another"),
+        CommitFailure::Other(message) => LegacyCode::Misc.with_message(message),
+    }
 }
 
 /// The plan produced when a migration is scheduled.

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -13,6 +13,7 @@
 //! builds each later transaction as its dependencies mine, driving the migration to
 //! completion.
 
+use base64ct::{Base64, Encoding};
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
@@ -23,7 +24,7 @@ use zcash_client_backend::data_api::{Account, WalletRead};
 use zcash_client_sqlite::AccountUuid;
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
-    MigrationState, MigrationStatus, MigrationTxKind, MigrationTxState,
+    MigrationState, MigrationStatus, MigrationTxKind, MigrationTxState, UnsignedMigrationTx,
 };
 use zcash_pool_migration_backend::state::{
     Blocker, NextAction, TransactionStatus as EngineTransactionStatus,
@@ -32,7 +33,7 @@ use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
 use crate::components::keystore::KeyStore;
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
-use crate::migrate::CommitFailure;
+use crate::migrate::{AdvanceError, CommitFailure};
 
 /// The identifier of the wallet's pool migration. The store holds at most one migration at a time,
 /// so a single fixed identifier names it: `z_startpoolmigration` returns this, and the status,
@@ -207,6 +208,32 @@ pub(crate) async fn decrypt_account_usk(
     .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))
 }
 
+/// One built-but-unsigned migration transaction, as returned to a client driving an EXTERNAL
+/// (hardware or offline) signer: its stable id within the migration and its unsigned PCZT, base64
+/// encoded. The client signs the PCZT out of band (on the device) and hands the signed PCZT back via
+/// `z_applypoolmigrationsignature`, matched to the transaction by this `id`.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct UnsignedMigrationTransaction {
+    /// The stable identifier of the transaction within the migration.
+    pub id: u32,
+    /// The unsigned PCZT to sign externally, base64 encoded.
+    pub pczt: String,
+}
+
+/// Base64-encodes the engine's unsigned PCZTs into the RPC response shape, preserving each
+/// transaction's id so the signed PCZT can be matched back on the way in.
+pub(crate) fn encode_unsigned(
+    unsigned: Vec<UnsignedMigrationTx>,
+) -> Vec<UnsignedMigrationTransaction> {
+    unsigned
+        .into_iter()
+        .map(|u| UnsignedMigrationTransaction {
+            id: u.id.0,
+            pczt: Base64::encode_string(&u.pczt),
+        })
+        .collect()
+}
+
 /// Validates that a migration identifier is well-formed (currently just non-empty).
 pub(crate) fn validate_migration_id(migration_id: &str) -> RpcResult<()> {
     if migration_id.trim().is_empty() {
@@ -277,6 +304,9 @@ pub(crate) enum MigrationTxRole {
 pub(crate) enum MigrationTxLifecycle {
     /// A placeholder that is not yet built or signed (it awaits its dependencies).
     Planned,
+    /// Built and awaiting an external signature: its unsigned PCZT has been exported to a hardware or
+    /// offline signer, and the wallet is waiting for the signed PCZT to be applied.
+    AwaitingSignature,
     /// Built and pre-signed, ready to prove and broadcast once it is due.
     Signed,
     /// Proved against a real anchor, ready to broadcast.
@@ -301,6 +331,9 @@ pub(crate) enum MigrationTxBlocker {
     /// Built and due only at a later height (the privacy broadcast schedule): waiting for the chain
     /// tip to reach its scheduled height.
     Schedule,
+    /// Built as an unsigned PCZT and waiting for an external (hardware or offline) signer to return
+    /// the signed PCZT, which the wallet then applies before proving and broadcasting.
+    Signature,
 }
 
 /// The action a wallet takes next on a ready migration transaction.
@@ -364,6 +397,7 @@ fn to_rpc_status(es: EngineTransactionStatus) -> MigrationTransactionStatus {
     };
     let state = match es.state {
         MigrationTxState::Planned => MigrationTxLifecycle::Planned,
+        MigrationTxState::AwaitingSignature => MigrationTxLifecycle::AwaitingSignature,
         MigrationTxState::Signed => MigrationTxLifecycle::Signed,
         MigrationTxState::Proved => MigrationTxLifecycle::Proved,
         MigrationTxState::Broadcast { .. } => MigrationTxLifecycle::Broadcast,
@@ -377,6 +411,7 @@ fn to_rpc_status(es: EngineTransactionStatus) -> MigrationTransactionStatus {
     let blocked_on = es.blocked_on.map(|b| match b {
         Blocker::Dependencies => MigrationTxBlocker::Dependencies,
         Blocker::Schedule => MigrationTxBlocker::Schedule,
+        Blocker::Signature => MigrationTxBlocker::Signature,
     });
     let txid = es.txid.map(|mut bytes| {
         bytes.reverse();
@@ -430,6 +465,17 @@ pub(crate) fn map_commit_failure(failure: CommitFailure) -> ErrorObjectOwned {
         CommitFailure::AlreadyInProgress => LegacyCode::InvalidParameter
             .with_static("a migration is already in progress; cancel it before starting another"),
         CommitFailure::Other(message) => LegacyCode::Misc.with_message(message),
+    }
+}
+
+/// Maps a migration advance/build failure to an RPC error.
+pub(crate) fn map_advance_error(err: AdvanceError) -> ErrorObjectOwned {
+    match err {
+        AdvanceError::NoMigration => no_such_migration(),
+        AdvanceError::Store(message) => LegacyCode::Database.with_message(message),
+        AdvanceError::Commit(failure) => map_commit_failure(failure),
+        AdvanceError::Prove(e) => LegacyCode::Misc.with_message(e.to_string()),
+        AdvanceError::Unsupported(message) => LegacyCode::InvalidParameter.with_message(message),
     }
 }
 

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -17,6 +17,7 @@ use base64ct::{Base64, Encoding};
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
+use pczt::Pczt;
 use schemars::JsonSchema;
 use secrecy::ExposeSecret;
 use serde::Serialize;
@@ -24,12 +25,13 @@ use zcash_client_backend::data_api::{Account, WalletRead};
 use zcash_client_sqlite::AccountUuid;
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
-    MigrationState, MigrationStatus, MigrationTxKind, MigrationTxState, UnsignedMigrationTx,
+    MigrationState, MigrationStatus, MigrationTxId, MigrationTxKind, MigrationTxState,
+    UnsignedMigrationTx,
 };
 use zcash_pool_migration_backend::state::{
     Blocker, NextAction, TransactionStatus as EngineTransactionStatus,
 };
-use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+use zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters};
 
 use crate::components::keystore::KeyStore;
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
@@ -228,8 +230,28 @@ pub(crate) fn encode_unsigned(
     unsigned
         .into_iter()
         .map(|u| UnsignedMigrationTransaction {
-            id: u.id.0,
-            pczt: Base64::encode_string(&u.pczt),
+            id: u32::from(u.id()),
+            pczt: Base64::encode_string(u.pczt()),
+        })
+        .collect()
+}
+
+/// Base64-encodes `(id, PCZT)` pairs into the RPC response shape. Used where the unsigned PCZTs are
+/// read straight from a stored [`MigrationState`] (its transactions already hold them) rather than
+/// freshly returned by the engine as [`UnsignedMigrationTx`].
+pub(crate) fn encode_unsigned_pairs(
+    unsigned: Vec<(MigrationTxId, Pczt)>,
+) -> Result<Vec<UnsignedMigrationTransaction>, ErrorObjectOwned> {
+    unsigned
+        .into_iter()
+        .map(|(id, pczt)| {
+            let bytes = pczt.serialize().map_err(|e| {
+                LegacyCode::Misc.with_message(format!("serializing a migration PCZT failed: {e:?}"))
+            })?;
+            Ok(UnsignedMigrationTransaction {
+                id: u32::from(id),
+                pczt: Base64::encode_string(&bytes),
+            })
         })
         .collect()
 }
@@ -276,11 +298,11 @@ pub(crate) fn migration_plan(transaction_count: u32) -> MigrationPlan {
 /// Summarizes a migration's progress: how many of its transactions have been mined, out of the
 /// total the migration comprises.
 pub(crate) fn migration_progress(state: &MigrationState) -> MigrationProgress {
-    let total_transactions = state.transactions.len() as u32;
+    let total_transactions = state.transactions().len() as u32;
     let completed_transactions = state
-        .transactions
+        .transactions()
         .iter()
-        .filter(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+        .filter(|t| matches!(t.state(), MigrationTxState::Mined { .. }))
         .count() as u32;
     MigrationProgress {
         completed_transactions,
@@ -302,8 +324,6 @@ pub(crate) enum MigrationTxRole {
 #[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum MigrationTxLifecycle {
-    /// A placeholder that is not yet built or signed (it awaits its dependencies).
-    Planned,
     /// Built and awaiting an external signature: its unsigned PCZT has been exported to a hardware or
     /// offline signer, and the wallet is waiting for the signed PCZT to be applied.
     AwaitingSignature,
@@ -315,8 +335,6 @@ pub(crate) enum MigrationTxLifecycle {
     Broadcast,
     /// Mined into a block.
     Mined,
-    /// Expired before it could be mined; the wallet rebuilds and re-signs it.
-    Expired,
 }
 
 /// Why a migration transaction is not yet actionable.
@@ -340,11 +358,9 @@ pub(crate) enum MigrationTxBlocker {
 #[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum MigrationTxAction {
-    /// Build and pre-sign this placeholder now that its dependencies are mined (a later preparation
-    /// layer, or the transfers once the whole preparation is mined).
-    BuildAndSign,
     /// Prove and broadcast this pre-signed transaction now that its dependencies are mined and it is
-    /// due.
+    /// due. This is the only action a wallet ever takes: the whole migration is built and pre-signed
+    /// in one pass at start, so there is no separate build-and-sign step.
     ProveAndBroadcast,
 }
 
@@ -387,7 +403,7 @@ pub(crate) struct MigrationTransactionStatus {
 /// `layer`/`crossing`, maps the lifecycle and reason enums to their serde-friendly counterparts, and
 /// renders the txid as a big-endian hex string.
 fn to_rpc_status(es: EngineTransactionStatus) -> MigrationTransactionStatus {
-    let (kind, layer, crossing) = match es.kind {
+    let (kind, layer, crossing) = match es.kind() {
         MigrationTxKind::Preparation { layer, .. } => {
             (MigrationTxRole::Preparation, Some(layer as u32), None)
         }
@@ -395,41 +411,45 @@ fn to_rpc_status(es: EngineTransactionStatus) -> MigrationTransactionStatus {
             (MigrationTxRole::Transfer, None, Some(crossing as u32))
         }
     };
-    let state = match es.state {
-        MigrationTxState::Planned => MigrationTxLifecycle::Planned,
+    // The engine dropped the `Planned` and `Expired` lifecycle states: a single commit pass now
+    // builds and pre-signs every transaction up front (so none is ever merely `Planned`), and expiry
+    // handling is not yet modelled. The RPC's `MigrationTxLifecycle` still defines those variants;
+    // they are simply never produced now.
+    let state = match es.state() {
         MigrationTxState::AwaitingSignature => MigrationTxLifecycle::AwaitingSignature,
         MigrationTxState::Signed => MigrationTxLifecycle::Signed,
         MigrationTxState::Proved => MigrationTxLifecycle::Proved,
         MigrationTxState::Broadcast { .. } => MigrationTxLifecycle::Broadcast,
         MigrationTxState::Mined { .. } => MigrationTxLifecycle::Mined,
-        MigrationTxState::Expired => MigrationTxLifecycle::Expired,
     };
-    let action = es.action.map(|a| match a {
-        NextAction::BuildAndSign => MigrationTxAction::BuildAndSign,
+    // With everything built up front, the only remaining per-transaction action is to prove and
+    // broadcast it; the old `BuildAndSign` action no longer exists.
+    let action = es.action().map(|a| match a {
         NextAction::ProveAndBroadcast => MigrationTxAction::ProveAndBroadcast,
     });
-    let blocked_on = es.blocked_on.map(|b| match b {
+    let blocked_on = es.blocked_on().map(|b| match b {
         Blocker::Dependencies => MigrationTxBlocker::Dependencies,
         Blocker::Schedule => MigrationTxBlocker::Schedule,
         Blocker::Signature => MigrationTxBlocker::Signature,
     });
-    let txid = es.txid.map(|mut bytes| {
+    let txid = es.txid().map(|txid| {
+        let mut bytes = *txid.as_ref();
         bytes.reverse();
         hex::encode(bytes)
     });
     MigrationTransactionStatus {
-        id: es.id.0,
+        id: u32::from(es.id()),
         kind,
         layer,
         crossing,
         state,
-        depends_on: es.depends_on.iter().map(|d| d.0).collect(),
-        scheduled_height: es.scheduled_height,
-        ready: es.ready,
+        depends_on: es.depends_on().iter().map(|d| u32::from(*d)).collect(),
+        scheduled_height: es.scheduled_height().into(),
+        ready: es.ready(),
         action,
         blocked_on,
         txid,
-        mined_height: es.mined_height,
+        mined_height: es.mined_height().map(u32::from),
     }
 }
 
@@ -442,7 +462,7 @@ pub(crate) fn migration_transactions(
     target_height: u32,
 ) -> Vec<MigrationTransactionStatus> {
     state
-        .transaction_statuses(target_height)
+        .transaction_statuses(BlockHeight::from_u32(target_height))
         .into_iter()
         .map(to_rpc_status)
         .collect()

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -349,6 +349,10 @@ pub(crate) enum MigrationTxBlocker {
     /// Built and due only at a later height (the privacy broadcast schedule): waiting for the chain
     /// tip to reach its scheduled height.
     Schedule,
+    /// A transfer whose drawn anchor boundary has not yet settled: waiting for the chain tip to move
+    /// strictly past the boundary block so its checkpoint exists and the transfer can be proved
+    /// against it (while it is still within the wallet's checkpoint-pruning window).
+    AnchorBoundary,
     /// Built as an unsigned PCZT and waiting for an external (hardware or offline) signer to return
     /// the signed PCZT, which the wallet then applies before proving and broadcasting.
     Signature,
@@ -358,10 +362,12 @@ pub(crate) enum MigrationTxBlocker {
 #[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum MigrationTxAction {
-    /// Prove and broadcast this pre-signed transaction now that its dependencies are mined and it is
-    /// due. This is the only action a wallet ever takes: the whole migration is built and pre-signed
-    /// in one pass at start, so there is no separate build-and-sign step.
-    ProveAndBroadcast,
+    /// Prove this pre-signed transaction now (install its deferred anchor and witnesses and store the
+    /// proven PCZT): its dependencies are mined and, for a transfer, its anchor boundary has settled
+    /// within the wallet's checkpoint-pruning window. It is not broadcast yet.
+    Prove,
+    /// Broadcast this already-proven transaction now that its scheduled broadcast height has arrived.
+    Broadcast,
 }
 
 /// The status of one migration transaction, as a wallet renders it and decides the next step. This
@@ -422,14 +428,16 @@ fn to_rpc_status(es: EngineTransactionStatus) -> MigrationTransactionStatus {
         MigrationTxState::Broadcast { .. } => MigrationTxLifecycle::Broadcast,
         MigrationTxState::Mined { .. } => MigrationTxLifecycle::Mined,
     };
-    // With everything built up front, the only remaining per-transaction action is to prove and
-    // broadcast it; the old `BuildAndSign` action no longer exists.
+    // Everything is built up front, so a transaction is either proved (installing its anchor and
+    // witnesses) or, once proved, broadcast; the old `BuildAndSign` action no longer exists.
     let action = es.action().map(|a| match a {
-        NextAction::ProveAndBroadcast => MigrationTxAction::ProveAndBroadcast,
+        NextAction::Prove => MigrationTxAction::Prove,
+        NextAction::Broadcast => MigrationTxAction::Broadcast,
     });
     let blocked_on = es.blocked_on().map(|b| match b {
         Blocker::Dependencies => MigrationTxBlocker::Dependencies,
         Blocker::Schedule => MigrationTxBlocker::Schedule,
+        Blocker::AnchorBoundary => MigrationTxBlocker::AnchorBoundary,
         Blocker::Signature => MigrationTxBlocker::Signature,
     });
     let txid = es.txid().map(|txid| {

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -17,11 +17,15 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use schemars::JsonSchema;
+use secrecy::ExposeSecret;
 use serde::Serialize;
-use zcash_client_backend::data_api::WalletRead;
+use zcash_client_backend::data_api::{Account, WalletRead};
+use zcash_client_sqlite::AccountUuid;
+use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{MigrationState, MigrationStatus, MigrationTxState};
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
+use crate::components::keystore::KeyStore;
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
 use crate::migrate::CommitFailure;
 
@@ -162,6 +166,40 @@ pub(crate) fn validate_pool_pair(
             migration.enabling_upgrade,
         ))),
     }
+}
+
+/// Decrypts the account's unified spending key. This is the async step that must run BEFORE the
+/// blocking build/prove section (no `.await` may occur while the database write lock is held).
+/// Mirrors the send path: find the account's ZIP-32 derivation, decrypt its seed, and derive the
+/// spending key.
+pub(crate) async fn decrypt_account_usk(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account_id: AccountUuid,
+) -> RpcResult<UnifiedSpendingKey> {
+    let account = wallet
+        .get_account(account_id)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InvalidParameter.with_static("no such account"))?;
+    let derivation = account.source().key_derivation().ok_or_else(|| {
+        LegacyCode::InvalidAddressOrKey
+            .with_static("the account has no spending key to migrate with")
+    })?;
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+    UnifiedSpendingKey::from_seed(
+        wallet.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))
 }
 
 /// Validates that a migration identifier is well-formed (currently just non-empty).

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -8,10 +8,10 @@
 //! shapes and their mapping from the engine's state, and the input validation.
 //!
 //! `z_startpoolmigration` builds, pre-signs, and persists the migration; the status
-//! and list methods read the persisted state; cancel marks it cancelled. Proving and
-//! broadcasting the pre-signed transactions (`z_advancepoolmigration`) is the one step
-//! not yet wired into Zallet, because it needs the `pczt` prover and an Orchard proving
-//! key; until then a committed migration cannot make on-chain progress.
+//! and list methods read the persisted state; cancel marks it cancelled; and
+//! `z_advancepoolmigration` proves, broadcasts, and (for a multi-layer preparation)
+//! builds each later transaction as its dependencies mine, driving the migration to
+//! completion.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
@@ -267,8 +267,6 @@ pub(crate) fn map_commit_failure(failure: CommitFailure) -> ErrorObjectOwned {
     match failure {
         CommitFailure::NothingToMigrate => LegacyCode::InvalidParameter
             .with_static("the account has no spendable source-pool balance to migrate"),
-        CommitFailure::UnsupportedMultiLayer => LegacyCode::InvalidParameter
-            .with_static("this balance needs multi-layer preparation, which is not yet supported"),
         CommitFailure::NoMigrationInProgress => {
             LegacyCode::InvalidParameter.with_static("no migration is in progress")
         }
@@ -278,9 +276,7 @@ pub(crate) fn map_commit_failure(failure: CommitFailure) -> ErrorObjectOwned {
     }
 }
 
-/// The plan produced when a migration is scheduled.
-///
-/// Stubbed in the current scaffold; the fields describe the intended shape only.
+/// The plan produced when a migration is committed.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct MigrationPlan {
     /// The number of transactions the migration is expected to require.
@@ -288,56 +284,10 @@ pub(crate) struct MigrationPlan {
 }
 
 /// Progress of an in-flight migration.
-///
-/// Stubbed in the current scaffold; the fields describe the intended shape only.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct MigrationProgress {
     /// The number of planned transactions that have been mined so far.
     completed_transactions: u32,
     /// The total number of transactions the migration requires.
     total_transactions: u32,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn pool_round_trips_through_its_wire_name() {
-        for pool in [Pool::Sapling, Pool::Orchard, Pool::Ironwood] {
-            assert_eq!(Pool::parse("pool", pool.name()).unwrap(), pool);
-        }
-    }
-
-    #[test]
-    fn unknown_pool_is_rejected() {
-        assert!(Pool::parse("pool", "transparent").is_err());
-        assert!(Pool::parse("pool", "").is_err());
-    }
-
-    #[test]
-    fn every_supported_migration_has_distinct_pools() {
-        for migration in SUPPORTED_MIGRATIONS {
-            assert_ne!(migration.from, migration.to);
-        }
-    }
-
-    #[test]
-    fn orchard_to_ironwood_is_supported_and_requires_nu6_3() {
-        let migration = supported_migration(Pool::Orchard, Pool::Ironwood)
-            .expect("Orchard to Ironwood must be supported");
-        assert!(matches!(migration.enabling_upgrade, NetworkUpgrade::Nu6_3));
-    }
-
-    #[test]
-    fn unsupported_pairs_are_absent_from_the_table() {
-        assert!(supported_migration(Pool::Ironwood, Pool::Orchard).is_none());
-        assert!(supported_migration(Pool::Sapling, Pool::Orchard).is_none());
-    }
-
-    #[test]
-    fn blank_migration_id_is_rejected() {
-        assert!(validate_migration_id("   ").is_err());
-        assert!(validate_migration_id("m-1").is_ok());
-    }
 }

--- a/zallet-core/src/components/json_rpc/methods/pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/pool_migration.rs
@@ -22,7 +22,9 @@ use serde::Serialize;
 use zcash_client_backend::data_api::{Account, WalletRead};
 use zcash_client_sqlite::AccountUuid;
 use zcash_keys::keys::UnifiedSpendingKey;
-use zcash_pool_migration_backend::engine::{MigrationState, MigrationStatus, MigrationTxState};
+use zcash_pool_migration_backend::engine::{
+    MigrationState, MigrationStatus, MigrationTxId, MigrationTxKind, MigrationTxState,
+};
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
 use crate::components::keystore::KeyStore;
@@ -254,6 +256,194 @@ pub(crate) fn migration_progress(state: &MigrationState) -> MigrationProgress {
         completed_transactions,
         total_transactions,
     }
+}
+
+/// Whether this is a preparation (note-splitting) or a transfer (pool-crossing) transaction.
+#[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MigrationTxRole {
+    /// A same-pool note-preparation transaction that mints self-funding notes.
+    Preparation,
+    /// A transfer that crosses one funding note into the destination pool.
+    Transfer,
+}
+
+/// The lifecycle state of one migration transaction.
+#[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MigrationTxLifecycle {
+    /// A placeholder that is not yet built or signed (it awaits its dependencies).
+    Planned,
+    /// Built and pre-signed, ready to prove and broadcast once it is due.
+    Signed,
+    /// Proved against a real anchor, ready to broadcast.
+    Proved,
+    /// Broadcast to the network, awaiting confirmation.
+    Broadcast,
+    /// Mined into a block.
+    Mined,
+    /// Expired before it could be mined; the wallet rebuilds and re-signs it.
+    Expired,
+}
+
+/// Why a migration transaction is not yet actionable.
+#[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MigrationTxBlocker {
+    /// Waiting for its dependency transactions (an earlier preparation layer, or the whole
+    /// preparation) to mine, so its input notes become witnessable in a new anchor bucket. A
+    /// multi-layer preparation signs and broadcasts each layer in a separate anchor bucket, so a
+    /// later layer cannot be built until its predecessor has mined.
+    Dependencies,
+    /// Built and due only at a later height (the privacy broadcast schedule): waiting for the chain
+    /// tip to reach its scheduled height.
+    Schedule,
+}
+
+/// The action a wallet takes next on a ready migration transaction.
+#[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MigrationTxAction {
+    /// Build and pre-sign this placeholder now that its dependencies are mined (a later preparation
+    /// layer, or the transfers once the whole preparation is mined).
+    BuildAndSign,
+    /// Prove and broadcast this pre-signed transaction now that its dependencies are mined and it is
+    /// due.
+    ProveAndBroadcast,
+}
+
+/// The status of one migration transaction, as a wallet renders it and decides the next step. This
+/// is the machine-readable companion to the human status string: a mobile wallet, which cannot
+/// pre-sign a multi-layer migration up front and may be restarted between layers, uses it to show
+/// the user which transaction to sign or broadcast next and what the rest are waiting on.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct MigrationTransactionStatus {
+    /// Stable identifier of this transaction within the migration.
+    id: u32,
+    /// Whether this is a preparation or a transfer transaction.
+    kind: MigrationTxRole,
+    /// For a preparation transaction, its layer, which is also its anchor bucket: layer 0 is signed
+    /// first, and each later layer is signed only once its predecessor has mined. Absent for
+    /// transfers.
+    layer: Option<u32>,
+    /// For a transfer, which crossing it performs. Absent for preparation transactions.
+    crossing: Option<u32>,
+    /// The transaction's current lifecycle state.
+    state: MigrationTxLifecycle,
+    /// The transactions that must be mined before this one can be built or broadcast.
+    depends_on: Vec<u32>,
+    /// The height at or after which this transaction is due to broadcast.
+    scheduled_height: u32,
+    /// Whether the wallet can act on this transaction right now.
+    ready: bool,
+    /// The action available now, when `ready` is true.
+    action: Option<MigrationTxAction>,
+    /// Why the transaction is not yet actionable, when it is waiting (and not already broadcast or
+    /// mined).
+    blocked_on: Option<MigrationTxBlocker>,
+    /// The transaction id, once broadcast (hex, big-endian display form).
+    txid: Option<String>,
+    /// The height it was mined at, once mined.
+    mined_height: Option<u32>,
+}
+
+/// Whether every id in `deps` names a transaction that is mined in `state`.
+fn deps_all_mined(state: &MigrationState, deps: &[MigrationTxId]) -> bool {
+    deps.iter().all(|d| {
+        state
+            .transactions
+            .iter()
+            .find(|t| t.id == *d)
+            .is_some_and(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+    })
+}
+
+/// Builds the per-transaction status view for a migration at `target_height` (the height the next
+/// transaction would build at, i.e. `chain_tip + 1`), so a wallet can render progress and decide,
+/// deterministically and from persisted state alone, the next transaction to sign or broadcast.
+///
+/// A transaction is `ready` when the wallet can act on it now: a `Planned` placeholder whose
+/// dependencies are all mined can be built and signed; a `Signed` transaction whose dependencies are
+/// mined and whose scheduled height has arrived can be proved and broadcast. Otherwise a waiting
+/// transaction reports what it is `blocked_on` (its dependencies, or the schedule).
+pub(crate) fn migration_transactions(
+    state: &MigrationState,
+    target_height: u32,
+) -> Vec<MigrationTransactionStatus> {
+    state
+        .transactions
+        .iter()
+        .map(|t| {
+            let (kind, layer, crossing) = match t.kind {
+                MigrationTxKind::Preparation { layer, .. } => {
+                    (MigrationTxRole::Preparation, Some(layer as u32), None)
+                }
+                MigrationTxKind::Transfer { crossing } => {
+                    (MigrationTxRole::Transfer, None, Some(crossing as u32))
+                }
+            };
+            let deps_mined = deps_all_mined(state, &t.depends_on);
+            // `Planned`/`Expired` need building; `Signed`/`Proved` need broadcasting. In both cases a
+            // transaction is actionable only once its dependencies (the prior anchor bucket) are
+            // mined, and a broadcastable one only once it is also due.
+            let (lifecycle, ready, action, blocked_on) = match t.state {
+                MigrationTxState::Planned | MigrationTxState::Expired => {
+                    let lc = match t.state {
+                        MigrationTxState::Expired => MigrationTxLifecycle::Expired,
+                        _ => MigrationTxLifecycle::Planned,
+                    };
+                    if deps_mined {
+                        (lc, true, Some(MigrationTxAction::BuildAndSign), None)
+                    } else {
+                        (lc, false, None, Some(MigrationTxBlocker::Dependencies))
+                    }
+                }
+                MigrationTxState::Signed | MigrationTxState::Proved => {
+                    let lc = match t.state {
+                        MigrationTxState::Proved => MigrationTxLifecycle::Proved,
+                        _ => MigrationTxLifecycle::Signed,
+                    };
+                    if !deps_mined {
+                        (lc, false, None, Some(MigrationTxBlocker::Dependencies))
+                    } else if t.scheduled_height <= target_height {
+                        (lc, true, Some(MigrationTxAction::ProveAndBroadcast), None)
+                    } else {
+                        (lc, false, None, Some(MigrationTxBlocker::Schedule))
+                    }
+                }
+                MigrationTxState::Broadcast { .. } => {
+                    (MigrationTxLifecycle::Broadcast, false, None, None)
+                }
+                MigrationTxState::Mined { .. } => (MigrationTxLifecycle::Mined, false, None, None),
+            };
+            let txid = match t.state {
+                MigrationTxState::Broadcast { txid } => {
+                    let mut bytes = txid;
+                    bytes.reverse();
+                    Some(hex::encode(bytes))
+                }
+                _ => None,
+            };
+            let mined_height = match t.state {
+                MigrationTxState::Mined { height } => Some(height),
+                _ => None,
+            };
+            MigrationTransactionStatus {
+                id: t.id.0,
+                kind,
+                layer,
+                crossing,
+                state: lifecycle,
+                depends_on: t.depends_on.iter().map(|d| d.0).collect(),
+                scheduled_height: t.scheduled_height,
+                ready,
+                action,
+                blocked_on,
+                txid,
+                mined_height,
+            }
+        })
+        .collect()
 }
 
 /// The RPC error for a migration id that does not name the wallet's migration, or when no migration

--- a/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
@@ -1,0 +1,323 @@
+//! `z_previewpoolmigration`: preview the note-split plan for a pool migration.
+//!
+//! Unlike the rest of the pool-migration surface (which is still a scaffold; see
+//! [`pool_migration`](super::pool_migration)), this method is fully wired: it reads the
+//! account's spendable balance in the source pool and runs the backend-agnostic
+//! note-split planner (`zcash_ironwood_migration_backend::note_splitting`) to show how
+//! that balance would be decomposed into the self-funding notes that cross the
+//! Orchard -> Ironwood turnstile.
+//!
+//! It is READ-ONLY: it computes and returns a plan but schedules, builds, proves, and
+//! broadcasts nothing. Actually carrying out a migration needs the (still-unreleased)
+//! Ironwood PCZT builder APIs, so that path stays behind [`not_implemented`] in
+//! `z_startpoolmigration`. This preview is the achievable planning slice today.
+
+use std::num::NonZeroU32;
+
+use documented::Documented;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use rand::rngs::OsRng;
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_client_backend::data_api::{AccountBalance, WalletRead, wallet::ConfirmationsPolicy};
+use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
+use zcash_protocol::value::Zatoshis;
+
+use super::pool_migration::{Pool, validate_pool_pair};
+use crate::{
+    components::{
+        database::DbConnection,
+        json_rpc::{server::LegacyCode, utils::parse_account_parameter},
+        keystore::KeyStore,
+    },
+    migrate::engine::note_splitting::{
+        CanonicalPowerOfTen, DenominationStrategy, NoteSplitPlan, RandomizedOneTwoFive,
+    },
+};
+
+/// Response to a `z_previewpoolmigration` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = PoolMigrationPreview;
+
+pub(super) const PARAM_ACCOUNT_DESC: &str =
+    "Either the UUID or ZIP 32 account index of the account whose balance to migrate.";
+pub(super) const PARAM_FROM_POOL_DESC: &str =
+    "The value pool to migrate funds from (\"sapling\", \"orchard\", or \"ironwood\").";
+pub(super) const PARAM_TO_POOL_DESC: &str =
+    "The value pool to migrate funds to (\"sapling\", \"orchard\", or \"ironwood\").";
+pub(super) const PARAM_MINCONF_DESC: &str =
+    "Only include outputs in transactions confirmed at least this many times.";
+pub(super) const PARAM_STRATEGY_DESC: &str =
+    "The denomination strategy to preview: \"randomized\" (default) or \"canonical\".";
+
+/// Wire name of the randomized `{1, 2, 5} * 10^k` denomination strategy.
+const STRATEGY_RANDOMIZED: &str = "randomized";
+/// Wire name of the deterministic canonical power-of-ten denomination strategy.
+const STRATEGY_CANONICAL: &str = "canonical";
+
+/// The proposed note-split plan for migrating an account's balance between two pools.
+///
+/// Read-only preview of the decomposition produced by the note-split planner. Nothing is
+/// scheduled or broadcast; the fields describe what a migration run would prepare.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct PoolMigrationPreview {
+    /// The value pool funds would be migrated from.
+    from_pool: Pool,
+    /// The value pool funds would be migrated to.
+    to_pool: Pool,
+    /// The network upgrade that enables this migration (for example `"Nu6.3"`).
+    enabling_upgrade: String,
+    /// The denomination strategy this plan was computed with (`"randomized"` or
+    /// `"canonical"`).
+    strategy: String,
+    /// The account's total spendable balance in the source pool, in zatoshis.
+    account_balance_zat: u64,
+    /// The fee (in zatoshis) reserved for the note-split ("prep") transaction before
+    /// decomposition.
+    ///
+    /// This preview reserves the ZIP-317 minimum fee; the final prep fee is computed by
+    /// the migration engine when the build path is wired in.
+    prep_fee_zat: u64,
+    /// The total input (in zatoshis) the plan decomposes (equal to
+    /// `account_balance_zat`).
+    total_input_zat: u64,
+    /// The total value (in zatoshis) that would migrate to the destination pool: the sum
+    /// of the crossing values.
+    total_migratable_zat: u64,
+    /// Residual (in zatoshis) left in the source pool because it could not form a whole
+    /// self-funding note (or the note cap was reached). Zero if the balance was consumed
+    /// exactly.
+    source_change_zat: u64,
+    /// The number of self-funding notes the split would prepare.
+    note_count: u32,
+    /// The per-note breakdown, one entry per prepared note.
+    notes: Vec<PreviewNote>,
+}
+
+/// One prepared note in a [`PoolMigrationPreview`].
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub(crate) struct PreviewNote {
+    /// The value (in zatoshis) of the prepared note: its crossing value plus the fee
+    /// buffer that lets it pay its own migration-transfer fee.
+    output_zat: u64,
+    /// The denomination value (in zatoshis) that crosses the turnstile when this note is
+    /// spent.
+    crossing_zat: u64,
+}
+
+/// Validates the requested denomination strategy and returns its canonical wire name,
+/// defaulting to the recommended randomized strategy.
+///
+/// Kept separate from [`build_strategy`] so the (cheap) validation runs before any wallet
+/// I/O, and so the non-`Send` strategy object is only constructed after the last `.await`.
+fn strategy_name(strategy: Option<&str>) -> RpcResult<&'static str> {
+    match strategy.unwrap_or(STRATEGY_RANDOMIZED) {
+        STRATEGY_RANDOMIZED => Ok(STRATEGY_RANDOMIZED),
+        STRATEGY_CANONICAL => Ok(STRATEGY_CANONICAL),
+        other => Err(LegacyCode::InvalidParameter.with_message(format!(
+            "strategy: unknown denomination strategy {other:?}; expected \
+             {STRATEGY_RANDOMIZED:?} or {STRATEGY_CANONICAL:?}",
+        ))),
+    }
+}
+
+/// Constructs the denomination strategy for a canonical name returned by
+/// [`strategy_name`]. The name is assumed already validated.
+fn build_strategy(name: &str) -> Box<dyn DenominationStrategy> {
+    match name {
+        STRATEGY_CANONICAL => Box::new(CanonicalPowerOfTen::zip_draft()),
+        // Any already-validated name other than canonical is the randomized default.
+        _ => Box::new(RandomizedOneTwoFive::recommended()),
+    }
+}
+
+/// Returns the spendable balance the given pool holds in the supplied account balance.
+fn spendable_in_pool(account_balance: &AccountBalance, pool: Pool) -> Zatoshis {
+    match pool {
+        Pool::Sapling => account_balance.sapling_balance().spendable_value(),
+        Pool::Orchard => account_balance.orchard_balance().spendable_value(),
+        Pool::Ironwood => account_balance.ironwood_balance().spendable_value(),
+    }
+}
+
+pub(crate) async fn call(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account: JsonValue,
+    from_pool: &str,
+    to_pool: &str,
+    minconf: Option<u32>,
+    strategy: Option<String>,
+) -> Response {
+    let (from_pool, to_pool, enabling_upgrade) = validate_pool_pair(wallet, from_pool, to_pool)?;
+    // Validate the strategy name before any wallet I/O; the strategy object itself is not
+    // `Send`, so it is built below, after the last `.await`.
+    let strategy_name = strategy_name(strategy.as_deref())?;
+    let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+
+    let confirmations_policy = match minconf.and_then(NonZeroU32::new) {
+        Some(c) => ConfirmationsPolicy::new_symmetrical(c, false),
+        None => ConfirmationsPolicy::new_symmetrical(NonZeroU32::MIN, true),
+    };
+
+    let summary = wallet
+        .get_wallet_summary(confirmations_policy)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+
+    let account_balance = summary.account_balances().get(&account_id).ok_or_else(|| {
+        LegacyCode::InvalidParameter.with_message(format!(
+            "Error: account {account} has not been generated by z_getnewaccount."
+        ))
+    })?;
+
+    let total_input_zat = spendable_in_pool(account_balance, from_pool).into_u64();
+    let prep_fee_zat = MINIMUM_FEE.into_u64();
+
+    // No `.await` past this point: build the (non-`Send`) strategy and plan synchronously.
+    let mut rng = OsRng;
+    let plan = build_strategy(strategy_name).plan(total_input_zat, prep_fee_zat, &mut rng);
+
+    Ok(preview_from_plan(
+        from_pool,
+        to_pool,
+        enabling_upgrade.to_string(),
+        strategy_name.to_string(),
+        total_input_zat,
+        &plan,
+    ))
+}
+
+/// Assembles the RPC response from a computed note-split plan.
+///
+/// Kept pure (no wallet access) so the response contract can be unit-tested directly
+/// against a plan.
+fn preview_from_plan(
+    from_pool: Pool,
+    to_pool: Pool,
+    enabling_upgrade: String,
+    strategy: String,
+    account_balance_zat: u64,
+    plan: &NoteSplitPlan,
+) -> PoolMigrationPreview {
+    let notes = plan
+        .migration_outputs()
+        .iter()
+        .zip(plan.crossing_values())
+        .map(|(&output_zat, &crossing_zat)| PreviewNote {
+            output_zat,
+            crossing_zat,
+        })
+        .collect::<Vec<_>>();
+
+    PoolMigrationPreview {
+        from_pool,
+        to_pool,
+        enabling_upgrade,
+        strategy,
+        account_balance_zat,
+        prep_fee_zat: plan.prep_fee_zatoshi(),
+        total_input_zat: plan.total_input_zatoshi(),
+        total_migratable_zat: plan.total_migratable_zatoshi(),
+        source_change_zat: plan.orchard_change().unwrap_or(0),
+        note_count: notes.len() as u32,
+        notes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::OsRng;
+    use zcash_protocol::value::COIN;
+
+    use super::*;
+    use crate::migrate::engine::note_splitting::plan_note_split;
+
+    #[test]
+    fn strategy_name_defaults_to_randomized() {
+        assert_eq!(strategy_name(None).unwrap(), STRATEGY_RANDOMIZED);
+    }
+
+    #[test]
+    fn strategy_name_parses_known_strategies() {
+        assert_eq!(
+            strategy_name(Some("randomized")).unwrap(),
+            STRATEGY_RANDOMIZED
+        );
+        assert_eq!(
+            strategy_name(Some("canonical")).unwrap(),
+            STRATEGY_CANONICAL
+        );
+    }
+
+    #[test]
+    fn strategy_name_rejects_unknown() {
+        assert!(strategy_name(Some("bogus")).is_err());
+        assert!(strategy_name(Some("")).is_err());
+    }
+
+    #[test]
+    fn preview_conserves_value_and_reports_notes() {
+        // Decompose a sample Orchard balance and check the response mirrors the plan and
+        // conserves value: migratable + change + prep fee + fee buffers == input.
+        let prep_fee = MINIMUM_FEE.into_u64();
+        let total_input = 723 * COIN;
+
+        let mut rng = OsRng;
+        let plan = plan_note_split(total_input, prep_fee, &mut rng);
+
+        let preview = preview_from_plan(
+            Pool::Orchard,
+            Pool::Ironwood,
+            "Nu6.3".to_string(),
+            STRATEGY_RANDOMIZED.to_string(),
+            total_input,
+            &plan,
+        );
+
+        assert_eq!(preview.account_balance_zat, total_input);
+        assert_eq!(preview.total_input_zat, total_input);
+        assert_eq!(preview.prep_fee_zat, prep_fee);
+        assert_eq!(preview.note_count as usize, preview.notes.len());
+        assert_eq!(preview.notes.len(), plan.migration_outputs().len());
+
+        // Every crossing value is positive and each output covers its crossing.
+        let crossings_sum: u64 = preview.notes.iter().map(|n| n.crossing_zat).sum();
+        for note in &preview.notes {
+            assert!(note.crossing_zat > 0);
+            assert!(note.output_zat >= note.crossing_zat);
+        }
+        assert_eq!(preview.total_migratable_zat, crossings_sum);
+
+        // Value conservation: the prepared notes plus the residual plus the reserved prep
+        // fee never exceed the input.
+        let notes_total: u64 = preview.notes.iter().map(|n| n.output_zat).sum();
+        assert_eq!(
+            notes_total + preview.source_change_zat + preview.prep_fee_zat,
+            total_input
+        );
+    }
+
+    #[test]
+    fn preview_of_dust_balance_migrates_nothing() {
+        // A balance below the smallest self-funding note migrates nothing and is kept as
+        // change.
+        let prep_fee = MINIMUM_FEE.into_u64();
+        let total_input = prep_fee + 1;
+
+        let mut rng = OsRng;
+        let plan = plan_note_split(total_input, prep_fee, &mut rng);
+        let preview = preview_from_plan(
+            Pool::Orchard,
+            Pool::Ironwood,
+            "Nu6.3".to_string(),
+            STRATEGY_RANDOMIZED.to_string(),
+            total_input,
+            &plan,
+        );
+
+        assert_eq!(preview.note_count, 0);
+        assert_eq!(preview.total_migratable_zat, 0);
+        assert!(preview.notes.is_empty());
+    }
+}

--- a/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
@@ -33,8 +33,7 @@ use crate::{
         SpendableSnapshot,
         engine::{
             engine::{MigrationError, MigrationPlan, plan_migration},
-            note_splitting::{FeePolicy, Zip317FeePolicy},
-            preparation::{PREP_TX_ACTIONS, PreparationPlan},
+            preparation::PreparationPlan,
         },
     },
 };
@@ -177,14 +176,13 @@ pub(crate) async fn call(
 
     let account_balance_zat: u64 = orchard_note_values.iter().sum();
 
-    // The ZIP-317 fee of a padded note-preparation transaction, which the note split and the
-    // preparation planner both reserve. Built from the crate's own constants (no magic numbers).
-    let prep_fee_zat = PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi();
-
-    // No `.await` past this point: build the snapshot backend and run the pure planner synchronously.
+    // No `.await` past this point: build the snapshot backend and run the pure planner
+    // synchronously. The engine now owns the preparation fee internally (its ZIP-317 fee policy), so
+    // planning takes only the network and the spendable-note snapshot.
+    let network = wallet.params();
     let backend = SpendableSnapshot::new(orchard_note_values, u32::from(chain_height));
     let mut rng = OsRng;
-    let plan = plan_migration(&backend, prep_fee_zat, &mut rng).map_err(map_plan_error)?;
+    let plan = plan_migration(network, &backend, &mut rng).map_err(map_plan_error)?;
 
     Ok(preview_from_plan(
         from_pool,
@@ -205,6 +203,12 @@ fn map_plan_error(
         MigrationError::Preparation(e) => LegacyCode::InvalidParameter.with_message(format!(
             "the spendable notes cannot fund the migration: {e}"
         )),
+        MigrationError::InvalidBalance(e) => LegacyCode::InvalidParameter
+            .with_message(format!("the account balance is invalid: {e}")),
+        MigrationError::Fee(e) => LegacyCode::InvalidParameter
+            .with_message(format!("the migration fee could not be computed: {e}")),
+        MigrationError::Nu63NotActive => LegacyCode::InvalidParameter
+            .with_static("NU6.3 (the Ironwood pool) is not active at the target height"),
         // The planning snapshot's read methods are infallible, so this arm is unreachable.
         MigrationError::Backend(e) => match e {},
     }
@@ -222,17 +226,20 @@ fn preview_from_plan(
 ) -> PoolMigrationPreview {
     // Each funding note holds its crossing value plus a fixed transfer fee buffer, so the crossing
     // value is the funding note less that buffer.
-    let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+    let buffer = u64::from(plan.note_split().note_fee_buffer());
 
     let funding_notes = plan
         .funding_notes()
         .iter()
         .zip(plan.schedule())
-        .map(|(&output_zat, schedule)| PreviewFundingNote {
-            output_zat,
-            crossing_zat: output_zat.saturating_sub(buffer),
-            broadcast_height: schedule.broadcast_height(),
-            expiry_height: schedule.expiry_height(),
+        .map(|(&output_zat, schedule)| {
+            let output_zat = u64::from(output_zat);
+            PreviewFundingNote {
+                output_zat,
+                crossing_zat: output_zat.saturating_sub(buffer),
+                broadcast_height: u32::from(schedule.broadcast_height()),
+                expiry_height: u32::from(schedule.expiry_height()),
+            }
         })
         .collect::<Vec<_>>();
 
@@ -243,15 +250,20 @@ fn preview_from_plan(
         to_pool,
         enabling_upgrade,
         account_balance_zat,
-        prep_fee_zat: plan.note_split().prep_fee_zatoshi(),
+        prep_fee_zat: u64::from(plan.note_split().prep_fees()),
         total_migratable_zat,
-        source_change_zat: plan.note_split().change().unwrap_or(0),
+        source_change_zat: plan.note_split().change().map(u64::from).unwrap_or(0),
         funding_note_count: funding_notes.len() as u32,
         funding_notes,
         note_split: PreviewNoteSplit {
             note_count: plan.note_split().crossing_values().len() as u32,
-            total_migratable_zat: plan.note_split().total_migratable_zatoshi(),
-            crossing_values: plan.note_split().crossing_values().to_vec(),
+            total_migratable_zat: u64::from(plan.note_split().total_migratable()),
+            crossing_values: plan
+                .note_split()
+                .crossing_values()
+                .iter()
+                .map(|&z| u64::from(z))
+                .collect(),
         },
         preparation: preparation_summary(plan.preparation()),
     }
@@ -273,6 +285,9 @@ mod tests {
 
     use super::*;
     use crate::migrate::engine::engine::MigrationBackend;
+    use crate::network::{Network, RegTestNuParam};
+    use zcash_protocol::consensus::{BlockHeight, BranchId, NetworkType};
+    use zcash_protocol::value::Zatoshis;
 
     /// A minimal planning backend for tests: a fixed set of spendable note values and a chain tip.
     /// Mirrors `SpendableSnapshot`; planning is infallible.
@@ -284,18 +299,27 @@ mod tests {
     impl MigrationBackend for MockBackend {
         type Error = core::convert::Infallible;
 
-        fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
-            Ok(self.notes.clone())
+        fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+            Ok(self
+                .notes
+                .iter()
+                .map(|&v| Zatoshis::from_u64(v).expect("a test note value is valid"))
+                .collect())
         }
 
-        fn chain_tip_height(&self) -> Result<u32, Self::Error> {
-            Ok(self.tip)
+        fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+            Ok(BlockHeight::from_u32(self.tip))
         }
     }
 
-    /// The ZIP-317 fee the preview reserves, as `call` computes it.
-    fn prep_fee() -> u64 {
-        PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
+    /// A regtest network with NU6.3 (the Ironwood pool) active from height 1, so a migration plans
+    /// against any chain tip.
+    fn regtest_nu63() -> Network {
+        let params = [
+            RegTestNuParam::try_from(format!("{:08x}:1", u32::from(BranchId::Nu6_3)))
+                .expect("a valid regtest nuparam"),
+        ];
+        Network::from_type(NetworkType::Regtest, &params)
     }
 
     #[test]
@@ -309,8 +333,9 @@ mod tests {
             notes,
             tip: 2_000_000,
         };
+        let network = regtest_nu63();
         let mut rng = OsRng;
-        let plan = plan_migration(&backend, prep_fee(), &mut rng).expect("a funded balance plans");
+        let plan = plan_migration(&network, &backend, &mut rng).expect("a funded balance plans");
 
         let preview = preview_from_plan(
             Pool::Orchard,
@@ -321,7 +346,10 @@ mod tests {
         );
 
         assert_eq!(preview.account_balance_zat, account_balance_zat);
-        assert_eq!(preview.prep_fee_zat, prep_fee());
+        assert_eq!(
+            preview.prep_fee_zat,
+            u64::from(plan.note_split().prep_fees())
+        );
         assert_eq!(
             preview.funding_note_count as usize,
             preview.funding_notes.len()
@@ -331,7 +359,7 @@ mod tests {
         // One schedule entry per funding note (the engine guarantees this).
         assert_eq!(preview.funding_notes.len(), plan.schedule().len());
 
-        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let buffer = u64::from(plan.note_split().note_fee_buffer());
         let mut crossings_sum = 0u64;
         for note in &preview.funding_notes {
             assert!(note.crossing_zat > 0, "every crossing value is positive");
@@ -360,9 +388,10 @@ mod tests {
             notes: Vec::new(),
             tip: 2_000_000,
         };
+        let network = regtest_nu63();
         let mut rng = OsRng;
         assert!(matches!(
-            plan_migration(&backend, prep_fee(), &mut rng),
+            plan_migration(&network, &backend, &mut rng),
             Err(MigrationError::NothingToMigrate)
         ));
     }

--- a/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
@@ -33,7 +33,7 @@ use crate::{
         keystore::KeyStore,
     },
     migrate::{
-        SnapshotError, SpendableSnapshot,
+        SpendableSnapshot,
         engine::{
             engine::{MigrationError, MigrationPlan, plan_migration},
             note_splitting::{FeePolicy, Zip317FeePolicy},
@@ -199,16 +199,17 @@ pub(crate) async fn call(
 }
 
 /// Maps a migration-planning error to an RPC error.
-fn map_plan_error(err: MigrationError<SnapshotError>) -> jsonrpsee::types::ErrorObjectOwned {
+fn map_plan_error(
+    err: MigrationError<core::convert::Infallible>,
+) -> jsonrpsee::types::ErrorObjectOwned {
     match err {
         MigrationError::NothingToMigrate => LegacyCode::InvalidParameter
             .with_static("the account has no spendable source-pool balance to migrate"),
         MigrationError::Preparation(e) => LegacyCode::InvalidParameter.with_message(format!(
             "the spendable notes cannot fund the migration: {e}"
         )),
-        // Planning calls only the snapshot's read methods, which never fail; a backend error here
-        // would indicate a future change to `plan_migration`, so surface it rather than hide it.
-        MigrationError::Backend(e) => LegacyCode::Misc.with_message(format!("{e}")),
+        // The planning snapshot's read methods are infallible, so this arm is unreachable.
+        MigrationError::Backend(e) => match e {},
     }
 }
 
@@ -274,19 +275,17 @@ mod tests {
     use zcash_protocol::value::COIN;
 
     use super::*;
-    use crate::migrate::engine::engine::{
-        MigrationBackend, MigrationState, MigrationTxId, MigrationTxState,
-    };
+    use crate::migrate::engine::engine::MigrationBackend;
 
     /// A minimal planning backend for tests: a fixed set of spendable note values and a chain tip.
-    /// Persistence is unsupported (planning never uses it), mirroring `SpendableSnapshot`.
+    /// Mirrors `SpendableSnapshot`; planning is infallible.
     struct MockBackend {
         notes: Vec<u64>,
         tip: u32,
     }
 
     impl MigrationBackend for MockBackend {
-        type Error = SnapshotError;
+        type Error = core::convert::Infallible;
 
         fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
             Ok(self.notes.clone())
@@ -294,22 +293,6 @@ mod tests {
 
         fn chain_tip_height(&self) -> Result<u32, Self::Error> {
             Ok(self.tip)
-        }
-
-        fn store_migration(&mut self, _state: &MigrationState) -> Result<(), Self::Error> {
-            Err(SnapshotError::PersistenceUnsupported)
-        }
-
-        fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
-            Ok(None)
-        }
-
-        fn update_transaction(
-            &mut self,
-            _id: MigrationTxId,
-            _state: MigrationTxState,
-        ) -> Result<(), Self::Error> {
-            Err(SnapshotError::PersistenceUnsupported)
         }
     }
 

--- a/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
@@ -1,18 +1,15 @@
 //! `z_previewpoolmigration`: preview the migration plan for a pool migration.
 //!
-//! Unlike the rest of the pool-migration surface (which is still a scaffold; see
-//! [`pool_migration`](super::pool_migration)), this method is fully wired: it enumerates the
-//! account's spendable source-pool (Orchard) notes and runs the backend-agnostic migration
-//! engine's PLANNING slice (`zcash_pool_migration_backend::engine::plan_migration`) to show how
-//! that balance would be decomposed into the self-funding notes that cross the Orchard -> Ironwood
-//! turnstile, when each note's transfer is scheduled to broadcast, and when it expires.
+//! This method enumerates the account's spendable source-pool (Orchard) notes and runs the
+//! backend-agnostic migration engine's PLANNING slice
+//! (`zcash_pool_migration_backend::engine::plan_migration`) to show how that balance would be
+//! decomposed into the self-funding notes that cross the Orchard -> Ironwood turnstile, when each
+//! note's transfer is scheduled to broadcast, and when it expires.
 //!
 //! It is READ-ONLY: it computes and returns a plan but schedules, builds, proves, and broadcasts
-//! nothing. Actually carrying out a migration needs the (still-unreleased) engine `commit` and
-//! reconcile slices that build, pre-sign, and persist the PCZTs, so that path stays behind
-//! [`not_implemented`](super::pool_migration::not_implemented) in `z_startpoolmigration`. This
-//! preview is the achievable planning slice today, and the preview a wallet shows the user for
-//! consent (ZIP 318 requires consent to the pool-crossing amounts before any funds leave the pool).
+//! nothing. `z_startpoolmigration` commits the plan (building and pre-signing the PCZTs) and
+//! `z_advancepoolmigration` drives it. This preview is the plan a wallet shows the user for consent
+//! (ZIP 318 requires consent to the pool-crossing amounts before any funds leave the pool).
 
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};

--- a/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/preview_pool_migration.rs
@@ -1,27 +1,29 @@
-//! `z_previewpoolmigration`: preview the note-split plan for a pool migration.
+//! `z_previewpoolmigration`: preview the migration plan for a pool migration.
 //!
 //! Unlike the rest of the pool-migration surface (which is still a scaffold; see
-//! [`pool_migration`](super::pool_migration)), this method is fully wired: it reads the
-//! account's spendable balance in the source pool and runs the backend-agnostic
-//! note-split planner (`zcash_ironwood_migration_backend::note_splitting`) to show how
-//! that balance would be decomposed into the self-funding notes that cross the
-//! Orchard -> Ironwood turnstile.
+//! [`pool_migration`](super::pool_migration)), this method is fully wired: it enumerates the
+//! account's spendable source-pool (Orchard) notes and runs the backend-agnostic migration
+//! engine's PLANNING slice (`zcash_pool_migration_backend::engine::plan_migration`) to show how
+//! that balance would be decomposed into the self-funding notes that cross the Orchard -> Ironwood
+//! turnstile, when each note's transfer is scheduled to broadcast, and when it expires.
 //!
-//! It is READ-ONLY: it computes and returns a plan but schedules, builds, proves, and
-//! broadcasts nothing. Actually carrying out a migration needs the (still-unreleased)
-//! Ironwood PCZT builder APIs, so that path stays behind [`not_implemented`] in
-//! `z_startpoolmigration`. This preview is the achievable planning slice today.
-
-use std::num::NonZeroU32;
+//! It is READ-ONLY: it computes and returns a plan but schedules, builds, proves, and broadcasts
+//! nothing. Actually carrying out a migration needs the (still-unreleased) engine `commit` and
+//! reconcile slices that build, pre-sign, and persist the PCZTs, so that path stays behind
+//! [`not_implemented`](super::pool_migration::not_implemented) in `z_startpoolmigration`. This
+//! preview is the achievable planning slice today, and the preview a wallet shows the user for
+//! consent (ZIP 318 requires consent to the pool-crossing amounts before any funds leave the pool).
 
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
 use rand::rngs::OsRng;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_client_backend::data_api::{AccountBalance, WalletRead, wallet::ConfirmationsPolicy};
-use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
-use zcash_protocol::value::Zatoshis;
+use zcash_client_backend::{
+    data_api::{InputSource, WalletRead, wallet::TargetHeight},
+    fees::orchard::InputView as _,
+};
+use zcash_protocol::ShieldedPool;
 
 use super::pool_migration::{Pool, validate_pool_pair};
 use crate::{
@@ -30,8 +32,13 @@ use crate::{
         json_rpc::{server::LegacyCode, utils::parse_account_parameter},
         keystore::KeyStore,
     },
-    migrate::engine::note_splitting::{
-        CanonicalPowerOfTen, DenominationStrategy, NoteSplitPlan, RandomizedOneTwoFive,
+    migrate::{
+        SnapshotError, SpendableSnapshot,
+        engine::{
+            engine::{MigrationError, MigrationPlan, plan_migration},
+            note_splitting::{FeePolicy, Zip317FeePolicy},
+            preparation::{PREP_TX_ACTIONS, PreparationPlan},
+        },
     },
 };
 
@@ -46,19 +53,15 @@ pub(super) const PARAM_FROM_POOL_DESC: &str =
 pub(super) const PARAM_TO_POOL_DESC: &str =
     "The value pool to migrate funds to (\"sapling\", \"orchard\", or \"ironwood\").";
 pub(super) const PARAM_MINCONF_DESC: &str =
-    "Only include outputs in transactions confirmed at least this many times.";
-pub(super) const PARAM_STRATEGY_DESC: &str =
-    "The denomination strategy to preview: \"randomized\" (default) or \"canonical\".";
+    "Only include source-pool notes confirmed at least this many times (default 1).";
 
-/// Wire name of the randomized `{1, 2, 5} * 10^k` denomination strategy.
-const STRATEGY_RANDOMIZED: &str = "randomized";
-/// Wire name of the deterministic canonical power-of-ten denomination strategy.
-const STRATEGY_CANONICAL: &str = "canonical";
+/// The default minimum number of confirmations a source-pool note must have to be planned over.
+const DEFAULT_MINCONF: u32 = 1;
 
-/// The proposed note-split plan for migrating an account's balance between two pools.
+/// The proposed migration plan for moving an account's balance between two pools.
 ///
-/// Read-only preview of the decomposition produced by the note-split planner. Nothing is
-/// scheduled or broadcast; the fields describe what a migration run would prepare.
+/// Read-only preview of the plan produced by the migration engine. Nothing is scheduled or
+/// broadcast; the fields describe what a migration run would prepare, cross, and leave behind.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct PoolMigrationPreview {
     /// The value pool funds would be migrated from.
@@ -67,77 +70,70 @@ pub(crate) struct PoolMigrationPreview {
     to_pool: Pool,
     /// The network upgrade that enables this migration (for example `"Nu6.3"`).
     enabling_upgrade: String,
-    /// The denomination strategy this plan was computed with (`"randomized"` or
-    /// `"canonical"`).
-    strategy: String,
-    /// The account's total spendable balance in the source pool, in zatoshis.
+    /// The account's total spendable balance in the source pool (in zatoshis): the sum of the
+    /// spendable source-pool notes the plan decomposes.
     account_balance_zat: u64,
-    /// The fee (in zatoshis) reserved for the note-split ("prep") transaction before
-    /// decomposition.
-    ///
-    /// This preview reserves the ZIP-317 minimum fee; the final prep fee is computed by
-    /// the migration engine when the build path is wired in.
+    /// The fee (in zatoshis) reserved for each note-preparation transaction: the ZIP-317 fee of a
+    /// padded preparation transaction (its fixed action count times the marginal fee).
     prep_fee_zat: u64,
-    /// The total input (in zatoshis) the plan decomposes (equal to
-    /// `account_balance_zat`).
-    total_input_zat: u64,
-    /// The total value (in zatoshis) that would migrate to the destination pool: the sum
-    /// of the crossing values.
+    /// The total value (in zatoshis) that would migrate to the destination pool: the sum of the
+    /// crossing values of the funding notes the plan actually mints (after reconciling the split
+    /// against the preparation fees).
     total_migratable_zat: u64,
-    /// Residual (in zatoshis) left in the source pool because it could not form a whole
-    /// self-funding note (or the note cap was reached). Zero if the balance was consumed
-    /// exactly.
+    /// Residual (in zatoshis) left in the source pool by the note split because it could not form a
+    /// whole self-funding note (or the note cap was reached). This is the note-split residual only;
+    /// the preparation transactions may leave further residual notes (see
+    /// [`PreviewPreparation::residual_note_count`]).
     source_change_zat: u64,
-    /// The number of self-funding notes the split would prepare.
-    note_count: u32,
-    /// The per-note breakdown, one entry per prepared note.
-    notes: Vec<PreviewNote>,
+    /// The number of self-funding notes the plan would mint (equal to `funding_notes.len()`).
+    funding_note_count: u32,
+    /// The per-note breakdown, one entry per funding note the plan mints, paired with that note's
+    /// transfer schedule.
+    funding_notes: Vec<PreviewFundingNote>,
+    /// A summary of the note-split decomposition before it was reconciled against the preparation
+    /// fees (the funding notes above are this split minus any denominations dropped to fit the
+    /// fees).
+    note_split: PreviewNoteSplit,
+    /// A summary of the note-preparation transactions that would mint the funding notes.
+    preparation: PreviewPreparation,
 }
 
-/// One prepared note in a [`PoolMigrationPreview`].
+/// One funding note in a [`PoolMigrationPreview`], with its transfer schedule.
 #[derive(Clone, Debug, Serialize, JsonSchema)]
-pub(crate) struct PreviewNote {
-    /// The value (in zatoshis) of the prepared note: its crossing value plus the fee
-    /// buffer that lets it pay its own migration-transfer fee.
+pub(crate) struct PreviewFundingNote {
+    /// The value (in zatoshis) of the self-funding note minted in the source pool: its crossing
+    /// value plus the fee buffer that lets it pay its own migration-transfer fee.
     output_zat: u64,
-    /// The denomination value (in zatoshis) that crosses the turnstile when this note is
-    /// spent.
+    /// The denomination value (in zatoshis) that crosses the turnstile when this note is spent.
     crossing_zat: u64,
+    /// The block height at which this note's migration transfer is scheduled to be broadcast.
+    broadcast_height: u32,
+    /// The block height at (and after) which this note's migration transfer is no longer valid.
+    expiry_height: u32,
 }
 
-/// Validates the requested denomination strategy and returns its canonical wire name,
-/// defaulting to the recommended randomized strategy.
-///
-/// Kept separate from [`build_strategy`] so the (cheap) validation runs before any wallet
-/// I/O, and so the non-`Send` strategy object is only constructed after the last `.await`.
-fn strategy_name(strategy: Option<&str>) -> RpcResult<&'static str> {
-    match strategy.unwrap_or(STRATEGY_RANDOMIZED) {
-        STRATEGY_RANDOMIZED => Ok(STRATEGY_RANDOMIZED),
-        STRATEGY_CANONICAL => Ok(STRATEGY_CANONICAL),
-        other => Err(LegacyCode::InvalidParameter.with_message(format!(
-            "strategy: unknown denomination strategy {other:?}; expected \
-             {STRATEGY_RANDOMIZED:?} or {STRATEGY_CANONICAL:?}",
-        ))),
-    }
+/// A summary of the note-split decomposition in a [`PoolMigrationPreview`], before reconciliation
+/// against the preparation fees.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub(crate) struct PreviewNoteSplit {
+    /// The number of denominations the raw split produced.
+    note_count: u32,
+    /// The total value (in zatoshis) the raw split would migrate (the sum of its crossing values).
+    total_migratable_zat: u64,
+    /// The crossing values (in zatoshis) the raw split chose, one per denomination.
+    crossing_values: Vec<u64>,
 }
 
-/// Constructs the denomination strategy for a canonical name returned by
-/// [`strategy_name`]. The name is assumed already validated.
-fn build_strategy(name: &str) -> Box<dyn DenominationStrategy> {
-    match name {
-        STRATEGY_CANONICAL => Box::new(CanonicalPowerOfTen::zip_draft()),
-        // Any already-validated name other than canonical is the randomized default.
-        _ => Box::new(RandomizedOneTwoFive::recommended()),
-    }
-}
-
-/// Returns the spendable balance the given pool holds in the supplied account balance.
-fn spendable_in_pool(account_balance: &AccountBalance, pool: Pool) -> Zatoshis {
-    match pool {
-        Pool::Sapling => account_balance.sapling_balance().spendable_value(),
-        Pool::Orchard => account_balance.orchard_balance().spendable_value(),
-        Pool::Ironwood => account_balance.ironwood_balance().spendable_value(),
-    }
+/// A summary of the note-preparation transactions in a [`PoolMigrationPreview`].
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub(crate) struct PreviewPreparation {
+    /// The number of sequential dependency layers of preparation transactions.
+    layer_count: u32,
+    /// The total number of preparation transactions across all layers.
+    transaction_count: u32,
+    /// The number of residual notes the preparation leaves in the source pool (at most one worth a
+    /// fee, plus any sub-fee dust).
+    residual_note_count: u32,
 }
 
 pub(crate) async fn call(
@@ -147,81 +143,128 @@ pub(crate) async fn call(
     from_pool: &str,
     to_pool: &str,
     minconf: Option<u32>,
-    strategy: Option<String>,
 ) -> Response {
     let (from_pool, to_pool, enabling_upgrade) = validate_pool_pair(wallet, from_pool, to_pool)?;
-    // Validate the strategy name before any wallet I/O; the strategy object itself is not
-    // `Send`, so it is built below, after the last `.await`.
-    let strategy_name = strategy_name(strategy.as_deref())?;
     let account_id = parse_account_parameter(wallet, keystore, &account).await?;
 
-    let confirmations_policy = match minconf.and_then(NonZeroU32::new) {
-        Some(c) => ConfirmationsPolicy::new_symmetrical(c, false),
-        None => ConfirmationsPolicy::new_symmetrical(NonZeroU32::MIN, true),
-    };
+    let minconf = minconf.unwrap_or(DEFAULT_MINCONF);
 
-    let summary = wallet
-        .get_wallet_summary(confirmations_policy)
+    // The chain tip: the height the schedule's delays accumulate from, and the basis for the target
+    // height at which notes are selected. Absent it, the wallet has not synced far enough to plan.
+    let chain_height = wallet
+        .chain_height()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
         .ok_or_else(|| LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+    let target_height = TargetHeight::from(chain_height + 1);
 
-    let account_balance = summary.account_balances().get(&account_id).ok_or_else(|| {
-        LegacyCode::InvalidParameter.with_message(format!(
-            "Error: account {account} has not been generated by z_getnewaccount."
-        ))
-    })?;
+    // Enumerate the account's spendable source-pool (Orchard) notes as individual values: the engine
+    // decomposes their total, and the preparation planner needs the per-note values. Mirrors the note
+    // selection and confirmation filter used by `z_listunspent`.
+    let received = wallet
+        .select_unspent_notes(account_id, &[ShieldedPool::Orchard], target_height, &[])
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
-    let total_input_zat = spendable_in_pool(account_balance, from_pool).into_u64();
-    let prep_fee_zat = MINIMUM_FEE.into_u64();
+    let mut orchard_note_values = Vec::new();
+    for note in received.orchard().iter() {
+        let mined_height = wallet
+            .get_tx_height(*note.txid())
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+        // Include only notes mined with at least `minconf` confirmations; skip unmined notes.
+        match mined_height {
+            Some(h) if h <= target_height.saturating_sub(minconf) => {
+                orchard_note_values.push(u64::from(note.value()));
+            }
+            _ => {}
+        }
+    }
 
-    // No `.await` past this point: build the (non-`Send`) strategy and plan synchronously.
+    let account_balance_zat: u64 = orchard_note_values.iter().sum();
+
+    // The ZIP-317 fee of a padded note-preparation transaction, which the note split and the
+    // preparation planner both reserve. Built from the crate's own constants (no magic numbers).
+    let prep_fee_zat = PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi();
+
+    // No `.await` past this point: build the snapshot backend and run the pure planner synchronously.
+    let backend = SpendableSnapshot::new(orchard_note_values, u32::from(chain_height));
     let mut rng = OsRng;
-    let plan = build_strategy(strategy_name).plan(total_input_zat, prep_fee_zat, &mut rng);
+    let plan = plan_migration(&backend, prep_fee_zat, &mut rng).map_err(map_plan_error)?;
 
     Ok(preview_from_plan(
         from_pool,
         to_pool,
         enabling_upgrade.to_string(),
-        strategy_name.to_string(),
-        total_input_zat,
+        account_balance_zat,
         &plan,
     ))
 }
 
-/// Assembles the RPC response from a computed note-split plan.
+/// Maps a migration-planning error to an RPC error.
+fn map_plan_error(err: MigrationError<SnapshotError>) -> jsonrpsee::types::ErrorObjectOwned {
+    match err {
+        MigrationError::NothingToMigrate => LegacyCode::InvalidParameter
+            .with_static("the account has no spendable source-pool balance to migrate"),
+        MigrationError::Preparation(e) => LegacyCode::InvalidParameter.with_message(format!(
+            "the spendable notes cannot fund the migration: {e}"
+        )),
+        // Planning calls only the snapshot's read methods, which never fail; a backend error here
+        // would indicate a future change to `plan_migration`, so surface it rather than hide it.
+        MigrationError::Backend(e) => LegacyCode::Misc.with_message(format!("{e}")),
+    }
+}
+
+/// Assembles the RPC response from a planned migration.
 ///
-/// Kept pure (no wallet access) so the response contract can be unit-tested directly
-/// against a plan.
+/// Kept pure (no wallet access) so the response contract can be unit-tested directly against a plan.
 fn preview_from_plan(
     from_pool: Pool,
     to_pool: Pool,
     enabling_upgrade: String,
-    strategy: String,
     account_balance_zat: u64,
-    plan: &NoteSplitPlan,
+    plan: &MigrationPlan,
 ) -> PoolMigrationPreview {
-    let notes = plan
-        .migration_outputs()
+    // Each funding note holds its crossing value plus a fixed transfer fee buffer, so the crossing
+    // value is the funding note less that buffer.
+    let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+
+    let funding_notes = plan
+        .funding_notes()
         .iter()
-        .zip(plan.crossing_values())
-        .map(|(&output_zat, &crossing_zat)| PreviewNote {
+        .zip(plan.schedule())
+        .map(|(&output_zat, schedule)| PreviewFundingNote {
             output_zat,
-            crossing_zat,
+            crossing_zat: output_zat.saturating_sub(buffer),
+            broadcast_height: schedule.broadcast_height(),
+            expiry_height: schedule.expiry_height(),
         })
         .collect::<Vec<_>>();
+
+    let total_migratable_zat = funding_notes.iter().map(|n| n.crossing_zat).sum();
 
     PoolMigrationPreview {
         from_pool,
         to_pool,
         enabling_upgrade,
-        strategy,
         account_balance_zat,
-        prep_fee_zat: plan.prep_fee_zatoshi(),
-        total_input_zat: plan.total_input_zatoshi(),
-        total_migratable_zat: plan.total_migratable_zatoshi(),
-        source_change_zat: plan.orchard_change().unwrap_or(0),
-        note_count: notes.len() as u32,
-        notes,
+        prep_fee_zat: plan.note_split().prep_fee_zatoshi(),
+        total_migratable_zat,
+        source_change_zat: plan.note_split().change().unwrap_or(0),
+        funding_note_count: funding_notes.len() as u32,
+        funding_notes,
+        note_split: PreviewNoteSplit {
+            note_count: plan.note_split().crossing_values().len() as u32,
+            total_migratable_zat: plan.note_split().total_migratable_zatoshi(),
+            crossing_values: plan.note_split().crossing_values().to_vec(),
+        },
+        preparation: preparation_summary(plan.preparation()),
+    }
+}
+
+/// Summarizes a preparation plan for the preview.
+fn preparation_summary(preparation: &PreparationPlan) -> PreviewPreparation {
+    PreviewPreparation {
+        layer_count: preparation.layer_count() as u32,
+        transaction_count: preparation.transaction_count() as u32,
+        residual_note_count: preparation.residual_count() as u32,
     }
 }
 
@@ -231,93 +274,116 @@ mod tests {
     use zcash_protocol::value::COIN;
 
     use super::*;
-    use crate::migrate::engine::note_splitting::plan_note_split;
+    use crate::migrate::engine::engine::{
+        MigrationBackend, MigrationState, MigrationTxId, MigrationTxState,
+    };
 
-    #[test]
-    fn strategy_name_defaults_to_randomized() {
-        assert_eq!(strategy_name(None).unwrap(), STRATEGY_RANDOMIZED);
+    /// A minimal planning backend for tests: a fixed set of spendable note values and a chain tip.
+    /// Persistence is unsupported (planning never uses it), mirroring `SpendableSnapshot`.
+    struct MockBackend {
+        notes: Vec<u64>,
+        tip: u32,
+    }
+
+    impl MigrationBackend for MockBackend {
+        type Error = SnapshotError;
+
+        fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
+            Ok(self.notes.clone())
+        }
+
+        fn chain_tip_height(&self) -> Result<u32, Self::Error> {
+            Ok(self.tip)
+        }
+
+        fn store_migration(&mut self, _state: &MigrationState) -> Result<(), Self::Error> {
+            Err(SnapshotError::PersistenceUnsupported)
+        }
+
+        fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(None)
+        }
+
+        fn update_transaction(
+            &mut self,
+            _id: MigrationTxId,
+            _state: MigrationTxState,
+        ) -> Result<(), Self::Error> {
+            Err(SnapshotError::PersistenceUnsupported)
+        }
+    }
+
+    /// The ZIP-317 fee the preview reserves, as `call` computes it.
+    fn prep_fee() -> u64 {
+        PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
     }
 
     #[test]
-    fn strategy_name_parses_known_strategies() {
-        assert_eq!(
-            strategy_name(Some("randomized")).unwrap(),
-            STRATEGY_RANDOMIZED
-        );
-        assert_eq!(
-            strategy_name(Some("canonical")).unwrap(),
-            STRATEGY_CANONICAL
-        );
-    }
-
-    #[test]
-    fn strategy_name_rejects_unknown() {
-        assert!(strategy_name(Some("bogus")).is_err());
-        assert!(strategy_name(Some("")).is_err());
-    }
-
-    #[test]
-    fn preview_conserves_value_and_reports_notes() {
-        // Decompose a sample Orchard balance and check the response mirrors the plan and
-        // conserves value: migratable + change + prep fee + fee buffers == input.
-        let prep_fee = MINIMUM_FEE.into_u64();
-        let total_input = 723 * COIN;
-
+    fn preview_reports_a_scheduled_conserving_plan() {
+        // Decompose a sample Orchard balance held as one large note and check the response mirrors
+        // the plan: every funding note has a positive crossing its output covers by exactly the fee
+        // buffer, each is scheduled, and the migratable total is the sum of the crossings.
+        let notes = vec![723 * COIN];
+        let account_balance_zat: u64 = notes.iter().sum();
+        let backend = MockBackend {
+            notes,
+            tip: 2_000_000,
+        };
         let mut rng = OsRng;
-        let plan = plan_note_split(total_input, prep_fee, &mut rng);
+        let plan = plan_migration(&backend, prep_fee(), &mut rng).expect("a funded balance plans");
 
         let preview = preview_from_plan(
             Pool::Orchard,
             Pool::Ironwood,
             "Nu6.3".to_string(),
-            STRATEGY_RANDOMIZED.to_string(),
-            total_input,
+            account_balance_zat,
             &plan,
         );
 
-        assert_eq!(preview.account_balance_zat, total_input);
-        assert_eq!(preview.total_input_zat, total_input);
-        assert_eq!(preview.prep_fee_zat, prep_fee);
-        assert_eq!(preview.note_count as usize, preview.notes.len());
-        assert_eq!(preview.notes.len(), plan.migration_outputs().len());
+        assert_eq!(preview.account_balance_zat, account_balance_zat);
+        assert_eq!(preview.prep_fee_zat, prep_fee());
+        assert_eq!(
+            preview.funding_note_count as usize,
+            preview.funding_notes.len()
+        );
+        assert!(preview.funding_note_count > 0);
 
-        // Every crossing value is positive and each output covers its crossing.
-        let crossings_sum: u64 = preview.notes.iter().map(|n| n.crossing_zat).sum();
-        for note in &preview.notes {
-            assert!(note.crossing_zat > 0);
-            assert!(note.output_zat >= note.crossing_zat);
+        // One schedule entry per funding note (the engine guarantees this).
+        assert_eq!(preview.funding_notes.len(), plan.schedule().len());
+
+        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let mut crossings_sum = 0u64;
+        for note in &preview.funding_notes {
+            assert!(note.crossing_zat > 0, "every crossing value is positive");
+            assert_eq!(
+                note.output_zat,
+                note.crossing_zat + buffer,
+                "the output funds the crossing plus exactly the fee buffer"
+            );
+            assert!(
+                note.expiry_height > note.broadcast_height,
+                "expiry follows broadcast"
+            );
+            crossings_sum += note.crossing_zat;
         }
         assert_eq!(preview.total_migratable_zat, crossings_sum);
 
-        // Value conservation: the prepared notes plus the residual plus the reserved prep
-        // fee never exceed the input.
-        let notes_total: u64 = preview.notes.iter().map(|n| n.output_zat).sum();
-        assert_eq!(
-            notes_total + preview.source_change_zat + preview.prep_fee_zat,
-            total_input
-        );
+        // The migratable value never exceeds the input balance.
+        assert!(preview.total_migratable_zat <= preview.account_balance_zat);
+        // Reconciliation only drops funding notes, so at most as many as the raw split.
+        assert!(preview.funding_notes.len() <= preview.note_split.note_count as usize);
     }
 
     #[test]
-    fn preview_of_dust_balance_migrates_nothing() {
-        // A balance below the smallest self-funding note migrates nothing and is kept as
-        // change.
-        let prep_fee = MINIMUM_FEE.into_u64();
-        let total_input = prep_fee + 1;
-
+    fn empty_balance_has_nothing_to_migrate() {
+        let backend = MockBackend {
+            notes: Vec::new(),
+            tip: 2_000_000,
+        };
         let mut rng = OsRng;
-        let plan = plan_note_split(total_input, prep_fee, &mut rng);
-        let preview = preview_from_plan(
-            Pool::Orchard,
-            Pool::Ironwood,
-            "Nu6.3".to_string(),
-            STRATEGY_RANDOMIZED.to_string(),
-            total_input,
-            &plan,
-        );
-
-        assert_eq!(preview.note_count, 0);
-        assert_eq!(preview.total_migratable_zat, 0);
-        assert!(preview.notes.is_empty());
+        assert!(matches!(
+            plan_migration(&backend, prep_fee(), &mut rng),
+            Err(MigrationError::NothingToMigrate)
+        ));
     }
 }

--- a/zallet-core/src/components/json_rpc/methods/sign_pool_migration_pczt.rs
+++ b/zallet-core/src/components/json_rpc/methods/sign_pool_migration_pczt.rs
@@ -1,0 +1,58 @@
+//! `z_signpoolmigrationpczt`: sign a migration PCZT with the account's spend authorization.
+//!
+//! For offline / air-gapped signing (build the migration on one wallet, sign on another holding the
+//! key), and the software stand-in a hardware device performs on-device: it takes an unsigned
+//! migration PCZT (from `z_startpoolmigration` with `external_signer`, or
+//! `z_buildpoolmigrationtransfers`), adds only the account's Orchard spend-authorization signature (the
+//! Signer role), and returns the signed PCZT to apply with `z_applypoolmigrationsignature`. It does not
+//! prove, extract, or broadcast. A hardware wallet performs the equivalent signing on the device
+//! instead of calling this.
+
+use base64ct::{Base64, Encoding};
+use documented::Documented;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use super::pool_migration::decrypt_account_usk;
+use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::components::json_rpc::utils::parse_account_parameter;
+use crate::components::keystore::KeyStore;
+use crate::migrate::sign_migration_pczt;
+
+/// Response to a `z_signpoolmigrationpczt` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = SignPoolMigrationPczt;
+
+pub(super) const PARAM_ACCOUNT_DESC: &str =
+    "Either the UUID or ZIP 32 account index of the account whose spend key signs the PCZT.";
+pub(super) const PARAM_PCZT_DESC: &str = "The unsigned migration PCZT to sign, base64 encoded (from z_startpoolmigration with \
+     external_signer, or z_buildpoolmigrationtransfers).";
+
+/// The result of signing a migration PCZT.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct SignPoolMigrationPczt {
+    /// The signed PCZT, base64 encoded, to apply with z_applypoolmigrationsignature.
+    pczt: String,
+}
+
+pub(crate) async fn call(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account: JsonValue,
+    pczt: &str,
+) -> Response {
+    let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+    let usk = decrypt_account_usk(wallet, keystore, account_id).await?;
+
+    let bytes = Base64::decode_vec(pczt)
+        .map_err(|_| LegacyCode::InvalidParameter.with_static("Malformed base64 PCZT"))?;
+    // Signing is CPU-light and touches no wallet database, so it needs no blocking section.
+    let signed = sign_migration_pczt(&usk, &bytes)
+        .map_err(|e| LegacyCode::Misc.with_message(e.to_string()))?;
+
+    Ok(SignPoolMigrationPczt {
+        pczt: Base64::encode_string(&signed),
+    })
+}

--- a/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
@@ -1,31 +1,44 @@
-//! `z_startpoolmigration`: schedule a generic pool-to-pool migration (scaffold).
+//! `z_startpoolmigration`: start a generic pool-to-pool migration.
+//!
+//! Builds and pre-signs the note-preparation transactions that split the account's source-pool
+//! balance into the self-funding notes that cross the turnstile, records the transfer schedule, and
+//! persists the whole committed migration (as pre-signed PCZTs plus metadata) so it can be advanced
+//! and broadcast later. Nothing is proved or broadcast here.
 
 use documented::Documented;
-use jsonrpsee::core::RpcResult;
+use jsonrpsee::core::{JsonValue, RpcResult};
 use schemars::JsonSchema;
+use secrecy::ExposeSecret;
 use serde::Serialize;
+use zcash_client_backend::data_api::{Account, WalletRead};
+use zcash_keys::keys::UnifiedSpendingKey;
 
-use super::pool_migration::{MigrationPlan, Pool, not_implemented, validate_pool_pair};
+use super::pool_migration::{
+    MIGRATION_ID, MigrationPlan, Pool, map_commit_failure, migration_plan, validate_pool_pair,
+};
 use crate::components::database::DbConnection;
+use crate::components::json_rpc::server::LegacyCode;
+use crate::components::json_rpc::utils::parse_account_parameter;
+use crate::components::keystore::KeyStore;
+use crate::migrate::{
+    CommitFailure, commit_preparation_over_wallet, is_terminal, load_migration, persist_migration,
+};
 
 /// Response to a `z_startpoolmigration` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) type ResultType = StartPoolMigration;
 
+pub(super) const PARAM_ACCOUNT_DESC: &str =
+    "Either the UUID or ZIP 32 account index of the account whose balance to migrate.";
 pub(super) const PARAM_FROM_POOL_DESC: &str =
     "The value pool to migrate funds from (\"sapling\", \"orchard\", or \"ironwood\").";
 pub(super) const PARAM_TO_POOL_DESC: &str =
     "The value pool to migrate funds to (\"sapling\", \"orchard\", or \"ironwood\").";
 
-/// The result of scheduling a pool migration.
-///
-/// Describes the response shape for when the migration engine is wired in; the scaffold
-/// validates inputs and then returns a not-implemented error rather than constructing
-/// this value.
+/// The result of starting a pool migration.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
 pub(crate) struct StartPoolMigration {
-    /// Opaque identifier for the scheduled migration, used with the status, advance,
-    /// and cancel methods.
+    /// Opaque identifier for the migration, used with the status, advance, and cancel methods.
     migration_id: String,
     /// The value pool funds are being migrated from.
     from_pool: Pool,
@@ -37,7 +50,74 @@ pub(crate) struct StartPoolMigration {
     plan: MigrationPlan,
 }
 
-pub(crate) fn call(wallet: &DbConnection, from_pool: &str, to_pool: &str) -> Response {
-    let (_from_pool, _to_pool, _enabling_upgrade) = validate_pool_pair(wallet, from_pool, to_pool)?;
-    not_implemented("z_startpoolmigration")
+pub(crate) async fn call(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account: JsonValue,
+    from_pool: &str,
+    to_pool: &str,
+) -> Response {
+    let (from_pool, to_pool, enabling_upgrade) = validate_pool_pair(wallet, from_pool, to_pool)?;
+    let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+
+    // The transactions build at the height after the current chain tip.
+    let chain_height = wallet
+        .chain_height()
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+    let target_height = u32::from(chain_height) + 1;
+
+    // Decrypt the account's spending key. This is the only async step, and it happens BEFORE the
+    // blocking build section (no `.await` may occur inside `with_raw_mut`).
+    let acct = wallet
+        .get_account(account_id)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InvalidParameter.with_static("no such account"))?;
+    let derivation = acct.source().key_derivation().ok_or_else(|| {
+        LegacyCode::InvalidAddressOrKey
+            .with_static("the account has no spending key to migrate with")
+    })?;
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+    let usk = UnifiedSpendingKey::from_seed(
+        wallet.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+
+    // Build + pre-sign the preparation over the wallet, then persist the resulting migration. Both
+    // the engine's wallet access and the store write run on one connection, sequentially.
+    let state = wallet
+        .with_raw_mut(|conn, network| -> Result<_, CommitFailure> {
+            // Refuse to overwrite an in-progress migration: its pre-signed transactions would be
+            // lost. A terminal (complete or failed) migration may be replaced.
+            if let Some(existing) =
+                load_migration(conn).map_err(|e| CommitFailure::Other(e.to_string()))?
+            {
+                if !is_terminal(&existing) {
+                    return Err(CommitFailure::AlreadyInProgress);
+                }
+            }
+            let state =
+                commit_preparation_over_wallet(conn, network, account_id, usk, target_height)?;
+            persist_migration(conn, &state).map_err(|e| CommitFailure::Other(e.to_string()))?;
+            Ok(state)
+        })
+        .map_err(map_commit_failure)?;
+
+    Ok(StartPoolMigration {
+        migration_id: MIGRATION_ID.to_string(),
+        from_pool,
+        to_pool,
+        enabling_upgrade: enabling_upgrade.to_string(),
+        plan: migration_plan(state.transactions.len() as u32),
+    })
 }

--- a/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
@@ -1,0 +1,43 @@
+//! `z_startpoolmigration`: schedule a generic pool-to-pool migration (scaffold).
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use super::pool_migration::{MigrationPlan, Pool, not_implemented, validate_pool_pair};
+use crate::components::database::DbConnection;
+
+/// Response to a `z_startpoolmigration` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = StartPoolMigration;
+
+pub(super) const PARAM_FROM_POOL_DESC: &str =
+    "The value pool to migrate funds from (\"sapling\", \"orchard\", or \"ironwood\").";
+pub(super) const PARAM_TO_POOL_DESC: &str =
+    "The value pool to migrate funds to (\"sapling\", \"orchard\", or \"ironwood\").";
+
+/// The result of scheduling a pool migration.
+///
+/// Describes the response shape for when the migration engine is wired in; the scaffold
+/// validates inputs and then returns a not-implemented error rather than constructing
+/// this value.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct StartPoolMigration {
+    /// Opaque identifier for the scheduled migration, used with the status, advance,
+    /// and cancel methods.
+    migration_id: String,
+    /// The value pool funds are being migrated from.
+    from_pool: Pool,
+    /// The value pool funds are being migrated to.
+    to_pool: Pool,
+    /// The network upgrade that enables this migration (for example `"Nu6.3"`).
+    enabling_upgrade: String,
+    /// The plan describing how the migration will be carried out.
+    plan: MigrationPlan,
+}
+
+pub(crate) fn call(wallet: &DbConnection, from_pool: &str, to_pool: &str) -> Response {
+    let (_from_pool, _to_pool, _enabling_upgrade) = validate_pool_pair(wallet, from_pool, to_pool)?;
+    not_implemented("z_startpoolmigration")
+}

--- a/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
@@ -20,7 +20,7 @@ use crate::components::json_rpc::server::LegacyCode;
 use crate::components::json_rpc::utils::parse_account_parameter;
 use crate::components::keystore::KeyStore;
 use crate::migrate::{
-    CommitFailure, commit_preparation_over_wallet, is_terminal, load_migration, persist_migration,
+    CommitFailure, commit_preparation_over_wallet, load_migration, persist_migration,
 };
 
 /// Response to a `z_startpoolmigration` RPC request.
@@ -79,7 +79,7 @@ pub(crate) async fn call(
             if let Some(existing) =
                 load_migration(conn).map_err(|e| CommitFailure::Other(e.to_string()))?
             {
-                if !is_terminal(&existing) {
+                if !existing.is_terminal() {
                     return Err(CommitFailure::AlreadyInProgress);
                 }
             }

--- a/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
@@ -12,15 +12,16 @@ use serde::Serialize;
 use zcash_client_backend::data_api::WalletRead;
 
 use super::pool_migration::{
-    MIGRATION_ID, MigrationPlan, Pool, decrypt_account_usk, map_commit_failure, migration_plan,
-    validate_pool_pair,
+    MIGRATION_ID, MigrationPlan, Pool, UnsignedMigrationTransaction, decrypt_account_usk,
+    encode_unsigned, map_commit_failure, migration_plan, validate_pool_pair,
 };
 use crate::components::database::DbConnection;
 use crate::components::json_rpc::server::LegacyCode;
 use crate::components::json_rpc::utils::parse_account_parameter;
 use crate::components::keystore::KeyStore;
 use crate::migrate::{
-    CommitFailure, commit_preparation_over_wallet, load_migration, persist_migration,
+    CommitFailure, build_preparation_unsigned_over_wallet, commit_preparation_over_wallet,
+    load_migration, persist_migration,
 };
 
 /// Response to a `z_startpoolmigration` RPC request.
@@ -33,6 +34,8 @@ pub(super) const PARAM_FROM_POOL_DESC: &str =
     "The value pool to migrate funds from (\"sapling\", \"orchard\", or \"ironwood\").";
 pub(super) const PARAM_TO_POOL_DESC: &str =
     "The value pool to migrate funds to (\"sapling\", \"orchard\", or \"ironwood\").";
+pub(super) const PARAM_EXTERNAL_SIGNER_DESC: &str = "When true, build the preparation transactions unsigned for an external (hardware or offline) \
+     signer and return their PCZTs to sign on the device; when false (default) pre-sign in process.";
 
 /// The result of starting a pool migration.
 #[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
@@ -47,6 +50,12 @@ pub(crate) struct StartPoolMigration {
     enabling_upgrade: String,
     /// The plan describing how the migration will be carried out.
     plan: MigrationPlan,
+    /// When the migration was started for an EXTERNAL signer (`external_signer=true`), the unsigned
+    /// preparation PCZTs to sign on the device; each is applied back with
+    /// `z_applypoolmigrationsignature`. Absent for the default in-process-signing path (where the
+    /// preparation is already pre-signed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unsigned_transactions: Option<Vec<UnsignedMigrationTransaction>>,
 }
 
 pub(crate) async fn call(
@@ -55,9 +64,11 @@ pub(crate) async fn call(
     account: JsonValue,
     from_pool: &str,
     to_pool: &str,
+    external_signer: Option<bool>,
 ) -> Response {
     let (from_pool, to_pool, enabling_upgrade) = validate_pool_pair(wallet, from_pool, to_pool)?;
     let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+    let external_signer = external_signer.unwrap_or(false);
 
     // The transactions build at the height after the current chain tip.
     let chain_height = wallet
@@ -67,15 +78,19 @@ pub(crate) async fn call(
     let target_height = u32::from(chain_height) + 1;
 
     // Decrypt the account's spending key. This is the only async step, and it happens BEFORE the
-    // blocking build section (no `.await` may occur inside `with_raw_mut`).
+    // blocking build section (no `.await` may occur inside `with_raw_mut`). For an external signer,
+    // the key still builds the PCZTs (it derives the account's viewing key and witnesses); it just
+    // does not sign them, leaving that to the device.
     let usk = decrypt_account_usk(wallet, keystore, account_id).await?;
 
-    // Build + pre-sign the preparation over the wallet, then persist the resulting migration. Both
-    // the engine's wallet access and the store write run on one connection, sequentially.
-    let state = wallet
+    // Build the preparation over the wallet, then persist the resulting migration. Both the engine's
+    // wallet access and the store write run on one connection, sequentially. In the default path the
+    // transactions are pre-signed; for an external signer they are left unsigned (in
+    // `AwaitingSignature`) and their PCZTs are returned for the device to sign.
+    let (state, unsigned_transactions) = wallet
         .with_raw_mut(|conn, network| -> Result<_, CommitFailure> {
-            // Refuse to overwrite an in-progress migration: its pre-signed transactions would be
-            // lost. A terminal (complete or failed) migration may be replaced.
+            // Refuse to overwrite an in-progress migration: its transactions would be lost. A
+            // terminal (complete or failed) migration may be replaced.
             if let Some(existing) =
                 load_migration(conn).map_err(|e| CommitFailure::Other(e.to_string()))?
             {
@@ -83,10 +98,22 @@ pub(crate) async fn call(
                     return Err(CommitFailure::AlreadyInProgress);
                 }
             }
-            let state =
-                commit_preparation_over_wallet(conn, network, account_id, usk, target_height)?;
+            let (state, unsigned) = if external_signer {
+                let (state, unsigned) = build_preparation_unsigned_over_wallet(
+                    conn,
+                    network,
+                    account_id,
+                    usk,
+                    target_height,
+                )?;
+                (state, Some(encode_unsigned(unsigned)))
+            } else {
+                let state =
+                    commit_preparation_over_wallet(conn, network, account_id, usk, target_height)?;
+                (state, None)
+            };
             persist_migration(conn, &state).map_err(|e| CommitFailure::Other(e.to_string()))?;
-            Ok(state)
+            Ok((state, unsigned))
         })
         .map_err(map_commit_failure)?;
 
@@ -96,5 +123,6 @@ pub(crate) async fn call(
         to_pool,
         enabling_upgrade: enabling_upgrade.to_string(),
         plan: migration_plan(state.transactions.len() as u32),
+        unsigned_transactions,
     })
 }

--- a/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
@@ -8,13 +8,12 @@
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
 use schemars::JsonSchema;
-use secrecy::ExposeSecret;
 use serde::Serialize;
-use zcash_client_backend::data_api::{Account, WalletRead};
-use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_client_backend::data_api::WalletRead;
 
 use super::pool_migration::{
-    MIGRATION_ID, MigrationPlan, Pool, map_commit_failure, migration_plan, validate_pool_pair,
+    MIGRATION_ID, MigrationPlan, Pool, decrypt_account_usk, map_commit_failure, migration_plan,
+    validate_pool_pair,
 };
 use crate::components::database::DbConnection;
 use crate::components::json_rpc::server::LegacyCode;
@@ -69,29 +68,7 @@ pub(crate) async fn call(
 
     // Decrypt the account's spending key. This is the only async step, and it happens BEFORE the
     // blocking build section (no `.await` may occur inside `with_raw_mut`).
-    let acct = wallet
-        .get_account(account_id)
-        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-        .ok_or_else(|| LegacyCode::InvalidParameter.with_static("no such account"))?;
-    let derivation = acct.source().key_derivation().ok_or_else(|| {
-        LegacyCode::InvalidAddressOrKey
-            .with_static("the account has no spending key to migrate with")
-    })?;
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
-        })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+    let usk = decrypt_account_usk(wallet, keystore, account_id).await?;
 
     // Build + pre-sign the preparation over the wallet, then persist the resulting migration. Both
     // the engine's wallet access and the store write run on one connection, sequentially.

--- a/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
+++ b/zallet-core/src/components/json_rpc/methods/start_pool_migration.rs
@@ -122,7 +122,7 @@ pub(crate) async fn call(
         from_pool,
         to_pool,
         enabling_upgrade: enabling_upgrade.to_string(),
-        plan: migration_plan(state.transactions.len() as u32),
+        plan: migration_plan(state.transactions().len() as u32),
         unsigned_transactions,
     })
 }

--- a/zallet-core/src/lib.rs
+++ b/zallet-core/src/lib.rs
@@ -62,6 +62,7 @@ pub mod components;
 pub mod config;
 pub mod error;
 mod i18n;
+pub mod migrate;
 pub mod network;
 mod prelude;
 mod task;

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -38,8 +38,8 @@ use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
     CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
-    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, commit_preparation,
-    commit_transfers, plan_migration,
+    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    commit_pending_preparation, commit_preparation, commit_transfers, plan_migration,
 };
 use zcash_pool_migration_backend::note_splitting::{FeePolicy, Zip317FeePolicy};
 use zcash_pool_migration_backend::preparation::PREP_TX_ACTIONS;
@@ -246,6 +246,29 @@ pub fn commit_transfers_over_wallet(
     commit_transfers(network, target_height, &mut migration, &mut rng).map_err(map_commit_error)
 }
 
+/// Commits the next ready PREPARATION LAYER of an in-progress multi-layer migration over the wallet:
+/// a later preparation layer spends the feeder notes minted by the layer before it, which are
+/// witnessable only once that layer is mined, so the layer is built here rather than up front. Builds
+/// and pre-signs every transaction of the earliest still-unbuilt layer whose predecessor has mined,
+/// returning the updated state (NOT persisted; the caller persists it). `loaded` is the migration read
+/// from the store. If no layer is ready it returns the state unchanged. Runs the engine synchronously;
+/// call inside the blocking database section.
+pub fn commit_pending_preparation_over_wallet(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    target_height: u32,
+    loaded: MigrationState,
+) -> Result<MigrationState, CommitFailure> {
+    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let store = InMemoryStore::seeded(Some(loaded));
+    let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
+    let mut rng = OsRng;
+    commit_pending_preparation(network, target_height, &mut migration, &mut rng)
+        .map_err(map_commit_error)
+}
+
 /// Why proving or extracting a migration transaction failed.
 pub enum BroadcastError {
     /// The stored PCZT could not be parsed.
@@ -368,6 +391,17 @@ fn deps_mined(state: &MigrationState, depends_on: &[MigrationTxId]) -> bool {
     })
 }
 
+/// Whether a deferred preparation layer is ready to build: a multi-layer preparation records its
+/// later layers (`layer > 0`) as unbuilt placeholders, and one becomes buildable once its whole
+/// prior layer (its `depends_on`) is mined and its feeder notes are witnessable.
+fn has_ready_prep_layer(state: &MigrationState) -> bool {
+    state.transactions.iter().any(|t| {
+        matches!(t.kind, MigrationTxKind::Preparation { layer, .. } if layer > 0)
+            && matches!(t.state, MigrationTxState::Planned)
+            && deps_mined(state, &t.depends_on)
+    })
+}
+
 /// The index of the next transaction ready to prove and broadcast: pre-signed (`Signed`), its
 /// dependencies mined, and scheduled at or before `target_height`.
 fn next_broadcastable(state: &MigrationState, target_height: u32) -> Option<usize> {
@@ -421,9 +455,11 @@ pub fn record_broadcast(
 
 /// The blocking half of advancing a migration one step: load it, detect newly mined transactions,
 /// then either (a) prove+extract the next broadcastable transaction and return it for the caller to
-/// broadcast, (b) build the phase-2 transfers once the preparation is mined, or (c) report what it is
-/// waiting for. Runs inside the database write lock; the caller broadcasts asynchronously. `tip` is
-/// the current chain tip; transactions build and become due at `tip + 1`.
+/// broadcast, (a.5) build the next preparation layer once its predecessor is mined (multi-layer
+/// preparations defer their later layers), (b) build the phase-2 transfers once the whole preparation
+/// is mined, or (c) report what it is waiting for. Runs inside the database write lock; the caller
+/// broadcasts asynchronously. `tip` is the current chain tip; transactions build and become due at
+/// `tip + 1`.
 pub fn advance_blocking(
     conn: &mut Connection,
     network: &Network,
@@ -471,6 +507,30 @@ pub fn advance_blocking(
             state,
             to_broadcast: Some((tx, tx_id)),
             message: format!("broadcasting a {kind} transaction"),
+        });
+    }
+
+    // (a.5) Build the next preparation layer once its predecessor is mined. A multi-layer preparation
+    // defers its later layers (their feeder notes are witnessable only after the prior layer mines);
+    // building the next ready layer turns its transactions into broadcastable `Signed` ones for a
+    // later step. This runs only after (a) finds nothing to broadcast, i.e. the current layer's
+    // transactions are all broadcast and mined.
+    if has_ready_prep_layer(&state) {
+        let mut updated = commit_pending_preparation_over_wallet(
+            conn,
+            network,
+            account,
+            usk,
+            target_height,
+            state.clone(),
+        )
+        .map_err(AdvanceError::Commit)?;
+        recompute_status(&mut updated);
+        persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
+        return Ok(AdvanceOutcome {
+            state: updated,
+            to_broadcast: None,
+            message: "built the next preparation layer".into(),
         });
     }
 

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -24,20 +24,30 @@
 //! wallet, not this snapshot.
 
 use core::convert::Infallible;
+use core::fmt;
+use std::sync::OnceLock;
 
+use orchard::circuit::{OrchardCircuitVersion, ProvingKey, VerifyingKey};
+use pczt::Pczt;
+use pczt::roles::prover::Prover;
+use pczt::roles::tx_extractor::TransactionExtractor;
 use rand::rngs::OsRng;
 use rusqlite::Connection;
+use zcash_client_backend::data_api::WalletRead;
 use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
     CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
-    MigrationTxState, PoolMigrationRead, PoolMigrationWrite, commit_preparation, commit_transfers,
-    plan_migration,
+    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, commit_preparation,
+    commit_transfers, plan_migration,
 };
 use zcash_pool_migration_backend::note_splitting::{FeePolicy, Zip317FeePolicy};
 use zcash_pool_migration_backend::preparation::PREP_TX_ACTIONS;
 use zcash_pool_migration_backend::wallet::WalletMigration;
 use zcash_pool_migration_sqlite::PoolMigrations;
+use zcash_primitives::transaction::components::orchard::bundle_version_for_branch;
+use zcash_primitives::transaction::{Transaction, TxId};
+use zcash_protocol::consensus::{BlockHeight, BranchId};
 
 use crate::network::Network;
 
@@ -112,7 +122,7 @@ pub fn is_terminal(state: &MigrationState) -> bool {
     )
 }
 
-fn map_plan_error<E: core::fmt::Display>(err: MigrationError<E>) -> CommitFailure {
+fn map_plan_error<E: fmt::Display>(err: MigrationError<E>) -> CommitFailure {
     match err {
         MigrationError::NothingToMigrate => CommitFailure::NothingToMigrate,
         MigrationError::Preparation(e) => CommitFailure::Other(format!(
@@ -122,7 +132,7 @@ fn map_plan_error<E: core::fmt::Display>(err: MigrationError<E>) -> CommitFailur
     }
 }
 
-fn map_commit_error<E: core::fmt::Display>(err: CommitError<E>) -> CommitFailure {
+fn map_commit_error<E: fmt::Display>(err: CommitError<E>) -> CommitFailure {
     match err {
         CommitError::UnsupportedMultiLayer => CommitFailure::UnsupportedMultiLayer,
         CommitError::NoMigrationInProgress => CommitFailure::NoMigrationInProgress,
@@ -234,4 +244,269 @@ pub fn commit_transfers_over_wallet(
     let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
     let mut rng = OsRng;
     commit_transfers(network, target_height, &mut migration, &mut rng).map_err(map_commit_error)
+}
+
+/// Why proving or extracting a migration transaction failed.
+pub enum BroadcastError {
+    /// The stored PCZT could not be parsed.
+    Parse(String),
+    /// Proving the PCZT failed.
+    Prove(String),
+    /// Extracting the transaction from the proved PCZT failed.
+    Extract(String),
+}
+
+impl fmt::Display for BroadcastError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BroadcastError::Parse(m) => write!(f, "parsing the migration transaction failed: {m}"),
+            BroadcastError::Prove(m) => write!(f, "proving the migration transaction failed: {m}"),
+            BroadcastError::Extract(m) => {
+                write!(f, "extracting the migration transaction failed: {m}")
+            }
+        }
+    }
+}
+
+/// The Orchard circuit version the migration's transactions are proved and verified against, derived
+/// from the consensus branch at `height`. A migration runs at NU6.3+, whose Orchard protocol
+/// revision fixes the circuit version; the same version applies to the Orchard preparation bundles
+/// and the Ironwood transfer bundles.
+fn orchard_circuit_version(params: &Network, height: BlockHeight) -> OrchardCircuitVersion {
+    let branch = BranchId::for_height(params, height);
+    bundle_version_for_branch(branch, orchard::ValuePool::Orchard)
+        .expect("a migration runs at NU6.3+, which has an Orchard bundle version")
+        .circuit_version()
+}
+
+/// The Orchard proving key, built once and cached (building it is expensive). The same key proves
+/// both the Orchard preparation bundles and the Ironwood transfer bundles. All of a migration's
+/// transactions share one circuit version (its consensus branch), so caching a single key is sound.
+fn orchard_proving_key(version: OrchardCircuitVersion) -> &'static ProvingKey {
+    static PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
+    PROVING_KEY.get_or_init(|| ProvingKey::build(version))
+}
+
+/// The Orchard verifying key, built once and cached. It verifies both the Orchard and the Ironwood
+/// bundles when the transaction is extracted.
+fn orchard_verifying_key(version: OrchardCircuitVersion) -> &'static VerifyingKey {
+    static VERIFYING_KEY: OnceLock<VerifyingKey> = OnceLock::new();
+    VERIFYING_KEY.get_or_init(|| VerifyingKey::build(version))
+}
+
+/// Proves a stored, pre-signed but unproven migration PCZT and extracts the broadcastable
+/// transaction. `height` selects the circuit version (the migration's consensus branch). Proving is
+/// CPU-heavy, so call this inside the blocking database section; the extracted transaction is then
+/// broadcast asynchronously by the caller.
+pub fn prove_and_extract(
+    params: &Network,
+    height: BlockHeight,
+    pczt_bytes: &[u8],
+) -> Result<Transaction, BroadcastError> {
+    let version = orchard_circuit_version(params, height);
+    let pczt = Pczt::parse(pczt_bytes).map_err(|e| BroadcastError::Parse(format!("{e:?}")))?;
+    let mut prover = Prover::new(pczt);
+    if prover.requires_orchard_proof() {
+        prover = prover
+            .create_orchard_proof(orchard_proving_key(version))
+            .map_err(|e| BroadcastError::Prove(format!("{e:?}")))?;
+    }
+    if prover.requires_ironwood_proof() {
+        prover = prover
+            .create_ironwood_proof(orchard_proving_key(version))
+            .map_err(|e| BroadcastError::Prove(format!("{e:?}")))?;
+    }
+    let pczt = prover.finish();
+    TransactionExtractor::new(pczt)
+        .with_orchard(orchard_verifying_key(version))
+        .extract()
+        .map_err(|e| BroadcastError::Extract(format!("{e:?}")))
+}
+
+/// Why advancing a migration one step failed.
+pub enum AdvanceError {
+    /// No migration is stored.
+    NoMigration,
+    /// A store (load/persist) failure.
+    Store(String),
+    /// Building the phase-2 transfers failed.
+    Commit(CommitFailure),
+    /// Proving or extracting a transaction failed.
+    Prove(BroadcastError),
+}
+
+/// The outcome of the blocking half of advancing a migration one step.
+pub struct AdvanceOutcome {
+    /// The migration state after the step. If `to_broadcast` is set, this is NOT yet persisted (the
+    /// caller broadcasts, records the txid, and persists); otherwise it is already persisted.
+    pub state: MigrationState,
+    /// A proved, extracted transaction to broadcast next, with the id of the migration transaction it
+    /// corresponds to.
+    pub to_broadcast: Option<(Transaction, MigrationTxId)>,
+    /// A short description of what the step did.
+    pub message: String,
+}
+
+/// Whether all of a migration's preparation transactions are mined.
+fn all_preparations_mined(state: &MigrationState) -> bool {
+    state
+        .transactions
+        .iter()
+        .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
+        .all(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+}
+
+/// Whether every transaction in `depends_on` is mined.
+fn deps_mined(state: &MigrationState, depends_on: &[MigrationTxId]) -> bool {
+    depends_on.iter().all(|dep| {
+        state
+            .transactions
+            .iter()
+            .find(|t| t.id == *dep)
+            .map(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+            .unwrap_or(false)
+    })
+}
+
+/// The index of the next transaction ready to prove and broadcast: pre-signed (`Signed`), its
+/// dependencies mined, and scheduled at or before `target_height`.
+fn next_broadcastable(state: &MigrationState, target_height: u32) -> Option<usize> {
+    state.transactions.iter().position(|t| {
+        matches!(t.state, MigrationTxState::Signed)
+            && t.scheduled_height <= target_height
+            && deps_mined(state, &t.depends_on)
+    })
+}
+
+/// Recomputes the overall migration status: complete once every transaction is mined, in progress
+/// once any has been broadcast or mined.
+fn recompute_status(state: &mut MigrationState) {
+    let all_mined = !state.transactions.is_empty()
+        && state
+            .transactions
+            .iter()
+            .all(|t| matches!(t.state, MigrationTxState::Mined { .. }));
+    let any_started = state.transactions.iter().any(|t| {
+        matches!(
+            t.state,
+            MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
+        )
+    });
+    if all_mined {
+        state.status = MigrationStatus::Complete;
+    } else if any_started {
+        state.status = MigrationStatus::InProgress;
+    }
+}
+
+/// The txid bytes of a transaction, for recording its broadcast in the store.
+pub fn transaction_txid_bytes(tx: &Transaction) -> [u8; 32] {
+    *tx.txid().as_ref()
+}
+
+/// Records that the migration transaction `tx_id` was broadcast with `txid`, recomputes the status,
+/// and persists the state.
+pub fn record_broadcast(
+    conn: &mut Connection,
+    state: &mut MigrationState,
+    tx_id: MigrationTxId,
+    txid: [u8; 32],
+) -> Result<(), AdvanceError> {
+    if let Some(tx) = state.transactions.iter_mut().find(|t| t.id == tx_id) {
+        tx.state = MigrationTxState::Broadcast { txid };
+    }
+    recompute_status(state);
+    persist_migration(conn, state).map_err(|e| AdvanceError::Store(e.to_string()))
+}
+
+/// The blocking half of advancing a migration one step: load it, detect newly mined transactions,
+/// then either (a) prove+extract the next broadcastable transaction and return it for the caller to
+/// broadcast, (b) build the phase-2 transfers once the preparation is mined, or (c) report what it is
+/// waiting for. Runs inside the database write lock; the caller broadcasts asynchronously. `tip` is
+/// the current chain tip; transactions build and become due at `tip + 1`.
+pub fn advance_blocking(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    tip: u32,
+) -> Result<AdvanceOutcome, AdvanceError> {
+    let target_height = tip + 1;
+
+    let mut state = load_migration(conn)
+        .map_err(|e| AdvanceError::Store(e.to_string()))?
+        .ok_or(AdvanceError::NoMigration)?;
+
+    // Detect newly mined transactions: a broadcast transaction the wallet now sees at a height.
+    {
+        let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+        for tx in state.transactions.iter_mut() {
+            if let MigrationTxState::Broadcast { txid } = tx.state {
+                if let Some(height) = wallet
+                    .get_tx_height(TxId::from_bytes(txid))
+                    .map_err(|e| AdvanceError::Store(e.to_string()))?
+                {
+                    tx.state = MigrationTxState::Mined {
+                        height: u32::from(height),
+                    };
+                }
+            }
+        }
+    }
+    recompute_status(&mut state);
+
+    // (a) Broadcast the next ready transaction.
+    if let Some(index) = next_broadcastable(&state, target_height) {
+        let bytes = state.transactions[index].pczt.clone().ok_or_else(|| {
+            AdvanceError::Store("a signed transaction is missing its PCZT".into())
+        })?;
+        let tx = prove_and_extract(network, BlockHeight::from(tip), &bytes)
+            .map_err(AdvanceError::Prove)?;
+        let tx_id = state.transactions[index].id;
+        let kind = match state.transactions[index].kind {
+            MigrationTxKind::Preparation { .. } => "preparation",
+            MigrationTxKind::Transfer { .. } => "transfer",
+        };
+        return Ok(AdvanceOutcome {
+            state,
+            to_broadcast: Some((tx, tx_id)),
+            message: format!("broadcasting a {kind} transaction"),
+        });
+    }
+
+    // (b) Build the phase-2 transfers once every preparation is mined.
+    let has_unbuilt_transfers = state.transactions.iter().any(|t| {
+        matches!(t.kind, MigrationTxKind::Transfer { .. })
+            && matches!(t.state, MigrationTxState::Planned)
+    });
+    if all_preparations_mined(&state) && has_unbuilt_transfers {
+        let mut updated =
+            commit_transfers_over_wallet(conn, network, account, usk, target_height, state.clone())
+                .map_err(AdvanceError::Commit)?;
+        recompute_status(&mut updated);
+        persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
+        return Ok(AdvanceOutcome {
+            state: updated,
+            to_broadcast: None,
+            message: "built the transfer transactions".into(),
+        });
+    }
+
+    // (c) Nothing to do this step: persist the mining updates and report what it is waiting for.
+    persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
+    let pending = state
+        .transactions
+        .iter()
+        .filter(|t| !matches!(t.state, MigrationTxState::Mined { .. }))
+        .count();
+    let message = if pending == 0 {
+        "the migration is complete".to_string()
+    } else {
+        format!("waiting for {pending} transaction(s) to mine")
+    };
+    Ok(AdvanceOutcome {
+        state,
+        to_broadcast: None,
+        message,
+    })
 }

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -101,9 +101,6 @@ impl MigrationBackend for SpendableSnapshot {
 pub enum CommitFailure {
     /// The account has no spendable source-pool balance to migrate.
     NothingToMigrate,
-    /// The plan needs multi-layer preparation, which the two-phase commit path does not yet
-    /// support.
-    UnsupportedMultiLayer,
     /// There is no committed migration to act on (nothing was loaded from the store).
     NoMigrationInProgress,
     /// A migration is already in progress; starting another would overwrite its pre-signed
@@ -134,10 +131,14 @@ fn map_plan_error<E: fmt::Display>(err: MigrationError<E>) -> CommitFailure {
 
 fn map_commit_error<E: fmt::Display>(err: CommitError<E>) -> CommitFailure {
     match err {
-        CommitError::UnsupportedMultiLayer => CommitFailure::UnsupportedMultiLayer,
         CommitError::NoMigrationInProgress => CommitFailure::NoMigrationInProgress,
         CommitError::Backend(e) => CommitFailure::Other(e.to_string()),
         CommitError::Build(m) => CommitFailure::Other(m),
+        // Multi-layer preparation is supported (committed layer by layer), so the engine no longer
+        // rejects it; any residual variant maps to a generic build failure.
+        CommitError::UnsupportedMultiLayer => {
+            CommitFailure::Other("unexpected multi-layer commit rejection".into())
+        }
     }
 }
 

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -16,18 +16,14 @@
 //! error handling in the RPC layer, and lets the pure planner run synchronously
 //! after the last `.await`.
 //!
-//! The trait also declares persistence methods (store/load/update) used by the
-//! still-unreleased commit and reconcile slices. This planning-only snapshot does
-//! not persist anything: `load_migration` reports "no migration in progress" and
-//! the mutating methods return [`SnapshotError::PersistenceUnsupported`]. A
-//! persistence-capable backend over the wallet database replaces it once those
-//! slices land.
+//! Persistence is a separate concern: the engine's `PoolMigrationRead` /
+//! `PoolMigrationWrite` store traits (implemented over the wallet database by
+//! `zcash_pool_migration_sqlite`) hold a committed migration, and the
+//! `MigrationBackend` trait this snapshot implements is now just the planning
+//! inputs. Committing a migration uses the `WalletMigration` adapter over the
+//! wallet, not this snapshot.
 
-use std::fmt;
-
-use zcash_pool_migration_backend::engine::{
-    MigrationBackend, MigrationState, MigrationTxId, MigrationTxState,
-};
+use zcash_pool_migration_backend::engine::MigrationBackend;
 
 /// The backend-agnostic value-pool migration engine.
 ///
@@ -37,37 +33,15 @@ use zcash_pool_migration_backend::engine::{
 /// avoid coupling Zallet code to specific items until the engine is released.
 pub use zcash_pool_migration_backend as engine;
 
-/// The error type of the planning-only [`SpendableSnapshot`] backend.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SnapshotError {
-    /// The planning snapshot cannot persist migration state. Committing a
-    /// migration (building, pre-signing, and storing the PCZTs) needs a
-    /// persistence-capable backend, which a later engine slice provides.
-    PersistenceUnsupported,
-}
-
-impl fmt::Display for SnapshotError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SnapshotError::PersistenceUnsupported => f.write_str(
-                "the migration preview backend does not persist migration state; \
-                 committing a migration is not yet available",
-            ),
-        }
-    }
-}
-
-impl std::error::Error for SnapshotError {}
-
 /// A point-in-time snapshot of the inputs the migration engine needs to PLAN a
 /// migration for one account: the values of the account's spendable source-pool
 /// (Orchard) notes, and the chain-tip height.
 ///
 /// This is Zallet's `MigrationBackend` for planning. The caller gathers both
 /// values from the wallet (mapping any wallet error to an RPC error), then hands
-/// the snapshot to `engine::plan_migration`. The persistence methods are not
-/// supported (see the module docs): planning never calls them, and committing
-/// needs a different, persistence-capable backend.
+/// the snapshot to `engine::plan_migration`. It holds only already-read values,
+/// so it is infallible; committing a migration uses the `WalletMigration`
+/// adapter over the wallet, not this snapshot.
 pub struct SpendableSnapshot {
     orchard_note_values: Vec<u64>,
     chain_tip_height: u32,
@@ -85,7 +59,7 @@ impl SpendableSnapshot {
 }
 
 impl MigrationBackend for SpendableSnapshot {
-    type Error = SnapshotError;
+    type Error = core::convert::Infallible;
 
     fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
         Ok(self.orchard_note_values.clone())
@@ -93,22 +67,5 @@ impl MigrationBackend for SpendableSnapshot {
 
     fn chain_tip_height(&self) -> Result<u32, Self::Error> {
         Ok(self.chain_tip_height)
-    }
-
-    fn store_migration(&mut self, _state: &MigrationState) -> Result<(), Self::Error> {
-        Err(SnapshotError::PersistenceUnsupported)
-    }
-
-    fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
-        // A planning snapshot never persists, so no migration is ever in progress through it.
-        Ok(None)
-    }
-
-    fn update_transaction(
-        &mut self,
-        _id: MigrationTxId,
-        _state: MigrationTxState,
-    ) -> Result<(), Self::Error> {
-        Err(SnapshotError::PersistenceUnsupported)
     }
 }

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -27,28 +27,29 @@ use core::convert::Infallible;
 use core::fmt;
 use std::sync::OnceLock;
 
-use orchard::circuit::{OrchardCircuitVersion, ProvingKey, VerifyingKey};
-use orchard::keys::SpendAuthorizingKey;
+use orchard::circuit::{OrchardCircuitVersion, VerifyingKey};
+use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
 use pczt::Pczt;
-use pczt::roles::prover::Prover;
 use pczt::roles::tx_extractor::TransactionExtractor;
 use rand::rngs::OsRng;
 use rusqlite::Connection;
-use zcash_client_backend::data_api::WalletRead;
+use shardtree::error::ShardTreeError;
+use zcash_client_backend::data_api::{WalletCommitmentTrees, WalletRead};
 use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::build::sign_pczt;
 use zcash_pool_migration_backend::engine::{
     CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
     MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, UnsignedMigrationTx,
-    build_preparation_unsigned, commit_preparation, plan_migration,
+    build_preparation_unsigned, commit_preparation, plan_migration, prove_preparation,
+    prove_transfer,
 };
 // The migration state machine lives in the engine (the mobile wallet drives it the same way); zallet
 // only performs the wallet I/O around the engine's decisions. The decision and transition logic are
 // methods on `MigrationState` (`next_step`, `mark_mined`, `mark_broadcast`, `is_terminal`, ...).
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
 use zcash_pool_migration_backend::state::AdvanceStep;
-use zcash_pool_migration_backend::wallet::WalletMigration;
+use zcash_pool_migration_backend::wallet::{WalletMigration, WalletMigrationProver};
 use zcash_primitives::transaction::components::orchard::bundle_version_for_branch;
 use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{BlockHeight, BranchId};
@@ -328,14 +329,6 @@ fn orchard_circuit_version(params: &Network, height: BlockHeight) -> OrchardCirc
         .circuit_version()
 }
 
-/// The Orchard proving key, built once and cached (building it is expensive). The same key proves
-/// both the Orchard preparation bundles and the Ironwood transfer bundles. All of a migration's
-/// transactions share one circuit version (its consensus branch), so caching a single key is sound.
-fn orchard_proving_key(version: OrchardCircuitVersion) -> &'static ProvingKey {
-    static PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-    PROVING_KEY.get_or_init(|| ProvingKey::build(version))
-}
-
 /// The Orchard verifying key, built once and cached. It verifies both the Orchard and the Ironwood
 /// bundles when the transaction is extracted.
 fn orchard_verifying_key(version: OrchardCircuitVersion) -> &'static VerifyingKey {
@@ -343,33 +336,53 @@ fn orchard_verifying_key(version: OrchardCircuitVersion) -> &'static VerifyingKe
     VERIFYING_KEY.get_or_init(|| VerifyingKey::build(version))
 }
 
-/// Proves a stored, pre-signed but unproven migration PCZT and extracts the broadcastable
-/// transaction. `height` selects the circuit version (the migration's consensus branch). Proving is
-/// CPU-heavy, so call this inside the blocking database section; the extracted transaction is then
-/// broadcast asynchronously by the caller.
-pub fn prove_and_extract(
+/// Extracts the broadcastable transaction from an already-proven migration PCZT, verifying its
+/// Orchard (and, for a transfer, Ironwood) proofs against the circuit's verifying key. `height`
+/// selects the circuit version (the migration's consensus branch). Proving itself is done through
+/// the engine (`prove_preparation` / `prove_transfer`), which installs the deferred anchor and
+/// witnesses from the wallet's own commitment tree before proving.
+fn extract_proven(
     params: &Network,
     height: BlockHeight,
     pczt_bytes: &[u8],
 ) -> Result<Transaction, BroadcastError> {
     let version = orchard_circuit_version(params, height);
     let pczt = Pczt::parse(pczt_bytes).map_err(|e| BroadcastError::Parse(format!("{e:?}")))?;
-    let mut prover = Prover::new(pczt);
-    if prover.requires_orchard_proof() {
-        prover = prover
-            .create_orchard_proof(orchard_proving_key(version))
-            .map_err(|e| BroadcastError::Prove(format!("{e:?}")))?;
-    }
-    if prover.requires_ironwood_proof() {
-        prover = prover
-            .create_ironwood_proof(orchard_proving_key(version))
-            .map_err(|e| BroadcastError::Prove(format!("{e:?}")))?;
-    }
-    let pczt = prover.finish();
     TransactionExtractor::new(pczt)
         .with_orchard(orchard_verifying_key(version))
         .extract()
         .map_err(|e| BroadcastError::Extract(format!("{e:?}")))
+}
+
+/// The highest Orchard checkpoint at or below `from` whose commitment-tree root is available, or
+/// `None` if there is none. A migration preparation spends the wallet's existing Orchard notes, so
+/// it anchors to the newest settled (rooted) checkpoint; right after scanning, the tip checkpoint is
+/// not yet rooted, so this walks down from `from` to the newest checkpoint with a root. This mirrors
+/// the anchor selection the mobile wallet performs.
+fn highest_rooted_orchard_checkpoint<W>(
+    db: &mut W,
+    from: BlockHeight,
+) -> Result<Option<BlockHeight>, AdvanceError>
+where
+    W: WalletCommitmentTrees,
+    <W as WalletCommitmentTrees>::Error: fmt::Debug,
+{
+    let mut height = u32::from(from);
+    loop {
+        let bh = BlockHeight::from_u32(height);
+        let rooted = db
+            .with_orchard_tree_mut::<_, _, ShardTreeError<<W as WalletCommitmentTrees>::Error>>(
+                |tree| Ok(tree.root_at_checkpoint_id(&bh)?.is_some()),
+            )
+            .map_err(|e| AdvanceError::Store(format!("{e:?}")))?;
+        if rooted {
+            return Ok(Some(bh));
+        }
+        if height == 0 {
+            return Ok(None);
+        }
+        height -= 1;
+    }
 }
 
 /// Why advancing a migration one step failed.
@@ -427,8 +440,8 @@ pub fn record_broadcast(
 pub fn advance_blocking(
     conn: &mut Connection,
     network: &Network,
-    _account: AccountUuid,
-    _usk: UnifiedSpendingKey,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
     tip: u32,
 ) -> Result<AdvanceOutcome, AdvanceError> {
     let target_height = tip + 1;
@@ -476,19 +489,91 @@ pub fn advance_blocking(
     // Decide the next step from state alone (the same decision the mobile wallet makes), then perform
     // the wallet I/O it calls for.
     match state.next_step(BlockHeight::from_u32(target_height)) {
-        // Prove and extract the next ready transaction; the caller broadcasts it.
+        // Prove and extract the next ready transaction; the caller broadcasts it. Proving runs
+        // through the engine, which installs each spend's deferred Orchard anchor and witnesses from
+        // the wallet's own commitment tree (the transaction was built and signed with the anchor
+        // absent, per ZIP 374), then produces the proofs.
+        // Prove the next due transaction (`Signed -> Proved`) and store the proven PCZT, WITHOUT
+        // broadcasting. Proving installs the deferred Orchard anchor and every spend's witness from
+        // the wallet's own commitment tree; for a transfer this must happen while its drawn anchor
+        // boundary is still within the wallet's checkpoint-pruning window, so proving is a step
+        // separate from (and earlier than) broadcasting, which waits for the privacy broadcast
+        // schedule. The proven state is persisted here; the caller broadcasts it in a later step.
+        AdvanceStep::Prove { id } => {
+            let (is_transfer, kind) = {
+                let tx_ref = state
+                    .transactions()
+                    .iter()
+                    .find(|t| t.id() == id)
+                    .ok_or_else(|| AdvanceError::Store("the next transaction is missing".into()))?;
+                match tx_ref.kind() {
+                    MigrationTxKind::Preparation { .. } => (false, "preparation"),
+                    MigrationTxKind::Transfer { .. } => (true, "transfer"),
+                }
+            };
+            // Prove in place, scoping the wallet's mutable borrow of `conn`.
+            {
+                let mut walletdb =
+                    WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+                let fvk = FullViewingKey::from(usk.orchard());
+                if is_transfer {
+                    // A transfer proves against the anchor boundary drawn for it at plan time. The
+                    // state machine only offers a transfer to prove once that boundary has settled
+                    // below the tip, so its checkpoint exists and is still within the pruning window.
+                    let mut prover = WalletMigrationProver::new(&mut walletdb, account, fvk);
+                    prove_transfer(&mut prover, &mut state, id).map_err(|e| {
+                        AdvanceError::Prove(BroadcastError::Prove(format!("{e:?}")))
+                    })?;
+                } else {
+                    // A preparation spends the wallet's existing Orchard notes; anchor it to the
+                    // newest rooted checkpoint at or below the tip.
+                    let anchor = highest_rooted_orchard_checkpoint(
+                        &mut walletdb,
+                        BlockHeight::from_u32(tip),
+                    )?
+                    .ok_or_else(|| {
+                        AdvanceError::Prove(BroadcastError::Prove(
+                            "no rooted Orchard checkpoint is available to anchor the \
+                                     preparation"
+                                .into(),
+                        ))
+                    })?;
+                    let mut prover = WalletMigrationProver::new(&mut walletdb, account, fvk);
+                    prove_preparation(&mut prover, &mut state, id, anchor).map_err(|e| {
+                        AdvanceError::Prove(BroadcastError::Prove(format!("{e:?}")))
+                    })?;
+                }
+            }
+            // The transaction is now `Proved`; persist it (no broadcast this step).
+            persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
+            Ok(AdvanceOutcome {
+                state,
+                to_broadcast: None,
+                message: format!("proving a {kind} transaction"),
+            })
+        }
+        // Broadcast an ALREADY-PROVEN transaction: extract the stored proven PCZT and hand it to the
+        // caller. Proving happened in an earlier `Prove` step, so this needs no wallet-tree access.
         AdvanceStep::Broadcast { id } => {
-            let tx_ref = state
+            let kind = {
+                let tx_ref = state
+                    .transactions()
+                    .iter()
+                    .find(|t| t.id() == id)
+                    .ok_or_else(|| AdvanceError::Store("the next transaction is missing".into()))?;
+                match tx_ref.kind() {
+                    MigrationTxKind::Preparation { .. } => "preparation",
+                    MigrationTxKind::Transfer { .. } => "transfer",
+                }
+            };
+            let proven_bytes = state
                 .transactions()
                 .iter()
                 .find(|t| t.id() == id)
-                .ok_or_else(|| AdvanceError::Store("the next transaction is missing".into()))?;
-            let bytes = tx_ref.pczt().clone();
-            let kind = match tx_ref.kind() {
-                MigrationTxKind::Preparation { .. } => "preparation",
-                MigrationTxKind::Transfer { .. } => "transfer",
-            };
-            let tx = prove_and_extract(network, BlockHeight::from(tip), &bytes)
+                .ok_or_else(|| AdvanceError::Store("the proven transaction is missing".into()))?
+                .pczt()
+                .clone();
+            let tx = extract_proven(network, BlockHeight::from(tip), &proven_bytes)
                 .map_err(AdvanceError::Prove)?;
             Ok(AdvanceOutcome {
                 state,

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -37,9 +37,9 @@ use zcash_client_backend::data_api::WalletRead;
 use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
-    CommitError, MigrationBackend, MigrationError, MigrationState, MigrationTxId, MigrationTxKind,
-    MigrationTxState, PoolMigrationRead, PoolMigrationWrite, commit_pending_preparation,
-    commit_preparation, commit_transfers, plan_migration,
+    CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
+    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    commit_pending_preparation, commit_preparation, commit_transfers, plan_migration,
 };
 // The migration state machine lives in the engine (the mobile wallet drives it the same way); zallet
 // only performs the wallet I/O around the engine's decisions. The decision and transition logic are
@@ -398,6 +398,21 @@ pub fn advance_blocking(
     let mut state = load_migration(conn)
         .map_err(|e| AdvanceError::Store(e.to_string()))?
         .ok_or(AdvanceError::NoMigration)?;
+
+    // A terminal migration (complete, or cancelled/failed) is never advanced: report its status and
+    // do nothing, so a cancelled migration cannot be driven further or resurrected.
+    if state.is_terminal() {
+        let message = if matches!(state.status, MigrationStatus::Complete) {
+            "the migration is complete"
+        } else {
+            "the migration was cancelled"
+        };
+        return Ok(AdvanceOutcome {
+            state,
+            to_broadcast: None,
+            message: message.to_string(),
+        });
+    }
 
     // Detect newly mined transactions: a broadcast transaction the wallet now sees at a height.
     // Collect the (id, height) pairs while the wallet is borrowed, then apply the engine's mining

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -1,18 +1,114 @@
 //! Scaffolding for the Orchard-to-Ironwood value-pool migration.
 //!
-//! This module wires the backend-agnostic Orchard-to-Ironwood migration engine
-//! into Zallet. It is currently only an integration point: the engine crate is
-//! still evolving upstream (it lives on a librustzcash feature branch and is not
-//! yet released to crates.io), so nothing here is written against the shape of
-//! its final API.
+//! This module wires the backend-agnostic pool-migration engine into Zallet. The
+//! engine crate is still evolving upstream (it lives on a librustzcash feature
+//! branch and is not yet released to crates.io), so this module keeps the
+//! integration seam small: the rest of Zallet reaches the engine through the
+//! [`engine`] re-export rather than depending on the external crate name
+//! directly.
 //!
-//! The engine is re-exported so that, as the integration grows, the rest of
-//! Zallet has a single stable path to reach it rather than depending on the
-//! external crate name directly.
+//! It also provides [`SpendableSnapshot`], Zallet's implementation of the
+//! engine's `MigrationBackend` trait for the PLANNING slice. The engine's
+//! `plan_migration` needs only the account's spendable source-pool note values
+//! and the chain-tip height, so the snapshot captures both from the wallet up
+//! front and serves them back to the engine. Capturing a snapshot (rather than
+//! querying the wallet from inside the trait methods) keeps all wallet I/O and its
+//! error handling in the RPC layer, and lets the pure planner run synchronously
+//! after the last `.await`.
+//!
+//! The trait also declares persistence methods (store/load/update) used by the
+//! still-unreleased commit and reconcile slices. This planning-only snapshot does
+//! not persist anything: `load_migration` reports "no migration in progress" and
+//! the mutating methods return [`SnapshotError::PersistenceUnsupported`]. A
+//! persistence-capable backend over the wallet database replaces it once those
+//! slices land.
 
-/// The backend-agnostic Orchard-to-Ironwood value-pool migration engine.
+use std::fmt;
+
+use zcash_pool_migration_backend::engine::{
+    MigrationBackend, MigrationState, MigrationTxId, MigrationTxState,
+};
+
+/// The backend-agnostic value-pool migration engine.
 ///
-/// Re-exported from the `zcash_ironwood_migration_backend` crate. Its API is not
-/// yet stable; treat this re-export as the integration seam and avoid coupling
-/// Zallet code to specific items until the engine is released.
-pub use zcash_ironwood_migration_backend as engine;
+/// Re-exported from the `zcash_pool_migration_backend` crate (formerly
+/// `zcash_ironwood_migration_backend`, renamed upstream to a pool-agnostic name).
+/// Its API is not yet stable; treat this re-export as the integration seam and
+/// avoid coupling Zallet code to specific items until the engine is released.
+pub use zcash_pool_migration_backend as engine;
+
+/// The error type of the planning-only [`SpendableSnapshot`] backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotError {
+    /// The planning snapshot cannot persist migration state. Committing a
+    /// migration (building, pre-signing, and storing the PCZTs) needs a
+    /// persistence-capable backend, which a later engine slice provides.
+    PersistenceUnsupported,
+}
+
+impl fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SnapshotError::PersistenceUnsupported => f.write_str(
+                "the migration preview backend does not persist migration state; \
+                 committing a migration is not yet available",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotError {}
+
+/// A point-in-time snapshot of the inputs the migration engine needs to PLAN a
+/// migration for one account: the values of the account's spendable source-pool
+/// (Orchard) notes, and the chain-tip height.
+///
+/// This is Zallet's `MigrationBackend` for planning. The caller gathers both
+/// values from the wallet (mapping any wallet error to an RPC error), then hands
+/// the snapshot to `engine::plan_migration`. The persistence methods are not
+/// supported (see the module docs): planning never calls them, and committing
+/// needs a different, persistence-capable backend.
+pub struct SpendableSnapshot {
+    orchard_note_values: Vec<u64>,
+    chain_tip_height: u32,
+}
+
+impl SpendableSnapshot {
+    /// Builds a snapshot from the spendable source-pool note values and the
+    /// chain-tip height the caller has already read from the wallet.
+    pub fn new(orchard_note_values: Vec<u64>, chain_tip_height: u32) -> Self {
+        Self {
+            orchard_note_values,
+            chain_tip_height,
+        }
+    }
+}
+
+impl MigrationBackend for SpendableSnapshot {
+    type Error = SnapshotError;
+
+    fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
+        Ok(self.orchard_note_values.clone())
+    }
+
+    fn chain_tip_height(&self) -> Result<u32, Self::Error> {
+        Ok(self.chain_tip_height)
+    }
+
+    fn store_migration(&mut self, _state: &MigrationState) -> Result<(), Self::Error> {
+        Err(SnapshotError::PersistenceUnsupported)
+    }
+
+    fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        // A planning snapshot never persists, so no migration is ever in progress through it.
+        Ok(None)
+    }
+
+    fn update_transaction(
+        &mut self,
+        _id: MigrationTxId,
+        _state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        Err(SnapshotError::PersistenceUnsupported)
+    }
+}

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -28,6 +28,7 @@ use core::fmt;
 use std::sync::OnceLock;
 
 use orchard::circuit::{OrchardCircuitVersion, ProvingKey, VerifyingKey};
+use orchard::keys::SpendAuthorizingKey;
 use pczt::Pczt;
 use pczt::roles::prover::Prover;
 use pczt::roles::tx_extractor::TransactionExtractor;
@@ -36,10 +37,12 @@ use rusqlite::Connection;
 use zcash_client_backend::data_api::WalletRead;
 use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
 use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_pool_migration_backend::build::sign_pczt;
 use zcash_pool_migration_backend::engine::{
     CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
-    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
-    commit_pending_preparation, commit_preparation, commit_transfers, plan_migration,
+    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, UnsignedMigrationTx,
+    build_preparation_unsigned, build_transfers_unsigned, commit_pending_preparation,
+    commit_preparation, commit_transfers, plan_migration,
 };
 // The migration state machine lives in the engine (the mobile wallet drives it the same way); zallet
 // only performs the wallet I/O around the engine's decisions. The decision and transition logic are
@@ -260,6 +263,79 @@ pub fn commit_pending_preparation_over_wallet(
         .map_err(map_commit_error)
 }
 
+/// Plans and builds the PREPARATION of a migration for an EXTERNAL signer: builds every layer-0
+/// preparation transaction but leaves it UNSIGNED, returning the resulting state (NOT persisted; the
+/// caller persists it) together with the unsigned PCZTs to route to the signing device. Mirrors
+/// [`commit_preparation_over_wallet`] but leaves the transactions in `AwaitingSignature`; the caller
+/// applies the signed PCZTs with [`MigrationState::apply_signature`]. Runs the engine synchronously;
+/// call inside the blocking database section.
+pub fn build_preparation_unsigned_over_wallet(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    target_height: u32,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitFailure> {
+    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let mut migration = WalletMigration::new(&mut wallet, account, usk, InMemoryStore::default());
+    let mut rng = OsRng;
+    let plan = plan_migration(&migration, prep_fee_zatoshi(), &mut rng).map_err(map_plan_error)?;
+    build_preparation_unsigned(network, target_height, &mut migration, &plan, &mut rng)
+        .map_err(map_commit_error)
+}
+
+/// Builds the TRANSFERS of an in-progress migration for an EXTERNAL signer: builds the phase-2
+/// transfer transactions (whose funding notes the mined preparation created) but leaves them
+/// UNSIGNED, returning the updated state (NOT persisted; the caller persists it) together with the
+/// unsigned PCZTs to route to the signing device. Mirrors [`commit_transfers_over_wallet`] but leaves
+/// the transactions in `AwaitingSignature`. `loaded` is the migration read from the store. Runs the
+/// engine synchronously; call inside the blocking database section.
+pub fn build_transfers_unsigned_over_wallet(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    target_height: u32,
+    loaded: MigrationState,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitFailure> {
+    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let store = InMemoryStore::seeded(Some(loaded));
+    let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
+    let mut rng = OsRng;
+    build_transfers_unsigned(network, target_height, &mut migration, &mut rng)
+        .map_err(map_commit_error)
+}
+
+/// Signs a migration PCZT with the account's Orchard spend authorization, for offline / air-gapped or
+/// external-device signing. Parses the unsigned PCZT, adds only the spend-auth signature (the Signer
+/// role; it neither proves nor extracts), and returns the serialized signed PCZT to apply to the
+/// migration via [`MigrationState::apply_signature`]. This is the counterpart the external signer runs
+/// on the built PCZT that [`build_preparation_unsigned_over_wallet`] /
+/// [`build_transfers_unsigned_over_wallet`] produced; a hardware wallet performs the same step on the
+/// device.
+pub fn sign_migration_pczt(
+    usk: &UnifiedSpendingKey,
+    pczt_bytes: &[u8],
+) -> Result<Vec<u8>, SignFailure> {
+    let pczt =
+        Pczt::parse(pczt_bytes).map_err(|e| SignFailure(format!("parsing the PCZT: {e:?}")))?;
+    let ask = SpendAuthorizingKey::from(usk.orchard());
+    let signed =
+        sign_pczt(pczt, &ask).map_err(|e| SignFailure(format!("signing the PCZT: {e:?}")))?;
+    signed
+        .serialize()
+        .map_err(|e| SignFailure(format!("serializing the signed PCZT: {e:?}")))
+}
+
+/// A failure to sign a migration PCZT with the account's spend authorization.
+pub struct SignFailure(pub String);
+
+impl fmt::Display for SignFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Why proving or extracting a migration transaction failed.
 pub enum BroadcastError {
     /// The stored PCZT could not be parsed.
@@ -347,6 +423,9 @@ pub enum AdvanceError {
     Commit(CommitFailure),
     /// Proving or extracting a transaction failed.
     Prove(BroadcastError),
+    /// The requested step is not supported for this migration (for example external signing of a
+    /// multi-layer preparation, which the seam does not yet cover).
+    Unsupported(String),
 }
 
 /// The outcome of the blocking half of advancing a migration one step.
@@ -511,6 +590,102 @@ pub fn advance_blocking(
                 to_broadcast: None,
                 message,
             })
+        }
+    }
+}
+
+/// The blocking half of building an EXTERNAL migration's transfers, the external-signer counterpart of
+/// the transfer-building that [`advance_blocking`] does in process. It loads the migration, detects
+/// newly mined preparation transactions (the same detection `advance_blocking` performs, so an
+/// external client uses this instead of advancing and never triggers in-process transfer signing), and
+/// once the whole preparation is mined builds the phase-2 transfers UNSIGNED, returning their PCZTs to
+/// route to the signing device. If the preparation is not yet fully mined it returns no PCZTs and
+/// leaves the migration waiting; a multi-layer preparation whose next step is a later unbuilt layer is
+/// reported as unsupported for external signing (the seam covers layer-0 preparation and transfers).
+/// Persists the state. Runs inside the database write lock. `tip` is the current chain tip;
+/// transactions build at `tip + 1`.
+pub fn build_transfers_unsigned_blocking(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    tip: u32,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>, String), AdvanceError> {
+    let target_height = tip + 1;
+
+    let mut state = load_migration(conn)
+        .map_err(|e| AdvanceError::Store(e.to_string()))?
+        .ok_or(AdvanceError::NoMigration)?;
+
+    if state.is_terminal() {
+        return Ok((
+            state,
+            Vec::new(),
+            "the migration is no longer in progress".to_string(),
+        ));
+    }
+
+    // Detect newly mined transactions (identical to `advance_blocking`).
+    let mut newly_mined: Vec<(MigrationTxId, u32)> = Vec::new();
+    {
+        let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+        for tx in state.transactions.iter() {
+            if let MigrationTxState::Broadcast { txid } = tx.state {
+                if let Some(height) = wallet
+                    .get_tx_height(TxId::from_bytes(txid))
+                    .map_err(|e| AdvanceError::Store(e.to_string()))?
+                {
+                    newly_mined.push((tx.id, u32::from(height)));
+                }
+            }
+        }
+    }
+    for (id, height) in newly_mined {
+        state.mark_mined(id, height);
+    }
+
+    match state.next_step(target_height) {
+        // The whole preparation is mined: build the transfers unsigned for the external signer.
+        AdvanceStep::BuildTransfers => {
+            let (mut updated, unsigned) = build_transfers_unsigned_over_wallet(
+                conn,
+                network,
+                account,
+                usk,
+                target_height,
+                state,
+            )
+            .map_err(AdvanceError::Commit)?;
+            updated.recompute_status();
+            persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
+            Ok((
+                updated,
+                unsigned,
+                "built the unsigned transfer transactions".to_string(),
+            ))
+        }
+        // A later preparation layer still needs building: external signing does not cover multi-layer
+        // preparation yet.
+        AdvanceStep::BuildPreparationLayer { layer } => Err(AdvanceError::Unsupported(format!(
+            "external signing of a multi-layer preparation is not yet supported (preparation layer \
+             {layer} still needs building)"
+        ))),
+        // The preparation is not yet fully mined (or nothing is ready to build): persist the mining
+        // updates and report what the migration is waiting for.
+        AdvanceStep::Broadcast { .. } | AdvanceStep::Waiting | AdvanceStep::Complete => {
+            persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
+            let pending_prep = state
+                .transactions
+                .iter()
+                .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
+                .filter(|t| !matches!(t.state, MigrationTxState::Mined { .. }))
+                .count();
+            let message = if pending_prep == 0 {
+                "the preparation is mined; no transfers are pending".to_string()
+            } else {
+                format!("waiting for {pending_prep} preparation transaction(s) to mine")
+            };
+            Ok((state, Vec::new(), message))
         }
     }
 }

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -23,7 +23,23 @@
 //! inputs. Committing a migration uses the `WalletMigration` adapter over the
 //! wallet, not this snapshot.
 
-use zcash_pool_migration_backend::engine::MigrationBackend;
+use core::convert::Infallible;
+
+use rand::rngs::OsRng;
+use rusqlite::Connection;
+use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_pool_migration_backend::engine::{
+    CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
+    MigrationTxState, PoolMigrationRead, PoolMigrationWrite, commit_preparation, commit_transfers,
+    plan_migration,
+};
+use zcash_pool_migration_backend::note_splitting::{FeePolicy, Zip317FeePolicy};
+use zcash_pool_migration_backend::preparation::PREP_TX_ACTIONS;
+use zcash_pool_migration_backend::wallet::WalletMigration;
+use zcash_pool_migration_sqlite::PoolMigrations;
+
+use crate::network::Network;
 
 /// The backend-agnostic value-pool migration engine.
 ///
@@ -59,7 +75,7 @@ impl SpendableSnapshot {
 }
 
 impl MigrationBackend for SpendableSnapshot {
-    type Error = core::convert::Infallible;
+    type Error = Infallible;
 
     fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
         Ok(self.orchard_note_values.clone())
@@ -68,4 +84,154 @@ impl MigrationBackend for SpendableSnapshot {
     fn chain_tip_height(&self) -> Result<u32, Self::Error> {
         Ok(self.chain_tip_height)
     }
+}
+
+/// Why committing (building/pre-signing) a migration failed, in terms the RPC layer maps to
+/// user-facing errors without depending on the engine's error shapes.
+pub enum CommitFailure {
+    /// The account has no spendable source-pool balance to migrate.
+    NothingToMigrate,
+    /// The plan needs multi-layer preparation, which the two-phase commit path does not yet
+    /// support.
+    UnsupportedMultiLayer,
+    /// There is no committed migration to act on (nothing was loaded from the store).
+    NoMigrationInProgress,
+    /// A migration is already in progress; starting another would overwrite its pre-signed
+    /// transactions. The caller must cancel the current migration first.
+    AlreadyInProgress,
+    /// Any other build/backend failure, rendered to a string.
+    Other(String),
+}
+
+/// Whether a stored migration has reached a terminal status (complete or failed), so a new migration
+/// may replace it. A non-terminal migration is still in progress and must not be overwritten.
+pub fn is_terminal(state: &MigrationState) -> bool {
+    matches!(
+        state.status,
+        MigrationStatus::Complete | MigrationStatus::Failed
+    )
+}
+
+fn map_plan_error<E: core::fmt::Display>(err: MigrationError<E>) -> CommitFailure {
+    match err {
+        MigrationError::NothingToMigrate => CommitFailure::NothingToMigrate,
+        MigrationError::Preparation(e) => CommitFailure::Other(format!(
+            "the spendable notes cannot fund the migration: {e}"
+        )),
+        MigrationError::Backend(e) => CommitFailure::Other(e.to_string()),
+    }
+}
+
+fn map_commit_error<E: core::fmt::Display>(err: CommitError<E>) -> CommitFailure {
+    match err {
+        CommitError::UnsupportedMultiLayer => CommitFailure::UnsupportedMultiLayer,
+        CommitError::NoMigrationInProgress => CommitFailure::NoMigrationInProgress,
+        CommitError::Backend(e) => CommitFailure::Other(e.to_string()),
+        CommitError::Build(m) => CommitFailure::Other(m),
+    }
+}
+
+/// An in-memory migration store used to run the engine's commit functions WITHOUT letting them
+/// write to SQLite. `commit_preparation` / `commit_transfers` return the resulting
+/// [`MigrationState`], so the caller runs the engine against this store, then persists the returned
+/// state to the real SQLite store separately. This keeps the engine's wallet access and the store's
+/// database access on ONE connection, used sequentially (never two live borrows at once).
+#[derive(Default)]
+pub struct InMemoryStore {
+    state: Option<MigrationState>,
+}
+
+impl InMemoryStore {
+    /// An in-memory store pre-seeded with a loaded migration (for `commit_transfers`, which reads
+    /// the in-progress migration before filling in the transfers).
+    pub fn seeded(state: Option<MigrationState>) -> Self {
+        Self { state }
+    }
+}
+
+impl PoolMigrationRead for InMemoryStore {
+    type Error = Infallible;
+
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        Ok(self.state.clone())
+    }
+}
+
+impl PoolMigrationWrite for InMemoryStore {
+    fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.state = Some(state.clone());
+        Ok(())
+    }
+
+    fn update_transaction(
+        &mut self,
+        id: MigrationTxId,
+        tx_state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        if let Some(state) = &mut self.state {
+            if let Some(tx) = state.transactions.iter_mut().find(|t| t.id == id) {
+                tx.state = tx_state;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The ZIP-317 fee reserved per note-preparation transaction (the fixed padded action count times
+/// the marginal fee), as the engine's planning and preparation both compute it.
+fn prep_fee_zatoshi() -> u64 {
+    PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
+}
+
+/// Loads the persisted migration from the SQLite store over `conn`.
+pub fn load_migration(
+    conn: &mut Connection,
+) -> Result<Option<MigrationState>, zcash_pool_migration_sqlite::Error> {
+    PoolMigrations::new(&mut *conn).get_migration()
+}
+
+/// Persists a migration to the SQLite store over `conn`, replacing any existing one.
+pub fn persist_migration(
+    conn: &mut Connection,
+    state: &MigrationState,
+) -> Result<(), zcash_pool_migration_sqlite::Error> {
+    PoolMigrations::new(&mut *conn).put_migration(state)
+}
+
+/// Plans and commits the PREPARATION of a migration over the wallet: builds and pre-signs every
+/// preparation transaction and records the transfer placeholders, returning the resulting state
+/// (NOT persisted; the caller persists it). Runs the engine synchronously; call inside the blocking
+/// database section, after the spending key has been decrypted.
+pub fn commit_preparation_over_wallet(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    target_height: u32,
+) -> Result<MigrationState, CommitFailure> {
+    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let mut migration = WalletMigration::new(&mut wallet, account, usk, InMemoryStore::default());
+    let mut rng = OsRng;
+    let plan = plan_migration(&migration, prep_fee_zatoshi(), &mut rng).map_err(map_plan_error)?;
+    commit_preparation(network, target_height, &mut migration, &plan, &mut rng)
+        .map_err(map_commit_error)
+}
+
+/// Commits the TRANSFERS of an in-progress migration over the wallet: builds and pre-signs the
+/// phase-2 transfer transactions (whose funding notes the mined preparation created), returning the
+/// updated state (NOT persisted; the caller persists it). `loaded` is the migration read from the
+/// store. Runs the engine synchronously; call inside the blocking database section.
+pub fn commit_transfers_over_wallet(
+    conn: &mut Connection,
+    network: &Network,
+    account: AccountUuid,
+    usk: UnifiedSpendingKey,
+    target_height: u32,
+    loaded: MigrationState,
+) -> Result<MigrationState, CommitFailure> {
+    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let store = InMemoryStore::seeded(Some(loaded));
+    let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
+    let mut rng = OsRng;
+    commit_transfers(network, target_height, &mut migration, &mut rng).map_err(map_commit_error)
 }

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -1,0 +1,18 @@
+//! Scaffolding for the Orchard-to-Ironwood value-pool migration.
+//!
+//! This module wires the backend-agnostic Orchard-to-Ironwood migration engine
+//! into Zallet. It is currently only an integration point: the engine crate is
+//! still evolving upstream (it lives on a librustzcash feature branch and is not
+//! yet released to crates.io), so nothing here is written against the shape of
+//! its final API.
+//!
+//! The engine is re-exported so that, as the integration grows, the rest of
+//! Zallet has a single stable path to reach it rather than depending on the
+//! external crate name directly.
+
+/// The backend-agnostic Orchard-to-Ironwood value-pool migration engine.
+///
+/// Re-exported from the `zcash_ironwood_migration_backend` crate. Its API is not
+/// yet stable; treat this re-export as the integration seam and avoid coupling
+/// Zallet code to specific items until the engine is released.
+pub use zcash_ironwood_migration_backend as engine;

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -37,12 +37,16 @@ use zcash_client_backend::data_api::WalletRead;
 use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration_backend::engine::{
-    CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
-    MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
-    commit_pending_preparation, commit_preparation, commit_transfers, plan_migration,
+    CommitError, MigrationBackend, MigrationError, MigrationState, MigrationTxId, MigrationTxKind,
+    MigrationTxState, PoolMigrationRead, PoolMigrationWrite, commit_pending_preparation,
+    commit_preparation, commit_transfers, plan_migration,
 };
+// The migration state machine lives in the engine (the mobile wallet drives it the same way); zallet
+// only performs the wallet I/O around the engine's decisions. The decision and transition logic are
+// methods on `MigrationState` (`next_step`, `mark_mined`, `mark_broadcast`, `is_terminal`, ...).
 use zcash_pool_migration_backend::note_splitting::{FeePolicy, Zip317FeePolicy};
 use zcash_pool_migration_backend::preparation::PREP_TX_ACTIONS;
+use zcash_pool_migration_backend::state::AdvanceStep;
 use zcash_pool_migration_backend::wallet::WalletMigration;
 use zcash_pool_migration_sqlite::PoolMigrations;
 use zcash_primitives::transaction::components::orchard::bundle_version_for_branch;
@@ -108,15 +112,6 @@ pub enum CommitFailure {
     AlreadyInProgress,
     /// Any other build/backend failure, rendered to a string.
     Other(String),
-}
-
-/// Whether a stored migration has reached a terminal status (complete or failed), so a new migration
-/// may replace it. A non-terminal migration is still in progress and must not be overwritten.
-pub fn is_terminal(state: &MigrationState) -> bool {
-    matches!(
-        state.status,
-        MigrationStatus::Complete | MigrationStatus::Failed
-    )
 }
 
 fn map_plan_error<E: fmt::Display>(err: MigrationError<E>) -> CommitFailure {
@@ -366,94 +361,29 @@ pub struct AdvanceOutcome {
     pub message: String,
 }
 
-/// Whether all of a migration's preparation transactions are mined.
-fn all_preparations_mined(state: &MigrationState) -> bool {
-    state
-        .transactions
-        .iter()
-        .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
-        .all(|t| matches!(t.state, MigrationTxState::Mined { .. }))
-}
-
-/// Whether every transaction in `depends_on` is mined.
-fn deps_mined(state: &MigrationState, depends_on: &[MigrationTxId]) -> bool {
-    depends_on.iter().all(|dep| {
-        state
-            .transactions
-            .iter()
-            .find(|t| t.id == *dep)
-            .map(|t| matches!(t.state, MigrationTxState::Mined { .. }))
-            .unwrap_or(false)
-    })
-}
-
-/// Whether a deferred preparation layer is ready to build: a multi-layer preparation records its
-/// later layers (`layer > 0`) as unbuilt placeholders, and one becomes buildable once its whole
-/// prior layer (its `depends_on`) is mined and its feeder notes are witnessable.
-fn has_ready_prep_layer(state: &MigrationState) -> bool {
-    state.transactions.iter().any(|t| {
-        matches!(t.kind, MigrationTxKind::Preparation { layer, .. } if layer > 0)
-            && matches!(t.state, MigrationTxState::Planned)
-            && deps_mined(state, &t.depends_on)
-    })
-}
-
-/// The index of the next transaction ready to prove and broadcast: pre-signed (`Signed`), its
-/// dependencies mined, and scheduled at or before `target_height`.
-fn next_broadcastable(state: &MigrationState, target_height: u32) -> Option<usize> {
-    state.transactions.iter().position(|t| {
-        matches!(t.state, MigrationTxState::Signed)
-            && t.scheduled_height <= target_height
-            && deps_mined(state, &t.depends_on)
-    })
-}
-
-/// Recomputes the overall migration status: complete once every transaction is mined, in progress
-/// once any has been broadcast or mined.
-fn recompute_status(state: &mut MigrationState) {
-    let all_mined = !state.transactions.is_empty()
-        && state
-            .transactions
-            .iter()
-            .all(|t| matches!(t.state, MigrationTxState::Mined { .. }));
-    let any_started = state.transactions.iter().any(|t| {
-        matches!(
-            t.state,
-            MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
-        )
-    });
-    if all_mined {
-        state.status = MigrationStatus::Complete;
-    } else if any_started {
-        state.status = MigrationStatus::InProgress;
-    }
-}
-
 /// The txid bytes of a transaction, for recording its broadcast in the store.
 pub fn transaction_txid_bytes(tx: &Transaction) -> [u8; 32] {
     *tx.txid().as_ref()
 }
 
-/// Records that the migration transaction `tx_id` was broadcast with `txid`, recomputes the status,
-/// and persists the state.
+/// Records that the migration transaction `tx_id` was broadcast with `txid` (via the engine's state
+/// transition, which also recomputes the overall status), and persists the state.
 pub fn record_broadcast(
     conn: &mut Connection,
     state: &mut MigrationState,
     tx_id: MigrationTxId,
     txid: [u8; 32],
 ) -> Result<(), AdvanceError> {
-    if let Some(tx) = state.transactions.iter_mut().find(|t| t.id == tx_id) {
-        tx.state = MigrationTxState::Broadcast { txid };
-    }
-    recompute_status(state);
+    state.mark_broadcast(tx_id, txid);
     persist_migration(conn, state).map_err(|e| AdvanceError::Store(e.to_string()))
 }
 
 /// The blocking half of advancing a migration one step: load it, detect newly mined transactions,
-/// then either (a) prove+extract the next broadcastable transaction and return it for the caller to
-/// broadcast, (a.5) build the next preparation layer once its predecessor is mined (multi-layer
-/// preparations defer their later layers), (b) build the phase-2 transfers once the whole preparation
-/// is mined, or (c) report what it is waiting for. Runs inside the database write lock; the caller
+/// then ask the engine for the next step (`state::next_step`, the same decision the mobile wallet
+/// makes from state alone) and perform the wallet I/O it calls for: prove+extract the next
+/// broadcastable transaction (returned for the caller to broadcast), build+sign the next ready
+/// preparation layer, build+sign the transfers, or report what it is waiting for. zallet only does
+/// the I/O; the decision lives in the engine. Runs inside the database write lock; the caller
 /// broadcasts asynchronously. `tip` is the current chain tip; transactions build and become due at
 /// `tip + 1`.
 pub fn advance_blocking(
@@ -470,99 +400,102 @@ pub fn advance_blocking(
         .ok_or(AdvanceError::NoMigration)?;
 
     // Detect newly mined transactions: a broadcast transaction the wallet now sees at a height.
+    // Collect the (id, height) pairs while the wallet is borrowed, then apply the engine's mining
+    // transition (which recomputes the overall status).
+    let mut newly_mined: Vec<(MigrationTxId, u32)> = Vec::new();
     {
         let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-        for tx in state.transactions.iter_mut() {
+        for tx in state.transactions.iter() {
             if let MigrationTxState::Broadcast { txid } = tx.state {
                 if let Some(height) = wallet
                     .get_tx_height(TxId::from_bytes(txid))
                     .map_err(|e| AdvanceError::Store(e.to_string()))?
                 {
-                    tx.state = MigrationTxState::Mined {
-                        height: u32::from(height),
-                    };
+                    newly_mined.push((tx.id, u32::from(height)));
                 }
             }
         }
     }
-    recompute_status(&mut state);
-
-    // (a) Broadcast the next ready transaction.
-    if let Some(index) = next_broadcastable(&state, target_height) {
-        let bytes = state.transactions[index].pczt.clone().ok_or_else(|| {
-            AdvanceError::Store("a signed transaction is missing its PCZT".into())
-        })?;
-        let tx = prove_and_extract(network, BlockHeight::from(tip), &bytes)
-            .map_err(AdvanceError::Prove)?;
-        let tx_id = state.transactions[index].id;
-        let kind = match state.transactions[index].kind {
-            MigrationTxKind::Preparation { .. } => "preparation",
-            MigrationTxKind::Transfer { .. } => "transfer",
-        };
-        return Ok(AdvanceOutcome {
-            state,
-            to_broadcast: Some((tx, tx_id)),
-            message: format!("broadcasting a {kind} transaction"),
-        });
+    for (id, height) in newly_mined {
+        state.mark_mined(id, height);
     }
 
-    // (a.5) Build the next preparation layer once its predecessor is mined. A multi-layer preparation
-    // defers its later layers (their feeder notes are witnessable only after the prior layer mines);
-    // building the next ready layer turns its transactions into broadcastable `Signed` ones for a
-    // later step. This runs only after (a) finds nothing to broadcast, i.e. the current layer's
-    // transactions are all broadcast and mined.
-    if has_ready_prep_layer(&state) {
-        let mut updated = commit_pending_preparation_over_wallet(
-            conn,
-            network,
-            account,
-            usk,
-            target_height,
-            state.clone(),
-        )
-        .map_err(AdvanceError::Commit)?;
-        recompute_status(&mut updated);
-        persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
-        return Ok(AdvanceOutcome {
-            state: updated,
-            to_broadcast: None,
-            message: "built the next preparation layer".into(),
-        });
+    // Decide the next step from state alone (the same decision the mobile wallet makes), then perform
+    // the wallet I/O it calls for.
+    match state.next_step(target_height) {
+        // Prove and extract the next ready transaction; the caller broadcasts it.
+        AdvanceStep::Broadcast { id } => {
+            let tx_ref = state
+                .transactions
+                .iter()
+                .find(|t| t.id == id)
+                .ok_or_else(|| AdvanceError::Store("the next transaction is missing".into()))?;
+            let bytes = tx_ref.pczt.clone().ok_or_else(|| {
+                AdvanceError::Store("a signed transaction is missing its PCZT".into())
+            })?;
+            let kind = match tx_ref.kind {
+                MigrationTxKind::Preparation { .. } => "preparation",
+                MigrationTxKind::Transfer { .. } => "transfer",
+            };
+            let tx = prove_and_extract(network, BlockHeight::from(tip), &bytes)
+                .map_err(AdvanceError::Prove)?;
+            Ok(AdvanceOutcome {
+                state,
+                to_broadcast: Some((tx, id)),
+                message: format!("broadcasting a {kind} transaction"),
+            })
+        }
+        // Build and pre-sign the next ready preparation layer, whose predecessor has now mined so its
+        // feeder notes are witnessable. This turns its transactions into broadcastable ones.
+        AdvanceStep::BuildPreparationLayer { layer } => {
+            let mut updated = commit_pending_preparation_over_wallet(
+                conn,
+                network,
+                account,
+                usk,
+                target_height,
+                state,
+            )
+            .map_err(AdvanceError::Commit)?;
+            updated.recompute_status();
+            persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
+            Ok(AdvanceOutcome {
+                state: updated,
+                to_broadcast: None,
+                message: format!("built preparation layer {layer}"),
+            })
+        }
+        // Build and pre-sign the transfers, now that the whole preparation is mined.
+        AdvanceStep::BuildTransfers => {
+            let mut updated =
+                commit_transfers_over_wallet(conn, network, account, usk, target_height, state)
+                    .map_err(AdvanceError::Commit)?;
+            updated.recompute_status();
+            persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
+            Ok(AdvanceOutcome {
+                state: updated,
+                to_broadcast: None,
+                message: "built the transfer transactions".into(),
+            })
+        }
+        // Nothing to build or broadcast this step: persist the mining updates and report progress.
+        AdvanceStep::Waiting | AdvanceStep::Complete => {
+            persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
+            let pending = state
+                .transactions
+                .iter()
+                .filter(|t| !matches!(t.state, MigrationTxState::Mined { .. }))
+                .count();
+            let message = if pending == 0 {
+                "the migration is complete".to_string()
+            } else {
+                format!("waiting for {pending} transaction(s) to mine")
+            };
+            Ok(AdvanceOutcome {
+                state,
+                to_broadcast: None,
+                message,
+            })
+        }
     }
-
-    // (b) Build the phase-2 transfers once every preparation is mined.
-    let has_unbuilt_transfers = state.transactions.iter().any(|t| {
-        matches!(t.kind, MigrationTxKind::Transfer { .. })
-            && matches!(t.state, MigrationTxState::Planned)
-    });
-    if all_preparations_mined(&state) && has_unbuilt_transfers {
-        let mut updated =
-            commit_transfers_over_wallet(conn, network, account, usk, target_height, state.clone())
-                .map_err(AdvanceError::Commit)?;
-        recompute_status(&mut updated);
-        persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
-        return Ok(AdvanceOutcome {
-            state: updated,
-            to_broadcast: None,
-            message: "built the transfer transactions".into(),
-        });
-    }
-
-    // (c) Nothing to do this step: persist the mining updates and report what it is waiting for.
-    persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
-    let pending = state
-        .transactions
-        .iter()
-        .filter(|t| !matches!(t.state, MigrationTxState::Mined { .. }))
-        .count();
-    let message = if pending == 0 {
-        "the migration is complete".to_string()
-    } else {
-        format!("waiting for {pending} transaction(s) to mine")
-    };
-    Ok(AdvanceOutcome {
-        state,
-        to_broadcast: None,
-        message,
-    })
 }

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -1,4 +1,4 @@
-//! Scaffolding for the Orchard-to-Ironwood value-pool migration.
+//! Orchard-to-Ironwood value-pool migration wiring.
 //!
 //! This module wires the backend-agnostic pool-migration engine into Zallet. The
 //! engine crate is still evolving upstream (it lives on a librustzcash feature
@@ -134,11 +134,6 @@ fn map_commit_error<E: fmt::Display>(err: CommitError<E>) -> CommitFailure {
         CommitError::NoMigrationInProgress => CommitFailure::NoMigrationInProgress,
         CommitError::Backend(e) => CommitFailure::Other(e.to_string()),
         CommitError::Build(m) => CommitFailure::Other(m),
-        // Multi-layer preparation is supported (committed layer by layer), so the engine no longer
-        // rejects it; any residual variant maps to a generic build failure.
-        CommitError::UnsupportedMultiLayer => {
-            CommitFailure::Other("unexpected multi-layer commit rejection".into())
-        }
     }
 }
 

--- a/zallet-core/src/migrate.rs
+++ b/zallet-core/src/migrate.rs
@@ -18,7 +18,7 @@
 //!
 //! Persistence is a separate concern: the engine's `PoolMigrationRead` /
 //! `PoolMigrationWrite` store traits (implemented over the wallet database by
-//! `zcash_pool_migration_sqlite`) hold a committed migration, and the
+//! `zcash_client_sqlite::pool_migration`) hold a committed migration, and the
 //! `MigrationBackend` trait this snapshot implements is now just the planning
 //! inputs. Committing a migration uses the `WalletMigration` adapter over the
 //! wallet, not this snapshot.
@@ -41,20 +41,18 @@ use zcash_pool_migration_backend::build::sign_pczt;
 use zcash_pool_migration_backend::engine::{
     CommitError, MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTxId,
     MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, UnsignedMigrationTx,
-    build_preparation_unsigned, build_transfers_unsigned, commit_pending_preparation,
-    commit_preparation, commit_transfers, plan_migration,
+    build_preparation_unsigned, commit_preparation, plan_migration,
 };
 // The migration state machine lives in the engine (the mobile wallet drives it the same way); zallet
 // only performs the wallet I/O around the engine's decisions. The decision and transition logic are
 // methods on `MigrationState` (`next_step`, `mark_mined`, `mark_broadcast`, `is_terminal`, ...).
-use zcash_pool_migration_backend::note_splitting::{FeePolicy, Zip317FeePolicy};
-use zcash_pool_migration_backend::preparation::PREP_TX_ACTIONS;
+use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
 use zcash_pool_migration_backend::state::AdvanceStep;
 use zcash_pool_migration_backend::wallet::WalletMigration;
-use zcash_pool_migration_sqlite::PoolMigrations;
 use zcash_primitives::transaction::components::orchard::bundle_version_for_branch;
 use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{BlockHeight, BranchId};
+use zcash_protocol::value::Zatoshis;
 
 use crate::network::Network;
 
@@ -94,12 +92,18 @@ impl SpendableSnapshot {
 impl MigrationBackend for SpendableSnapshot {
     type Error = Infallible;
 
-    fn spendable_orchard_note_values(&self) -> Result<Vec<u64>, Self::Error> {
-        Ok(self.orchard_note_values.clone())
+    fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+        Ok(self
+            .orchard_note_values
+            .iter()
+            .map(|&v| {
+                Zatoshis::from_u64(v).expect("a spendable wallet note value is a valid amount")
+            })
+            .collect())
     }
 
-    fn chain_tip_height(&self) -> Result<u32, Self::Error> {
-        Ok(self.chain_tip_height)
+    fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+        Ok(BlockHeight::from_u32(self.chain_tip_height))
     }
 }
 
@@ -124,33 +128,47 @@ fn map_plan_error<E: fmt::Display>(err: MigrationError<E>) -> CommitFailure {
             "the spendable notes cannot fund the migration: {e}"
         )),
         MigrationError::Backend(e) => CommitFailure::Other(e.to_string()),
+        MigrationError::InvalidBalance(e) => {
+            CommitFailure::Other(format!("the account balance is invalid: {e}"))
+        }
+        MigrationError::Fee(e) => {
+            CommitFailure::Other(format!("the migration fee could not be computed: {e}"))
+        }
+        MigrationError::Nu63NotActive => CommitFailure::Other(
+            "NU6.3 (the Ironwood pool) is not active at the target height".to_string(),
+        ),
     }
 }
 
 fn map_commit_error<E: fmt::Display>(err: CommitError<E>) -> CommitFailure {
     match err {
         CommitError::NoMigrationInProgress => CommitFailure::NoMigrationInProgress,
+        CommitError::MigrationInProgress => CommitFailure::AlreadyInProgress,
         CommitError::Backend(e) => CommitFailure::Other(e.to_string()),
-        CommitError::Build(m) => CommitFailure::Other(m),
+        CommitError::Build(m) => CommitFailure::Other(m.to_string()),
+        CommitError::Serialize(e) => {
+            CommitFailure::Other(format!("serializing a migration transaction failed: {e:?}"))
+        }
+        CommitError::StalePlan => CommitFailure::Other(
+            "the migration plan is stale (the wallet's spendable notes changed); retry".to_string(),
+        ),
+        CommitError::InconsistentPlan(m) => {
+            CommitFailure::Other(format!("the migration plan is inconsistent: {m}"))
+        }
+        CommitError::Nu63NotActive => CommitFailure::Other(
+            "NU6.3 (the Ironwood pool) is not active at the target height".to_string(),
+        ),
     }
 }
 
-/// An in-memory migration store used to run the engine's commit functions WITHOUT letting them
-/// write to SQLite. `commit_preparation` / `commit_transfers` return the resulting
-/// [`MigrationState`], so the caller runs the engine against this store, then persists the returned
-/// state to the real SQLite store separately. This keeps the engine's wallet access and the store's
-/// database access on ONE connection, used sequentially (never two live borrows at once).
+/// An in-memory migration store used to run the engine's commit function WITHOUT letting it write
+/// to SQLite. `commit_preparation` returns the resulting [`MigrationState`], so the caller runs the
+/// engine against this store, then persists the returned state to the real SQLite store separately.
+/// This keeps the engine's wallet access and the store's database access on ONE connection, used
+/// sequentially (never two live borrows at once).
 #[derive(Default)]
 pub struct InMemoryStore {
     state: Option<MigrationState>,
-}
-
-impl InMemoryStore {
-    /// An in-memory store pre-seeded with a loaded migration (for `commit_transfers`, which reads
-    /// the in-progress migration before filling in the transfers).
-    pub fn seeded(state: Option<MigrationState>) -> Self {
-        Self { state }
-    }
 }
 
 impl PoolMigrationRead for InMemoryStore {
@@ -162,35 +180,28 @@ impl PoolMigrationRead for InMemoryStore {
 }
 
 impl PoolMigrationWrite for InMemoryStore {
-    fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
         self.state = Some(state.clone());
         Ok(())
     }
 
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
-        tx_state: MigrationTxState,
+        _id: MigrationTxId,
+        _tx_state: MigrationTxState,
     ) -> Result<(), Self::Error> {
-        if let Some(state) = &mut self.state {
-            if let Some(tx) = state.transactions.iter_mut().find(|t| t.id == id) {
-                tx.state = tx_state;
-            }
-        }
+        // No-op: this in-memory store only backs the engine's commit functions, which persist the
+        // whole migration via `replace_migration`. Per-transaction state transitions run against the
+        // real SQLite store during advance/broadcast, and `MigrationState` exposes no cross-crate
+        // per-transaction state setter to apply one here.
         Ok(())
     }
-}
-
-/// The ZIP-317 fee reserved per note-preparation transaction (the fixed padded action count times
-/// the marginal fee), as the engine's planning and preparation both compute it.
-fn prep_fee_zatoshi() -> u64 {
-    PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
 }
 
 /// Loads the persisted migration from the SQLite store over `conn`.
 pub fn load_migration(
     conn: &mut Connection,
-) -> Result<Option<MigrationState>, zcash_pool_migration_sqlite::Error> {
+) -> Result<Option<MigrationState>, zcash_client_sqlite::pool_migration::orchard_ironwood::Error> {
     PoolMigrations::new(&mut *conn).get_migration()
 }
 
@@ -198,8 +209,8 @@ pub fn load_migration(
 pub fn persist_migration(
     conn: &mut Connection,
     state: &MigrationState,
-) -> Result<(), zcash_pool_migration_sqlite::Error> {
-    PoolMigrations::new(&mut *conn).put_migration(state)
+) -> Result<(), zcash_client_sqlite::pool_migration::orchard_ironwood::Error> {
+    PoolMigrations::new(&mut *conn).replace_migration(state)
 }
 
 /// Plans and commits the PREPARATION of a migration over the wallet: builds and pre-signs every
@@ -213,54 +224,18 @@ pub fn commit_preparation_over_wallet(
     usk: UnifiedSpendingKey,
     target_height: u32,
 ) -> Result<MigrationState, CommitFailure> {
-    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-    let mut migration = WalletMigration::new(&mut wallet, account, usk, InMemoryStore::default());
+    let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let mut migration = WalletMigration::new(&wallet, account, usk, InMemoryStore::default());
     let mut rng = OsRng;
-    let plan = plan_migration(&migration, prep_fee_zatoshi(), &mut rng).map_err(map_plan_error)?;
-    commit_preparation(network, target_height, &mut migration, &plan, &mut rng)
-        .map_err(map_commit_error)
-}
-
-/// Commits the TRANSFERS of an in-progress migration over the wallet: builds and pre-signs the
-/// phase-2 transfer transactions (whose funding notes the mined preparation created), returning the
-/// updated state (NOT persisted; the caller persists it). `loaded` is the migration read from the
-/// store. Runs the engine synchronously; call inside the blocking database section.
-pub fn commit_transfers_over_wallet(
-    conn: &mut Connection,
-    network: &Network,
-    account: AccountUuid,
-    usk: UnifiedSpendingKey,
-    target_height: u32,
-    loaded: MigrationState,
-) -> Result<MigrationState, CommitFailure> {
-    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-    let store = InMemoryStore::seeded(Some(loaded));
-    let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
-    let mut rng = OsRng;
-    commit_transfers(network, target_height, &mut migration, &mut rng).map_err(map_commit_error)
-}
-
-/// Commits the next ready PREPARATION LAYER of an in-progress multi-layer migration over the wallet:
-/// a later preparation layer spends the feeder notes minted by the layer before it, which are
-/// witnessable only once that layer is mined, so the layer is built here rather than up front. Builds
-/// and pre-signs every transaction of the earliest still-unbuilt layer whose predecessor has mined,
-/// returning the updated state (NOT persisted; the caller persists it). `loaded` is the migration read
-/// from the store. If no layer is ready it returns the state unchanged. Runs the engine synchronously;
-/// call inside the blocking database section.
-pub fn commit_pending_preparation_over_wallet(
-    conn: &mut Connection,
-    network: &Network,
-    account: AccountUuid,
-    usk: UnifiedSpendingKey,
-    target_height: u32,
-    loaded: MigrationState,
-) -> Result<MigrationState, CommitFailure> {
-    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-    let store = InMemoryStore::seeded(Some(loaded));
-    let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
-    let mut rng = OsRng;
-    commit_pending_preparation(network, target_height, &mut migration, &mut rng)
-        .map_err(map_commit_error)
+    let plan = plan_migration(network, &migration, &mut rng).map_err(map_plan_error)?;
+    commit_preparation(
+        network,
+        BlockHeight::from_u32(target_height),
+        &mut migration,
+        &plan,
+        &mut rng,
+    )
+    .map_err(map_commit_error)
 }
 
 /// Plans and builds the PREPARATION of a migration for an EXTERNAL signer: builds every layer-0
@@ -276,42 +251,26 @@ pub fn build_preparation_unsigned_over_wallet(
     usk: UnifiedSpendingKey,
     target_height: u32,
 ) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitFailure> {
-    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-    let mut migration = WalletMigration::new(&mut wallet, account, usk, InMemoryStore::default());
+    let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
+    let mut migration = WalletMigration::new(&wallet, account, usk, InMemoryStore::default());
     let mut rng = OsRng;
-    let plan = plan_migration(&migration, prep_fee_zatoshi(), &mut rng).map_err(map_plan_error)?;
-    build_preparation_unsigned(network, target_height, &mut migration, &plan, &mut rng)
-        .map_err(map_commit_error)
-}
-
-/// Builds the TRANSFERS of an in-progress migration for an EXTERNAL signer: builds the phase-2
-/// transfer transactions (whose funding notes the mined preparation created) but leaves them
-/// UNSIGNED, returning the updated state (NOT persisted; the caller persists it) together with the
-/// unsigned PCZTs to route to the signing device. Mirrors [`commit_transfers_over_wallet`] but leaves
-/// the transactions in `AwaitingSignature`. `loaded` is the migration read from the store. Runs the
-/// engine synchronously; call inside the blocking database section.
-pub fn build_transfers_unsigned_over_wallet(
-    conn: &mut Connection,
-    network: &Network,
-    account: AccountUuid,
-    usk: UnifiedSpendingKey,
-    target_height: u32,
-    loaded: MigrationState,
-) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitFailure> {
-    let mut wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-    let store = InMemoryStore::seeded(Some(loaded));
-    let mut migration = WalletMigration::new(&mut wallet, account, usk, store);
-    let mut rng = OsRng;
-    build_transfers_unsigned(network, target_height, &mut migration, &mut rng)
-        .map_err(map_commit_error)
+    let plan = plan_migration(network, &migration, &mut rng).map_err(map_plan_error)?;
+    build_preparation_unsigned(
+        network,
+        BlockHeight::from_u32(target_height),
+        &mut migration,
+        &plan,
+        &mut rng,
+    )
+    .map_err(map_commit_error)
 }
 
 /// Signs a migration PCZT with the account's Orchard spend authorization, for offline / air-gapped or
 /// external-device signing. Parses the unsigned PCZT, adds only the spend-auth signature (the Signer
 /// role; it neither proves nor extracts), and returns the serialized signed PCZT to apply to the
 /// migration via [`MigrationState::apply_signature`]. This is the counterpart the external signer runs
-/// on the built PCZT that [`build_preparation_unsigned_over_wallet`] /
-/// [`build_transfers_unsigned_over_wallet`] produced; a hardware wallet performs the same step on the
+/// on the built PCZTs that [`build_preparation_unsigned_over_wallet`] produced (a single pass builds
+/// every preparation transaction AND every transfer); a hardware wallet performs the same step on the
 /// device.
 pub fn sign_migration_pczt(
     usk: &UnifiedSpendingKey,
@@ -453,7 +412,7 @@ pub fn record_broadcast(
     tx_id: MigrationTxId,
     txid: [u8; 32],
 ) -> Result<(), AdvanceError> {
-    state.mark_broadcast(tx_id, txid);
+    state.mark_broadcast(tx_id, TxId::from_bytes(txid));
     persist_migration(conn, state).map_err(|e| AdvanceError::Store(e.to_string()))
 }
 
@@ -468,8 +427,8 @@ pub fn record_broadcast(
 pub fn advance_blocking(
     conn: &mut Connection,
     network: &Network,
-    account: AccountUuid,
-    usk: UnifiedSpendingKey,
+    _account: AccountUuid,
+    _usk: UnifiedSpendingKey,
     tip: u32,
 ) -> Result<AdvanceOutcome, AdvanceError> {
     let target_height = tip + 1;
@@ -481,7 +440,7 @@ pub fn advance_blocking(
     // A terminal migration (complete, or cancelled/failed) is never advanced: report its status and
     // do nothing, so a cancelled migration cannot be driven further or resurrected.
     if state.is_terminal() {
-        let message = if matches!(state.status, MigrationStatus::Complete) {
+        let message = if matches!(state.status(), MigrationStatus::Complete) {
             "the migration is complete"
         } else {
             "the migration was cancelled"
@@ -496,16 +455,16 @@ pub fn advance_blocking(
     // Detect newly mined transactions: a broadcast transaction the wallet now sees at a height.
     // Collect the (id, height) pairs while the wallet is borrowed, then apply the engine's mining
     // transition (which recomputes the overall status).
-    let mut newly_mined: Vec<(MigrationTxId, u32)> = Vec::new();
+    let mut newly_mined: Vec<(MigrationTxId, BlockHeight)> = Vec::new();
     {
         let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-        for tx in state.transactions.iter() {
-            if let MigrationTxState::Broadcast { txid } = tx.state {
+        for tx in state.transactions().iter() {
+            if let MigrationTxState::Broadcast { txid } = tx.state() {
                 if let Some(height) = wallet
-                    .get_tx_height(TxId::from_bytes(txid))
+                    .get_tx_height(txid)
                     .map_err(|e| AdvanceError::Store(e.to_string()))?
                 {
-                    newly_mined.push((tx.id, u32::from(height)));
+                    newly_mined.push((tx.id(), height));
                 }
             }
         }
@@ -516,18 +475,16 @@ pub fn advance_blocking(
 
     // Decide the next step from state alone (the same decision the mobile wallet makes), then perform
     // the wallet I/O it calls for.
-    match state.next_step(target_height) {
+    match state.next_step(BlockHeight::from_u32(target_height)) {
         // Prove and extract the next ready transaction; the caller broadcasts it.
         AdvanceStep::Broadcast { id } => {
             let tx_ref = state
-                .transactions
+                .transactions()
                 .iter()
-                .find(|t| t.id == id)
+                .find(|t| t.id() == id)
                 .ok_or_else(|| AdvanceError::Store("the next transaction is missing".into()))?;
-            let bytes = tx_ref.pczt.clone().ok_or_else(|| {
-                AdvanceError::Store("a signed transaction is missing its PCZT".into())
-            })?;
-            let kind = match tx_ref.kind {
+            let bytes = tx_ref.pczt().clone();
+            let kind = match tx_ref.kind() {
                 MigrationTxKind::Preparation { .. } => "preparation",
                 MigrationTxKind::Transfer { .. } => "transfer",
             };
@@ -539,46 +496,16 @@ pub fn advance_blocking(
                 message: format!("broadcasting a {kind} transaction"),
             })
         }
-        // Build and pre-sign the next ready preparation layer, whose predecessor has now mined so its
-        // feeder notes are witnessable. This turns its transactions into broadcastable ones.
-        AdvanceStep::BuildPreparationLayer { layer } => {
-            let mut updated = commit_pending_preparation_over_wallet(
-                conn,
-                network,
-                account,
-                usk,
-                target_height,
-                state,
-            )
-            .map_err(AdvanceError::Commit)?;
-            updated.recompute_status();
-            persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
-            Ok(AdvanceOutcome {
-                state: updated,
-                to_broadcast: None,
-                message: format!("built preparation layer {layer}"),
-            })
-        }
-        // Build and pre-sign the transfers, now that the whole preparation is mined.
-        AdvanceStep::BuildTransfers => {
-            let mut updated =
-                commit_transfers_over_wallet(conn, network, account, usk, target_height, state)
-                    .map_err(AdvanceError::Commit)?;
-            updated.recompute_status();
-            persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
-            Ok(AdvanceOutcome {
-                state: updated,
-                to_broadcast: None,
-                message: "built the transfer transactions".into(),
-            })
-        }
         // Nothing to build or broadcast this step: persist the mining updates and report progress.
+        // Every preparation layer and every transfer was built and pre-signed up front by
+        // `commit_preparation`, so advancing only ever proves and broadcasts due transactions (the
+        // `Broadcast` arm above); there is no incremental build step.
         AdvanceStep::Waiting | AdvanceStep::Complete => {
             persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
             let pending = state
-                .transactions
+                .transactions()
                 .iter()
-                .filter(|t| !matches!(t.state, MigrationTxState::Mined { .. }))
+                .filter(|t| !matches!(t.state(), MigrationTxState::Mined { .. }))
                 .count();
             let message = if pending == 0 {
                 "the migration is complete".to_string()
@@ -594,26 +521,28 @@ pub fn advance_blocking(
     }
 }
 
-/// The blocking half of building an EXTERNAL migration's transfers, the external-signer counterpart of
-/// the transfer-building that [`advance_blocking`] does in process. It loads the migration, detects
-/// newly mined preparation transactions (the same detection `advance_blocking` performs, so an
-/// external client uses this instead of advancing and never triggers in-process transfer signing), and
-/// once the whole preparation is mined builds the phase-2 transfers UNSIGNED, returning their PCZTs to
-/// route to the signing device. If the preparation is not yet fully mined it returns no PCZTs and
-/// leaves the migration waiting; a multi-layer preparation whose next step is a later unbuilt layer is
-/// reported as unsupported for external signing (the seam covers layer-0 preparation and transfers).
-/// Persists the state. Runs inside the database write lock. `tip` is the current chain tip;
-/// transactions build at `tip + 1`.
+/// The pre-built unsigned transfers to route to an external signer: the loaded migration state,
+/// each transfer's `(id, unsigned PCZT)`, and a human-readable status message.
+type UnsignedTransfers = (MigrationState, Vec<(MigrationTxId, Pczt)>, String);
+
+/// Returns the migration's pre-built UNSIGNED transfer transactions, for an EXTERNAL signer.
+///
+/// A single `commit_preparation` / `build_preparation_unsigned` pass now builds and pre-signs (or,
+/// for an external signer, leaves unsigned) every preparation transaction AND every transfer up
+/// front — a transfer's funding note is recovered from the still-unmined preparation bundle that
+/// mints it, so nothing waits on mining to be built. The transfers therefore already exist in the
+/// stored migration (in `AwaitingSignature` until the device signs them). This loads the migration
+/// and returns those transfers' unsigned PCZTs to route to the signing device; it builds nothing
+/// and persists nothing. `tip` is unused, retained for RPC-signature stability. Runs inside the
+/// database write lock.
 pub fn build_transfers_unsigned_blocking(
     conn: &mut Connection,
-    network: &Network,
-    account: AccountUuid,
-    usk: UnifiedSpendingKey,
-    tip: u32,
-) -> Result<(MigrationState, Vec<UnsignedMigrationTx>, String), AdvanceError> {
-    let target_height = tip + 1;
-
-    let mut state = load_migration(conn)
+    _network: &Network,
+    _account: AccountUuid,
+    _usk: UnifiedSpendingKey,
+    _tip: u32,
+) -> Result<UnsignedTransfers, AdvanceError> {
+    let state = load_migration(conn)
         .map_err(|e| AdvanceError::Store(e.to_string()))?
         .ok_or(AdvanceError::NoMigration)?;
 
@@ -625,67 +554,27 @@ pub fn build_transfers_unsigned_blocking(
         ));
     }
 
-    // Detect newly mined transactions (identical to `advance_blocking`).
-    let mut newly_mined: Vec<(MigrationTxId, u32)> = Vec::new();
-    {
-        let wallet = WalletDb::from_connection(&mut *conn, *network, SystemClock, OsRng);
-        for tx in state.transactions.iter() {
-            if let MigrationTxState::Broadcast { txid } = tx.state {
-                if let Some(height) = wallet
-                    .get_tx_height(TxId::from_bytes(txid))
-                    .map_err(|e| AdvanceError::Store(e.to_string()))?
-                {
-                    newly_mined.push((tx.id, u32::from(height)));
-                }
-            }
-        }
-    }
-    for (id, height) in newly_mined {
-        state.mark_mined(id, height);
-    }
+    let transfers: Vec<(MigrationTxId, Pczt)> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+        .filter(|t| matches!(t.state(), MigrationTxState::AwaitingSignature))
+        .map(|t| {
+            Pczt::parse(t.pczt())
+                .map(|pczt| (t.id(), pczt))
+                .map_err(|e| {
+                    AdvanceError::Store(format!("a stored transfer PCZT is corrupt: {e:?}"))
+                })
+        })
+        .collect::<Result<_, _>>()?;
 
-    match state.next_step(target_height) {
-        // The whole preparation is mined: build the transfers unsigned for the external signer.
-        AdvanceStep::BuildTransfers => {
-            let (mut updated, unsigned) = build_transfers_unsigned_over_wallet(
-                conn,
-                network,
-                account,
-                usk,
-                target_height,
-                state,
-            )
-            .map_err(AdvanceError::Commit)?;
-            updated.recompute_status();
-            persist_migration(conn, &updated).map_err(|e| AdvanceError::Store(e.to_string()))?;
-            Ok((
-                updated,
-                unsigned,
-                "built the unsigned transfer transactions".to_string(),
-            ))
-        }
-        // A later preparation layer still needs building: external signing does not cover multi-layer
-        // preparation yet.
-        AdvanceStep::BuildPreparationLayer { layer } => Err(AdvanceError::Unsupported(format!(
-            "external signing of a multi-layer preparation is not yet supported (preparation layer \
-             {layer} still needs building)"
-        ))),
-        // The preparation is not yet fully mined (or nothing is ready to build): persist the mining
-        // updates and report what the migration is waiting for.
-        AdvanceStep::Broadcast { .. } | AdvanceStep::Waiting | AdvanceStep::Complete => {
-            persist_migration(conn, &state).map_err(|e| AdvanceError::Store(e.to_string()))?;
-            let pending_prep = state
-                .transactions
-                .iter()
-                .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
-                .filter(|t| !matches!(t.state, MigrationTxState::Mined { .. }))
-                .count();
-            let message = if pending_prep == 0 {
-                "the preparation is mined; no transfers are pending".to_string()
-            } else {
-                format!("waiting for {pending_prep} preparation transaction(s) to mine")
-            };
-            Ok((state, Vec::new(), message))
-        }
-    }
+    let message = if transfers.is_empty() {
+        "no transfers are awaiting signature".to_string()
+    } else {
+        format!(
+            "{} unsigned transfer transaction(s) awaiting signature",
+            transfers.len()
+        )
+    };
+    Ok((state, transfers, message))
 }


### PR DESCRIPTION
Note: I would be in favor to add a flag `experimental` to not encourage users to use some RPCs.

------

Wires the new backend-agnostic `zcash_ironwood_migration_backend` crate (the Orchard -> Ironwood migration engine) into zallet as a dependency scaffold, independent of the crate's still-evolving API.

- Adds `zcash_ironwood_migration_backend` pinned to the `feat/ironwood-denominations` git branch of `zcash/librustzcash` (the crate is unpublished; to be repointed at a release later).
- Wires it through `zallet-core` via a thin `zallet_core::migrate` scaffold module (a whole-crate re-export, no coupling to the evolving API), so all three workspaces (root, backends/zebra, backends/zaino) resolve its git-sourced transitive librustzcash crates identically and `check-lockstep.sh` stays green.
- Regenerates all three lockfiles via `utils/sync-lockfiles.sh`; CHANGELOG entry included.

Note: the separate "sync existing librustzcash deps" commit was a verified no-op (all pins already at their latest published versions), so this is a single commit. Verified: `cargo test` 194 passed, both backends `cargo check` clean, fmt/clippy clean, lockstep OK.

Draft; part of the Ironwood migration effort. Do not merge yet.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>