### PR TITLE
book: Add a configuration reference page

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
 
 # Reference guide
 
+- [Configuration](config/README.md)
 - [Command-line tool](cli/README.md)
   - [start](cli/start.md)
   - [example-config](cli/example-config.md)

--- a/book/src/config/README.md
+++ b/book/src/config/README.md
@@ -1,0 +1,15 @@
+# Configuration reference
+
+Zallet reads its configuration from `zallet.toml` in the datadir (override the
+file with `-c/--config`, and the datadir with `-d/--datadir`; see
+[Wallet setup](../guide/setup.md)).
+
+The reference below is the output of
+[`zallet example-config`](../cli/example-config.md): every available option
+with its documentation, generated directly from the source code and checked in
+CI, so it always matches the release it ships with. Options are commented out
+where they show a default value.
+
+```toml
+{{#include ../../../backends/zebra/tests/cmd/example_config.out/zallet.toml}}
+```


### PR DESCRIPTION
## Summary

Adds a "Configuration" page to the Reference guide that `{{#include}}`s the **entire** generated example config (360 lines, every option with its documentation). The content is generated from the rustdoc on `zallet-core/src/config.rs` and pinned by the existing trycmd test (`backends/zebra/tests/cmd/example_config.out/zallet.toml`), so the page stays in lockstep with the code with zero new prose to maintain. Previously the book showed only the first 25 lines (as an illustration on the `example-config` CLI page, which is left unchanged).

Closes #603. Part of #600. Related: #187 (documenting the `[features]` processes will land in the same generated content).

## Test plan

- [x] `mdbook build` succeeds; the rendered page contains the full option set (spot-checked `keystore`, `note_management`, `recover_batch_size`)

## AI disclosure

Written with AI assistance (Claude Fable 5, via Claude Code); `Co-Authored-By` metadata is on the commit. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
