### PR TITLE
docs: Publish zallet-core rustdoc with the book, and expand architecture docs

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -36,6 +36,14 @@ jobs:
         run: |
           mdbook build book
 
+      # Publish zallet-core's rustdoc alongside the book, under /rustdoc/.
+      # Private items are included: zallet-core is not a public library, so the
+      # audience for these docs is Zallet contributors.
+      - name: Build rustdoc (zallet-core)
+        run: |
+          cargo doc --no-deps --document-private-items -p zallet-core
+          cp -r target/doc book/book/rustdoc
+
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 

--- a/zallet-core/src/application.rs
+++ b/zallet-core/src/application.rs
@@ -1,4 +1,12 @@
-//! Zallet Abscissa Application
+//! Zallet Abscissa Application.
+//!
+//! Each backend binary calls [`boot`] with its [`ChainRuntime`] factory; `boot` records
+//! the backend in a process-wide slot (consumed by commands via `chain_runtime`) and
+//! hands control to Abscissa, which parses the CLI and runs the selected command. Config
+//! loading validates that a config file's `backend` key names the registered backend,
+//! since every backend binary operates on the same wallet database.
+//!
+//! [`ChainRuntime`]: crate::components::chain::ChainRuntime
 
 use std::path::Path;
 use std::sync::OnceLock;

--- a/zallet-core/src/lib.rs
+++ b/zallet-core/src/lib.rs
@@ -1,6 +1,45 @@
-//! Zallet
+//! The shared core of Zallet, a full-node Zcash wallet.
 //!
-//! Application based on the [Abscissa] framework.
+//! Zallet is not designed to be used as a Rust library; this crate is the common
+//! implementation that Zallet's per-backend binaries statically link. Its documentation
+//! is for Zallet contributors.
+//!
+//! # Architecture
+//!
+//! Zallet ships as several binaries built from three Cargo workspaces:
+//!
+//! - `zallet` (in the root workspace, alongside this crate) is a dependency-light
+//!   launcher: it reads the config file's top-level `backend` key and hands the entire
+//!   invocation over to the matching `zallet-<backend>` binary.
+//! - `zallet-zebra` and `zallet-zaino` (each in its own workspace under `backends/`, so
+//!   their `zebra`/`zaino` dependency trees can move independently) are the real wallet
+//!   binaries. Each supplies a [`components::chain::ChainRuntime`] for its chain backend
+//!   and calls [`application::boot`], which registers the backend and starts the
+//!   [Abscissa] application defined here; everything else — CLI, configuration, wallet
+//!   database, key store, sync engine, JSON-RPC interface — is this crate.
+//!
+//! All backend binaries operate on the same wallet database, which is why they validate
+//! the config's `backend` key against the backend they provide, and why the
+//! `zcash_client_sqlite` stack must resolve to identical versions across the three
+//! workspaces (enforced in CI).
+//!
+//! # Components
+//!
+//! The long-running pieces live in [`components`]:
+//!
+//! - [`components::chain`] — the interface to the chain backend.
+//! - `components::database` — the wallet database (`zcash_client_sqlite`).
+//! - `components::keystore` — age-encrypted key material; see its module docs for the
+//!   design.
+//! - `components::sync` — the sync engine keeping the wallet's chain view current; see
+//!   its module docs for the design.
+//! - `components::json_rpc` — the JSON-RPC server and methods. The rustdoc on the RPC
+//!   traits is the single source of truth for method documentation: the build script
+//!   generates the `zallet rpc help` output, the `rpc.discover` OpenRPC document, and
+//!   the book's JSON-RPC reference from it.
+//!
+//! Similarly, the rustdoc on [`config`] generates the `zallet example-config` output and
+//! the book's configuration reference.
 //!
 //! [Abscissa]: https://github.com/iqlusioninc/abscissa
 


### PR DESCRIPTION
## Summary

Two parts:

1. **Publish rustdoc.** The book deploy workflow (`book.yml`) now also runs `cargo doc --no-deps --document-private-items -p zallet-core` and copies the output into the Pages artifact under `/rustdoc/`, so the API docs get a linkable home at `https://zcash.github.io/zallet/rustdoc/zallet_core/` (zallet-core is not on crates.io, so there is no docs.rs). Private items are included deliberately: the crate is not a public library, and the audience is contributors. Backend crates are left out for now (separate workspaces, heavy builds) — easy follow-up if wanted.
2. **Architecture docs.** Expands `lib.rs`'s crate docs from five lines to an overview of the launcher/backend-binary split, backend registration via `application::boot`/`ChainRuntime`, the shared-wallet-database constraint behind backend validation and dependency lockstep, the component map, and the docs-from-code pipelines. Also expands the `application` module header. The `sync` and `keystore` modules already carry detailed `# Design` docs — they are pointed to, not duplicated.

Verified: `cargo doc` builds clean **both** with and without `--document-private-items` (all new intra-doc links target public items, so contributors running plain `cargo doc` hit no `broken_intra_doc_links` errors), and `cargo fmt --check` passes.

Closes #609. Part of #600.

## Test plan

- [x] `cargo doc --no-deps -p zallet-core` and `cargo doc --no-deps --document-private-items -p zallet-core` both succeed with zero warnings
- [x] `cargo fmt --all -- --check` clean
- [ ] After merge: confirm `/zallet/rustdoc/zallet_core/` deploys (first run of the modified workflow)

## AI disclosure

Written with AI assistance (Claude Fable 5, via Claude Code); `Co-Authored-By` metadata is on the commit. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
