### PR TITLE
book: Add a Concepts section

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,13 @@
   - [Debian packages](guide/installation/debian.md)
 - [Wallet setup](guide/setup.md)
 
+# Concepts
+
+- [Accounts and keys](concepts/accounts.md)
+- [Wallet encryption](concepts/encryption.md)
+- [Notes, confirmations, and fees](concepts/notes.md)
+- [Asynchronous operations](concepts/async-operations.md)
+
 # Reference guide
 
 - [Command-line tool](cli/README.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Wallet encryption](concepts/encryption.md)
 - [Notes, confirmations, and fees](concepts/notes.md)
 - [Asynchronous operations](concepts/async-operations.md)
+- [The legacy transparent pool](concepts/legacy-pool.md)
 
 # Reference guide
 

--- a/book/src/concepts/accounts.md
+++ b/book/src/concepts/accounts.md
@@ -1,0 +1,45 @@
+# Accounts and keys
+
+## Seeds
+
+A Zallet wallet can hold multiple mnemonic seed phrases, created with
+[`zallet generate-mnemonic`](../cli/generate-mnemonic.md) or imported with
+[`zallet import-mnemonic`](../cli/import-mnemonic.md). Each phrase is an
+independent root of spend authority, identified by its **seed fingerprint**
+(`seedfp`), and must be [backed up](../guide/backup.md) independently.
+
+## Accounts
+
+Accounts are derived from a seed following [ZIP 32] hierarchical deterministic
+derivation: an account is identified by its seed fingerprint plus a ZIP 32
+account index, numbered from zero per seed. Each account is a separate group
+of funds, and every account adds scanning cost, so create them deliberately —
+they are not intended as address labels.
+
+Within a Zallet instance, every account also has a **UUID**, which is how RPC
+methods identify accounts (`account_uuid` fields, and account parameters).
+UUIDs are local to the instance; the portable identity of an account is
+`(seedfp, account index)`, which is what
+[recovery](../guide/backup.md#from-a-mnemonic) uses.
+
+This differs from `zcashd`, where the legacy wallet largely operated as a
+single implicit account. Zallet still accepts plain account numbers in some
+methods, but only for wallets with a single seed.
+
+Wallets can also track things that are not derived from a seed: spending keys
+imported with `z_importkey`, and watch-only transparent addresses imported
+with `z_importaddress`. These become accounts with UUIDs too, but no mnemonic
+covers them.
+
+## Addresses
+
+Addresses are obtained per account with the `z_getaddressforaccount` RPC
+method, which derives [ZIP 316] **Unified Addresses**: a single encoding
+bundling receivers for one or more pools (Orchard, Sapling, transparent). Many
+addresses can be derived for the same account at different diversifier
+indices; they all receive into the same account, and payments to their
+shielded receivers are not linkable on-chain (transparent receivers, when
+included, do not have this property).
+
+[ZIP 32]: https://zips.z.cash/zip-0032
+[ZIP 316]: https://zips.z.cash/zip-0316

--- a/book/src/concepts/async-operations.md
+++ b/book/src/concepts/async-operations.md
@@ -1,0 +1,21 @@
+# Asynchronous operations
+
+Building a shielded transaction involves note selection and zero-knowledge
+proving, which takes real time — so the sending RPC methods do not block.
+Methods such as `z_sendmany` and `z_shieldcoinbase` validate their arguments,
+start the work in the background, and immediately return an **operation id**
+(e.g. `opid-...`).
+
+Clients then follow the same lifecycle `zcashd` used:
+
+1. **Poll** with `z_getoperationstatus [["opid-..."]]` — returns the current
+   state (executing, success, failed) without consuming it.
+2. **Collect** with `z_getoperationresult [["opid-..."]]` — returns the
+   outcome of finished operations *and removes them*: the result value on
+   success (for sends, the transaction ids), or an error object on failure.
+3. `z_listoperationids` lists the operations the wallet currently knows about.
+
+Operations are held in memory, not in the wallet database — do not expect an
+operation id to survive a wallet restart. If you lose track of a send, check
+`z_listtransactions` / `z_viewtransaction` to see whether the transaction was
+created and broadcast.

--- a/book/src/concepts/encryption.md
+++ b/book/src/concepts/encryption.md
@@ -1,0 +1,36 @@
+# Wallet encryption
+
+Zallet encrypts key material with [age], asymmetric file encryption. During
+[wallet setup](../guide/setup.md#initialize-the-wallet-encryption) — before
+any keys exist — you create an **encryption identity** (a file, by default
+`{datadir}/encryption-identity.txt`) and initialize the wallet with it.
+
+From then on:
+
+- **Everything secret is encrypted to that identity**: mnemonic phrases and
+  imported spending keys are stored in the wallet database as age ciphertexts,
+  and [`zallet export-mnemonic`](../cli/export-mnemonic.md) output is
+  encrypted to it too. Decrypting any of it requires the identity file.
+- **The wallet database as a whole is *not* encrypted.** Transaction history,
+  addresses, and viewing keys are stored in the clear in `wallet.db` — anyone
+  who reads the file learns your full transaction history, though they cannot
+  spend without the identity.
+
+The identity file can itself be protected with a passphrase (created with
+`zallet generate-encryption-identity -p`). With a passphrase-encrypted
+identity, the key store starts **locked**: operations that need spending keys
+fail with "Wallet is locked" until it is unlocked with the `walletpassphrase`
+RPC method (`walletlock` re-locks it). In non-interactive contexts the
+passphrase can be supplied via the `ZALLET_IDENTITY_PASSPHRASE` environment
+variable.
+
+Consequences worth internalizing:
+
+- Losing the identity file (or forgetting its passphrase) makes the key
+  material in every copy of `wallet.db` permanently undecryptable — back it
+  up, and see [Backup and restore](../guide/backup.md).
+- There is no equivalent of `zcashd`'s `encryptwallet` RPC method: encryption
+  is not something you turn on later, it is established at setup, before any
+  key exists.
+
+[age]: https://age-encryption.org/

--- a/book/src/concepts/legacy-pool.md
+++ b/book/src/concepts/legacy-pool.md
@@ -1,0 +1,55 @@
+# The legacy transparent pool
+
+Zallet's model is [one account per spending authority](accounts.md): each
+account is a separate pool of funds, and transparent funds belong to the
+account that received them. `zcashd`'s transparent RPC methods, inherited from
+Bitcoin Core, instead treated **all** transparent funds in the wallet as a
+single undifferentiated pool — `sendmany` spent from any address, `getbalance`
+summed across all of them. Those semantics are incompatible with the
+per-account model, so the methods and fields that depend on them are disabled
+in Zallet by default.
+
+For operators migrating a `zcashd` wallet that relied on this behaviour, Zallet
+can re-enable it for **one** migrated wallet at a time.
+
+## Enabling it
+
+Set the seed fingerprint of the migrated `zcashd` wallet in your config:
+
+```toml
+[features]
+legacy_pool_seed_fingerprint = "<seed fingerprint>"
+```
+
+The fingerprint identifies which migrated wallet's account acts as the legacy
+pool (it is the account at the special ZIP 32 index `zcashd` used for its
+legacy transparent funds). Available seed fingerprints appear in the output of
+the `z_listaccounts` and `listaddresses` RPC methods.
+
+Only one wallet can have legacy semantics enabled at a time: the Bitcoin-Core
+single-pool model is inherently wallet-wide, so it cannot be scoped to more
+than one migrated seed. Accounts imported from a viewing key cannot be the
+legacy pool — `zcashd` derived the pool from the wallet's seed, so a legacy
+account must have known ZIP 32 derivation.
+
+## What it changes
+
+With the fingerprint set:
+
+- **`z_sendmany` accepts `"ANY_TADDR"`** as its `fromaddress`, selecting
+  non-coinbase UTXOs from any transparent address in the pool — the
+  Bitcoin-Core "spend from anywhere" behaviour. Because covering a payment from
+  more than one of the pool's addresses links them on-chain, such a call
+  requires a `privacy_policy` of `AllowLinkingAccountAddresses` (or `NoPrivacy`
+  if it also has a transparent recipient or change). See
+  [Notes, confirmations, and fees](notes.md).
+- **`z_getbalances` includes legacy-pool balance fields** that are otherwise
+  omitted.
+
+## Should you use it?
+
+Treat it as a migration bridge, not a destination. These semantics are
+deprecated — they reveal more on-chain than the per-account model, and are not
+how new wallets should operate. Prefer moving funds into a unified account and
+using the account-scoped methods (`z_getbalanceforaccount`, and
+`z_sendfromaccount` once available) going forward.

--- a/book/src/concepts/notes.md
+++ b/book/src/concepts/notes.md
@@ -1,0 +1,37 @@
+# Notes, confirmations, and fees
+
+## Notes
+
+Shielded funds are held as **notes**: discrete, encrypted outputs in the
+Orchard or Sapling pools, analogous to transparent UTXOs but visible only to
+holders of the right viewing key. A wallet's shielded balance is the sum of
+its unspent notes; spending selects specific notes, and any excess value
+returns to the account as a new **change** note. Change handling is entirely
+internal — Zallet derives change addresses itself and never exposes them
+(there is no `getrawchangeaddress`).
+
+## Confirmations and spendability
+
+Zallet follows the [ZIP 315] wallet best-practices draft in distinguishing two
+kinds of received outputs:
+
+- **Trusted** outputs — those the wallet trusts to stay mined, such as change
+  created by the wallet itself — become spendable after
+  **3 confirmations** by default.
+- **Untrusted** outputs — everything received from other parties — become
+  spendable after **10 confirmations** by default, because a malicious sender
+  could attempt a double-spend.
+
+Both thresholds are configurable (`builder.trusted_confirmations` and
+`builder.untrusted_confirmations`); lowering them trades reliability under
+reorgs for latency. Methods such as `z_sendmany` apply this policy when
+`minconf` is not given explicitly.
+
+## Fees
+
+Transaction fees follow [ZIP 317] (proportional to transaction size), always.
+There is no fee parameter to tune: `z_sendmany` requires its `fee` argument to
+be `null` if present, and `zcashd`'s `settxfee` has no equivalent.
+
+[ZIP 315]: https://zips.z.cash/zip-0315
+[ZIP 317]: https://zips.z.cash/zip-0317


### PR DESCRIPTION
## Summary

Adds a "Concepts" section to the book — four short pages, each citing zips.z.cash for protocol semantics rather than restating specs:

- **Accounts and keys**: multiple seeds and seed fingerprints, ZIP 32 account derivation, instance-local UUIDs vs the portable `(seedfp, index)` identity used for recovery, imported keys/watch-only addresses as accounts, ZIP 316 unified addresses (with the transparent-receiver linkability caveat).
- **Wallet encryption**: the age identity model, what is and is not encrypted in `wallet.db`, passphrase locking (`walletpassphrase`/`walletlock`, `ZALLET_IDENTITY_PASSPHRASE`), and why there is no `encryptwallet` equivalent.
- **Notes, confirmations, and fees**: notes vs UTXOs, internal change handling, the ZIP 315 draft trusted/untrusted policy with the verified defaults (3/10 via `builder.trusted_confirmations`/`builder.untrusted_confirmations`), mandatory ZIP 317 fees.
- **Asynchronous operations**: the operation-id lifecycle (`z_getoperationstatus` polls, `z_getoperationresult` collects-and-removes, `z_listoperationids`), the in-memory nature of operations, and how to recover a lost opid.

Facts verified against the RPC trait rustdoc, the generated example config, and the keystore/commands sources. Note: pages link to the backup guide added in #624 (soft dependency; nothing breaks if this merges first).

Closes #604. Part of #600.

## Test plan

- [x] `mdbook build` succeeds with no warnings; all four pages render and are linked from SUMMARY

## AI disclosure

Written with AI assistance (Claude Fable 5, via Claude Code); `Co-Authored-By` metadata is on the commits. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
