### PR TITLE
z_getbalances: split transparent balance into regular and coinbase; z_listunspent: add 'generated' flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ be considered breaking changes.
     unified addresses (returning the account's unified full viewing key), and
     an optional `ivk` argument that exports the account's unified incoming
     viewing key instead.
+- `z_listunspent` transparent outputs now include a `generated` field
+  indicating coinbase origin (mirroring `zcashd`'s `listunspent`), so
+  integrators no longer need a `getrawtransaction` round-trip per UTXO to
+  distinguish coinbase from spendable-to-transparent funds.
 
 ### Changed
 
@@ -27,6 +31,15 @@ be considered breaking changes.
 
 ### Fixed
 
+- `z_getbalances` now reports the documented transparent balance split:
+  `regular` contains only non-coinbase funds and `coinbase` is populated with
+  coinbase funds (immature coinbase is reported as `pending` rather than
+  spendable). Previously `regular` silently included coinbase value and
+  `coinbase` was never present.
+- `z_getbalances` account `total` now includes transparent value in its
+  `spendable` and `pending` buckets. Previously only the shielded pools
+  contributed, so a wallet holding only transparent funds reported a zero
+  spendable total.
 - `z_sendmany` and `z_shieldcoinbase` now verify, after building a transaction
   and before broadcasting it, that every transparent output either exactly
   matches a requested payment or has an address that re-derives from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
 ]
@@ -5749,7 +5749,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5762,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5812,7 +5812,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "corez",
  "hex",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6007,8 +6007,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6043,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "corez",
  "document-features",
@@ -6106,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bip32",
  "bs58",
@@ -6224,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "zewif"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abbade0d83234bfef4eeff61e115c667871dc164895209f30815bf301e5389b"
+checksum = "9b300001aff0db0e844ea42359640b6abe648776b055d7861fb7075782abb715"
 dependencies = [
  "hex",
  "minicbor",
@@ -6235,9 +6234,9 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88a240e836ec479c2b8a5384978fce6965471d0878d48c2d4025400be3a1e16"
+checksum = "33950619fb1ed89b7878a8d147b23469f3000702706f631b3510ea340bdfff44"
 dependencies = [
  "aes",
  "bech32 0.12.0",
@@ -6285,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,8 @@ zip32 = "0.2"
 bip32 = "0.2"
 
 # Zcashd wallet migration
-zewif = { version = "1.0.0-rc.2" }
-zewif-zcashd = { version = "0.1.0-rc.2" }
+zewif = { version = "1.0.0-rc.3" }
+zewif-zcashd = { version = "0.1.0-rc.3" }
 which = "8.0"
 anyhow = "1.0"
 
@@ -160,24 +160,19 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-# Temporary patch for `WalletDb::transactionally_with_extension` (adds atomic
-# z_importkey account+key writes), merged upstream but not yet released. The API
-# lives in zcash_client_sqlite, but the repo is a workspace: pinning only that
-# crate pulls its path-dep siblings from git while their crates.io copies remain,
-# duplicating the librustzcash stack, so the whole stack is pinned to one rev.
-# Replace with the crates.io releases once the next zcash_client_sqlite release
-# ships.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
+# Replace with the crates.io releases once they ship.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7026,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7124,7 +7124,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "corez",
  "hex",
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7282,8 +7282,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7318,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "corez",
  "document-features",
@@ -7381,7 +7380,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bip32",
  "bs58",
@@ -7774,9 +7773,9 @@ dependencies = [
 
 [[package]]
 name = "zewif"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abbade0d83234bfef4eeff61e115c667871dc164895209f30815bf301e5389b"
+checksum = "9b300001aff0db0e844ea42359640b6abe648776b055d7861fb7075782abb715"
 dependencies = [
  "hex",
  "minicbor",
@@ -7785,9 +7784,9 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88a240e836ec479c2b8a5384978fce6965471d0878d48c2d4025400be3a1e16"
+checksum = "33950619fb1ed89b7878a8d147b23469f3000702706f631b3510ea340bdfff44"
 dependencies = [
  "aes",
  "bech32 0.12.0",
@@ -7835,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -72,24 +72,19 @@ once_cell = "1.2"
 tempfile = "3"
 
 [patch.crates-io]
-# Temporary patch for `WalletDb::transactionally_with_extension` (adds atomic
-# z_importkey account+key writes), merged upstream but not yet released. The API
-# lives in zcash_client_sqlite, but the repo is a workspace: pinning only that
-# crate pulls its path-dep siblings from git while their crates.io copies remain,
-# duplicating the librustzcash stack, so the whole stack is pinned to one rev.
-# Replace with the crates.io releases once the next zcash_client_sqlite release
-# ships.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
+# Replace with the crates.io releases once they ship.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
 # which surfaces the Ironwood (NU6.3) note commitment treestate from

--- a/backends/zaino/supply-chain/config.toml
+++ b/backends/zaino/supply-chain/config.toml
@@ -23,8 +23,10 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [policy.equihash]
+audit-as-crates-io = false
 
 [policy.f4jumble]
+audit-as-crates-io = false
 
 [policy.incrementalmerkletree]
 
@@ -47,24 +49,33 @@ audit-as-crates-io = false
 audit-as-crates-io = false
 
 [policy.zcash_address]
+audit-as-crates-io = false
 
 [policy.zcash_client_backend]
+audit-as-crates-io = false
 
 [policy.zcash_client_sqlite]
+audit-as-crates-io = false
 
 [policy.zcash_encoding]
+audit-as-crates-io = false
 
 [policy.zcash_history]
 
 [policy.zcash_keys]
+audit-as-crates-io = false
 
 [policy.zcash_primitives]
+audit-as-crates-io = false
 
 [policy.zcash_proofs]
+audit-as-crates-io = false
 
 [policy.zcash_protocol]
+audit-as-crates-io = false
 
 [policy.zcash_transparent]
+audit-as-crates-io = false
 
 [policy.zebra-chain]
 
@@ -81,6 +92,7 @@ audit-as-crates-io = false
 [policy.zebra-state]
 
 [policy.zip321]
+audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -1090,10 +1102,6 @@ criteria = "safe-to-deploy"
 version = "0.4.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-conv]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.num_cpus]]
 version = "1.16.0"
 criteria = "safe-to-deploy"
@@ -1700,10 +1708,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.53"
-criteria = "safe-to-deploy"
-
-[[exemptions.time-core]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]

--- a/backends/zaino/supply-chain/imports.lock
+++ b/backends/zaino/supply-chain/imports.lock
@@ -321,13 +321,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_address]]
-version = "0.13.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_history]]
 version = "0.5.0"
 when = "2026-07-09"
@@ -342,13 +335,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_keys]]
-version = "0.15.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_primitives]]
 version = "0.28.0"
 when = "2026-06-03"
@@ -356,30 +342,9 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_primitives]]
-version = "0.29.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_proofs]]
-version = "0.29.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_protocol]]
 version = "0.9.0"
 when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_protocol]]
-version = "0.10.0"
-when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -398,23 +363,16 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_transparent]]
-version = "0.9.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zewif]]
-version = "1.0.0-rc.2"
-when = "2026-07-11"
+version = "1.0.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zewif-zcashd]]
-version = "0.1.0-rc.2"
-when = "2026-07-11"
+version = "0.1.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -769,6 +727,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.50.1 -> 0.50.3"
 notes = "CI changes, Rust changes, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
 
 [[audits.bytecode-alliance.audits.object]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2595,6 +2559,23 @@ delta = "0.29.0 -> 0.30.1"
 notes = "Some new wrappers, support for minor platforms and lots of work around type safety that reduces the unsafe surafce."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.objc2-core-foundation]]
 who = "Andy Leiserson <aleiserson@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -2918,6 +2899,37 @@ criteria = "safe-to-deploy"
 delta = "1.0.43 -> 1.0.69"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.toml_datetime]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3192,6 +3204,13 @@ Additions are:
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
+[[audits.zcash.audits.num-conv]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to unsafe code, straightforward refactoring and cleanup."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.num_cpus]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3394,6 +3413,13 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.1.8 -> 1.1.9"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.tinyvec_macros]]
 who = "Jack Grigg <jack@z.cash>"

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6655,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "corez",
  "hex",
@@ -6755,7 +6755,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6831,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6861,8 +6861,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6897,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "corez",
  "document-features",
@@ -6960,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "bip32",
  "bs58",
@@ -7353,9 +7352,9 @@ dependencies = [
 
 [[package]]
 name = "zewif"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abbade0d83234bfef4eeff61e115c667871dc164895209f30815bf301e5389b"
+checksum = "9b300001aff0db0e844ea42359640b6abe648776b055d7861fb7075782abb715"
 dependencies = [
  "hex",
  "minicbor",
@@ -7364,9 +7363,9 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88a240e836ec479c2b8a5384978fce6965471d0878d48c2d4025400be3a1e16"
+checksum = "33950619fb1ed89b7878a8d147b23469f3000702706f631b3510ea340bdfff44"
 dependencies = [
  "aes",
  "bech32 0.12.0",
@@ -7414,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=d09d1f390f2e4e3d8978bedfe84dd18aeceef008#d09d1f390f2e4e3d8978bedfe84dd18aeceef008"
+source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -75,24 +75,19 @@ rpc-cli = ["zallet-core/rpc-cli"]
 tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
-# Temporary patch for `WalletDb::transactionally_with_extension` (adds atomic
-# z_importkey account+key writes), merged upstream but not yet released. The API
-# lives in zcash_client_sqlite, but the repo is a workspace: pinning only that
-# crate pulls its path-dep siblings from git while their crates.io copies remain,
-# duplicating the librustzcash stack, so the whole stack is pinned to one rev.
-# Replace with the crates.io releases once the next zcash_client_sqlite release
-# ships.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "d09d1f390f2e4e3d8978bedfe84dd18aeceef008" }
+# Replace with the crates.io releases once they ship.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/backends/zebra/supply-chain/config.toml
+++ b/backends/zebra/supply-chain/config.toml
@@ -23,8 +23,10 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [policy.equihash]
+audit-as-crates-io = false
 
 [policy.f4jumble]
+audit-as-crates-io = false
 
 [policy.incrementalmerkletree]
 
@@ -35,24 +37,33 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [policy.tower-fallback]
 
 [policy.zcash_address]
+audit-as-crates-io = false
 
 [policy.zcash_client_backend]
+audit-as-crates-io = false
 
 [policy.zcash_client_sqlite]
+audit-as-crates-io = false
 
 [policy.zcash_encoding]
+audit-as-crates-io = false
 
 [policy.zcash_history]
 
 [policy.zcash_keys]
+audit-as-crates-io = false
 
 [policy.zcash_primitives]
+audit-as-crates-io = false
 
 [policy.zcash_proofs]
+audit-as-crates-io = false
 
 [policy.zcash_protocol]
+audit-as-crates-io = false
 
 [policy.zcash_transparent]
+audit-as-crates-io = false
 
 [policy.zebra-chain]
 
@@ -69,6 +80,7 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [policy.zebra-state]
 
 [policy.zip321]
+audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -1018,10 +1030,6 @@ criteria = "safe-to-deploy"
 version = "0.4.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-conv]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.num_cpus]]
 version = "1.16.0"
 criteria = "safe-to-deploy"
@@ -1588,10 +1596,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.53"
-criteria = "safe-to-deploy"
-
-[[exemptions.time-core]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]

--- a/backends/zebra/supply-chain/imports.lock
+++ b/backends/zebra/supply-chain/imports.lock
@@ -321,13 +321,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_address]]
-version = "0.13.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_history]]
 version = "0.5.0"
 when = "2026-07-09"
@@ -342,13 +335,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_keys]]
-version = "0.15.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_primitives]]
 version = "0.28.0"
 when = "2026-06-03"
@@ -356,30 +342,9 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_primitives]]
-version = "0.29.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_proofs]]
-version = "0.29.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_protocol]]
 version = "0.9.0"
 when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_protocol]]
-version = "0.10.0"
-when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -398,23 +363,16 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_transparent]]
-version = "0.9.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zewif]]
-version = "1.0.0-rc.2"
-when = "2026-07-11"
+version = "1.0.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zewif-zcashd]]
-version = "0.1.0-rc.2"
-when = "2026-07-11"
+version = "0.1.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -759,6 +717,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.50.1 -> 0.50.3"
 notes = "CI changes, Rust changes, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
 
 [[audits.bytecode-alliance.audits.object]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2532,6 +2496,23 @@ delta = "0.29.0 -> 0.30.1"
 notes = "Some new wrappers, support for minor platforms and lots of work around type safety that reduces the unsafe surafce."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.once_cell]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2845,6 +2826,37 @@ criteria = "safe-to-deploy"
 delta = "1.0.43 -> 1.0.69"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.toml_datetime]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3119,6 +3131,13 @@ Additions are:
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
+[[audits.zcash.audits.num-conv]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to unsafe code, straightforward refactoring and cleanup."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.num_cpus]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3321,6 +3340,13 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.1.8 -> 1.1.9"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.tinyvec_macros]]
 who = "Jack Grigg <jack@z.cash>"

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -151,6 +151,31 @@ instead, or you may lose access to funds.
 - `address` (string, required) The Sapling payment address corresponding to the
   spending key to export.
 
+## `z_exportviewingkey`
+
+*Only available in wallet builds of Zallet.*
+
+Reveals the viewing key corresponding to 'zaddr'.
+
+#### Arguments
+
+- `zaddr` (string, required) The Sapling payment address or unified
+  address.
+- `ivk` (boolean, optional, default=`false`) When `true`, export the
+  unified incoming viewing key (UIVK) for the account holding `zaddr`
+  instead of the full viewing key.
+
+#### Returns
+A string containing the viewing key:
+- For a Sapling payment address, the Sapling extended full viewing key
+  (`zxviews…`).
+- For a unified address, the unified full viewing key (`uview…`) of the
+  account holding the address.
+- When `ivk` is `true`, the unified incoming viewing key (`uivk…`) of
+  the account holding the address, for either address kind. Note that
+  a UIVK grants incoming viewing capability for every pool in the
+  account, even when `zaddr` is a Sapling address.
+
 ## `z_getaccount`
 
 Returns details about the given account.

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -23,32 +23,44 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [policy.equihash]
+audit-as-crates-io = false
 
 [policy.f4jumble]
+audit-as-crates-io = false
 
 [policy.incrementalmerkletree]
 
 [policy.shardtree]
 
 [policy.zcash_address]
+audit-as-crates-io = false
 
 [policy.zcash_client_backend]
+audit-as-crates-io = false
 
 [policy.zcash_client_sqlite]
+audit-as-crates-io = false
 
 [policy.zcash_encoding]
+audit-as-crates-io = false
 
 [policy.zcash_keys]
+audit-as-crates-io = false
 
 [policy.zcash_primitives]
+audit-as-crates-io = false
 
 [policy.zcash_proofs]
+audit-as-crates-io = false
 
 [policy.zcash_protocol]
+audit-as-crates-io = false
 
 [policy.zcash_transparent]
+audit-as-crates-io = false
 
 [policy.zip321]
+audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -894,10 +906,6 @@ criteria = "safe-to-deploy"
 version = "0.4.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-conv]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.num_cpus]]
 version = "1.16.0"
 criteria = "safe-to-deploy"
@@ -1356,10 +1364,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.53"
-criteria = "safe-to-deploy"
-
-[[exemptions.time-core]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -314,23 +314,9 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_address]]
-version = "0.13.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_keys]]
 version = "0.14.0"
 when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_keys]]
-version = "0.15.0"
-when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -342,30 +328,9 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_primitives]]
-version = "0.29.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_proofs]]
-version = "0.29.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_protocol]]
 version = "0.9.0"
 when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_protocol]]
-version = "0.10.0"
-when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -384,23 +349,16 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_transparent]]
-version = "0.9.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zewif]]
-version = "1.0.0-rc.2"
-when = "2026-07-11"
+version = "1.0.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zewif-zcashd]]
-version = "0.1.0-rc.2"
-when = "2026-07-11"
+version = "0.1.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -748,6 +706,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.50.1 -> 0.50.3"
 notes = "CI changes, Rust changes, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
 
 [[audits.bytecode-alliance.audits.object]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2434,6 +2398,23 @@ criteria = "safe-to-deploy"
 delta = "0.28.0 -> 0.29.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.once_cell]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2692,6 +2673,37 @@ criteria = "safe-to-deploy"
 delta = "1.0.43 -> 1.0.69"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.toml_datetime]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -2923,6 +2935,13 @@ Additions are:
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
+[[audits.zcash.audits.num-conv]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to unsafe code, straightforward refactoring and cleanup."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.num_cpus]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3078,6 +3097,13 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.1.8 -> 1.1.9"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.tinyvec_macros]]
 who = "Jack Grigg <jack@z.cash>"

--- a/zallet-core/src/components/json_rpc/methods/get_balances.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_balances.rs
@@ -177,18 +177,7 @@ pub(crate) fn call(wallet: &DbConnection, minconf: Option<u32>) -> Response {
         .account_balances()
         .iter()
         .map(|(account_uuid, account)| {
-            // TODO: Separate out transparent coinbase and standalone balances.
-            let transparent_regular = account.unshielded_balance();
-
-            Ok(AccountBalance {
-                account_uuid: account_uuid.expose_uuid().to_string(),
-                transparent: opt_transparent_balance(transparent_regular)?,
-                transparent_watchonly: vec![],
-                sapling: opt_balance_from(account.sapling_balance())?,
-                orchard: opt_balance_from(account.orchard_balance())?,
-                ironwood: opt_balance_from(account.ironwood_balance())?,
-                total: balance_from(account)?,
-            })
+            account_balance_response(account_uuid.expose_uuid().to_string(), account)
         })
         .collect::<RpcResult<_>>()?;
 
@@ -201,26 +190,69 @@ pub(crate) fn call(wallet: &DbConnection, minconf: Option<u32>) -> Response {
     })
 }
 
+/// Builds the balance report for a single account.
+fn account_balance_response(
+    account_uuid: String,
+    account: &zcash_client_backend::data_api::AccountBalance,
+) -> RpcResult<AccountBalance> {
+    Ok(AccountBalance {
+        account_uuid,
+        transparent: opt_transparent_balance(
+            account.unshielded_regular_balance(),
+            account.unshielded_coinbase_balance(),
+        )?,
+        // TODO: Fetch balances for standalone/watch-only transparent addresses.
+        transparent_watchonly: vec![],
+        sapling: opt_balance_from(account.sapling_balance())?,
+        orchard: opt_balance_from(account.orchard_balance())?,
+        ironwood: opt_balance_from(account.ironwood_balance())?,
+        total: balance_from(account)?,
+    })
+}
+
 fn opt_transparent_balance(
     regular: &zcash_client_backend::data_api::Balance,
+    coinbase: &zcash_client_backend::data_api::Balance,
 ) -> RpcResult<Option<TransparentBalance>> {
-    if regular.total().is_zero() && regular.uneconomic_value().is_zero() {
+    let is_empty = |b: &zcash_client_backend::data_api::Balance| {
+        b.total().is_zero() && b.uneconomic_value().is_zero()
+    };
+    if is_empty(regular) && is_empty(coinbase) {
         Ok(None)
     } else {
         Ok(Some(TransparentBalance {
             regular: opt_balance_from(regular)?,
-            coinbase: None,
+            coinbase: opt_balance_from(coinbase)?,
         }))
     }
 }
 
 fn balance_from(b: &zcash_client_backend::data_api::AccountBalance) -> RpcResult<Balance> {
+    let regular = b.unshielded_regular_balance();
+    let coinbase = b.unshielded_coinbase_balance();
+
     Ok(balance(
-        b.spendable_value(),
-        (b.change_pending_confirmation() + b.value_pending_spendability()).ok_or(
+        // `AccountBalance::spendable_value` covers the shielded pools only.
+        (b.spendable_value() + regular.spendable_value() + coinbase.spendable_value()).ok_or(
             LegacyCode::Database
                 .with_static("Wallet database is corrupt: storing more than MAX_MONEY"),
         )?,
+        // `AccountBalance::change_pending_confirmation` and
+        // `AccountBalance::value_pending_spendability` cover the shielded pools only.
+        // Immature transparent coinbase funds are reported by the coinbase bucket's
+        // pending fields.
+        (b.change_pending_confirmation()
+            + b.value_pending_spendability()
+            + regular.change_pending_confirmation()
+            + regular.value_pending_spendability()
+            + coinbase.change_pending_confirmation()
+            + coinbase.value_pending_spendability())
+        .ok_or(
+            LegacyCode::Database
+                .with_static("Wallet database is corrupt: storing more than MAX_MONEY"),
+        )?,
+        // `AccountBalance::uneconomic_value` already includes both transparent buckets,
+        // so it must be used exactly once here.
         b.uneconomic_value(),
     ))
 }
@@ -264,4 +296,258 @@ fn opt_value(value: Zatoshis) -> Option<Value> {
     (!value.is_zero()).then(|| Value {
         value_zat: value.into_u64(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use zcash_client_backend::data_api::{self, AccountBalance};
+    use zcash_protocol::value::{BalanceError, Zatoshis};
+
+    use super::account_balance_response;
+
+    const UUID: &str = "test-uuid";
+
+    fn zat(value: u64) -> Zatoshis {
+        Zatoshis::const_from_u64(value)
+    }
+
+    /// Adds the given values (in zatoshis) to each bucket of a pool's [`data_api::Balance`].
+    fn fill(
+        balance: &mut data_api::Balance,
+        spendable: u64,
+        pending_change: u64,
+        pending_spendable: u64,
+        dust: u64,
+    ) -> Result<(), BalanceError> {
+        balance.add_spendable_value(zat(spendable))?;
+        balance.add_pending_change_value(zat(pending_change))?;
+        balance.add_pending_spendable_value(zat(pending_spendable))?;
+        balance.add_uneconomic_value(zat(dust))
+    }
+
+    /// Renders the response for an account balance to its JSON representation (the
+    /// actual RPC output contract).
+    fn rendered(account: &AccountBalance) -> serde_json::Value {
+        serde_json::to_value(account_balance_response(UUID.into(), account).unwrap()).unwrap()
+    }
+
+    // An account with no funds anywhere omits the `transparent` key entirely (along
+    // with all shielded pool keys), and reports a zero spendable total.
+    #[test]
+    fn empty_account_omits_transparent() {
+        assert_eq!(
+            rendered(&AccountBalance::ZERO),
+            json!({
+                "account_uuid": UUID,
+                "total": {"spendable": {"valueZat": 0}},
+            }),
+        );
+    }
+
+    // Regular-only transparent funds render under `transparent.regular`, with the
+    // `coinbase` key omitted.
+    #[test]
+    fn regular_only_omits_coinbase() {
+        let mut account = AccountBalance::ZERO;
+        account
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(10_000))
+            })
+            .unwrap();
+
+        assert_eq!(
+            rendered(&account),
+            json!({
+                "account_uuid": UUID,
+                "transparent": {"regular": {"spendable": {"valueZat": 10_000}}},
+                "total": {"spendable": {"valueZat": 10_000}},
+            }),
+        );
+    }
+
+    // Coinbase-only transparent funds render under `transparent.coinbase`, with the
+    // `regular` key omitted. Mature (spendable) coinbase appears in both
+    // `coinbase.spendable` and `total.spendable`.
+    #[test]
+    fn mature_coinbase_only_is_spendable_and_omits_regular() {
+        let mut account = AccountBalance::ZERO;
+        account
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(625_000_000))
+            })
+            .unwrap();
+
+        assert_eq!(
+            rendered(&account),
+            json!({
+                "account_uuid": UUID,
+                "transparent": {"coinbase": {"spendable": {"valueZat": 625_000_000u64}}},
+                "total": {"spendable": {"valueZat": 625_000_000u64}},
+            }),
+        );
+    }
+
+    // Immature coinbase funds are pending, not spendable: they appear in
+    // `coinbase.pending` and are included in `total.pending`.
+    #[test]
+    fn immature_coinbase_is_pending() {
+        let mut account = AccountBalance::ZERO;
+        account
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                b.add_pending_spendable_value(zat(625_000_000))
+            })
+            .unwrap();
+
+        assert_eq!(
+            rendered(&account),
+            json!({
+                "account_uuid": UUID,
+                "transparent": {
+                    "coinbase": {
+                        "spendable": {"valueZat": 0},
+                        "pending": {"valueZat": 625_000_000u64},
+                    },
+                },
+                "total": {
+                    "spendable": {"valueZat": 0},
+                    "pending": {"valueZat": 625_000_000u64},
+                },
+            }),
+        );
+    }
+
+    // When both buckets hold funds, `regular` and `coinbase` render side by side and
+    // both contribute to the account total.
+    #[test]
+    fn regular_and_coinbase_render_side_by_side() {
+        let mut account = AccountBalance::ZERO;
+        account
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(10_000))
+            })
+            .unwrap();
+        account
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(625_000_000))
+            })
+            .unwrap();
+
+        assert_eq!(
+            rendered(&account),
+            json!({
+                "account_uuid": UUID,
+                "transparent": {
+                    "regular": {"spendable": {"valueZat": 10_000}},
+                    "coinbase": {"spendable": {"valueZat": 625_000_000u64}},
+                },
+                "total": {"spendable": {"valueZat": 625_010_000u64}},
+            }),
+        );
+    }
+
+    // `AccountBalance::uneconomic_value` already includes the transparent buckets, so
+    // dust spread across shielded and both transparent buckets must be counted exactly
+    // once in `total.dust`.
+    #[test]
+    fn dust_across_pools_is_counted_once() {
+        let mut account = AccountBalance::ZERO;
+        account
+            .with_sapling_balance_mut::<_, BalanceError>(|b| b.add_uneconomic_value(zat(100)))
+            .unwrap();
+        account
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
+                b.add_uneconomic_value(zat(200))
+            })
+            .unwrap();
+        account
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                b.add_uneconomic_value(zat(300))
+            })
+            .unwrap();
+
+        assert_eq!(account.uneconomic_value(), zat(600));
+        assert_eq!(
+            rendered(&account),
+            json!({
+                "account_uuid": UUID,
+                "transparent": {
+                    "regular": {"spendable": {"valueZat": 0}, "dust": {"valueZat": 200}},
+                    "coinbase": {"spendable": {"valueZat": 0}, "dust": {"valueZat": 300}},
+                },
+                "sapling": {"spendable": {"valueZat": 0}, "dust": {"valueZat": 100}},
+                "total": {"spendable": {"valueZat": 0}, "dust": {"valueZat": 600}},
+            }),
+        );
+    }
+
+    // With every bucket of every pool nonzero, the account total's spendable, pending,
+    // and dust fields each equal the exact sum of the per-pool parts.
+    #[test]
+    fn total_is_sum_of_parts_across_all_pools() {
+        let mut account = AccountBalance::ZERO;
+        // Distinct powers of two so that every sum is unambiguous.
+        account
+            .with_sapling_balance_mut(|b| fill(b, 1, 2, 4, 8))
+            .unwrap();
+        account
+            .with_orchard_balance_mut(|b| fill(b, 16, 32, 64, 128))
+            .unwrap();
+        account
+            .with_ironwood_balance_mut(|b| fill(b, 256, 512, 1024, 2048))
+            .unwrap();
+        account
+            .with_unshielded_regular_balance_mut(|b| fill(b, 4096, 8192, 16384, 32768))
+            .unwrap();
+        account
+            .with_unshielded_coinbase_balance_mut(|b| fill(b, 65536, 131072, 262144, 524288))
+            .unwrap();
+
+        // Expected sums, computed by hand:
+        // spendable = 1 + 16 + 256 + 4096 + 65536
+        let spendable = 69_905u64;
+        // pending = (2+4) + (32+64) + (512+1024) + (8192+16384) + (131072+262144)
+        let pending = 6 + 96 + 1536 + 24576 + 393216u64;
+        // dust = 8 + 128 + 2048 + 32768 + 524288
+        let dust = 559_240u64;
+
+        assert_eq!(
+            rendered(&account),
+            json!({
+                "account_uuid": UUID,
+                "transparent": {
+                    "regular": {
+                        "spendable": {"valueZat": 4096},
+                        "pending": {"valueZat": 8192 + 16384},
+                        "dust": {"valueZat": 32768},
+                    },
+                    "coinbase": {
+                        "spendable": {"valueZat": 65536},
+                        "pending": {"valueZat": 131072 + 262144},
+                        "dust": {"valueZat": 524288},
+                    },
+                },
+                "sapling": {
+                    "spendable": {"valueZat": 1},
+                    "pending": {"valueZat": 6},
+                    "dust": {"valueZat": 8},
+                },
+                "orchard": {
+                    "spendable": {"valueZat": 16},
+                    "pending": {"valueZat": 96},
+                    "dust": {"valueZat": 128},
+                },
+                "ironwood": {
+                    "spendable": {"valueZat": 256},
+                    "pending": {"valueZat": 1536},
+                    "dust": {"valueZat": 2048},
+                },
+                "total": {
+                    "spendable": {"valueZat": spendable},
+                    "pending": {"valueZat": pending},
+                    "dust": {"valueZat": dust},
+                },
+            }),
+        );
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -20,7 +20,7 @@ use zcash_client_backend::{
     wallet::NoteId,
 };
 use zcash_keys::address::Address;
-use zcash_protocol::ShieldedPool;
+use zcash_protocol::{ShieldedPool, value::Zatoshis};
 use zip32::Scope;
 
 use crate::components::{
@@ -76,6 +76,12 @@ pub(crate) struct UnspentOutput {
     /// result of some wallet-internal operation.
     #[serde(rename = "walletInternal")]
     wallet_internal: bool,
+
+    /// `true` if the output was produced by a coinbase transaction.
+    ///
+    /// Omitted if this is a shielded output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generated: Option<bool>,
 
     /// The value of the output in ZEC.
     value: JsonZec,
@@ -191,26 +197,36 @@ pub(crate) fn call(
             })?
             .iter()
             .try_fold(vec![], |mut acc, (addr, _)| {
-                let mut outputs = wallet
-                    .get_spendable_transparent_outputs(
-                        addr,
-                        target_height,
-                        confirmations_policy,
-                        CoinbaseFilter::AllTransparentOutputs,
-                    )
-                    .map_err(|e| {
-                        RpcError::owned(
-                            LegacyCode::Database.into(),
-                            "WalletDb::get_spendable_transparent_outputs failed",
-                            Some(format!("{e}")),
+                // Query non-coinbase and coinbase outputs separately so that each UTXO
+                // can be tagged with its coinbase origin. The two filters partition the
+                // full set of spendable outputs: outputs with an unknown transaction
+                // index are treated as non-coinbase by `NonCoinbaseOnly` and excluded
+                // by `CoinbaseOnly`, so nothing is dropped or duplicated.
+                for (coinbase_filter, generated) in [
+                    (CoinbaseFilter::NonCoinbaseOnly, false),
+                    (CoinbaseFilter::CoinbaseOnly, true),
+                ] {
+                    let outputs = wallet
+                        .get_spendable_transparent_outputs(
+                            addr,
+                            target_height,
+                            confirmations_policy,
+                            coinbase_filter,
                         )
-                    })?;
+                        .map_err(|e| {
+                            RpcError::owned(
+                                LegacyCode::Database.into(),
+                                "WalletDb::get_spendable_transparent_outputs failed",
+                                Some(format!("{e}")),
+                            )
+                        })?;
 
-                acc.append(&mut outputs);
+                    acc.extend(outputs.into_iter().map(|utxo| (utxo, generated)));
+                }
                 Ok::<_, RpcError>(acc)
             })?;
 
-        for utxo in utxos {
+        for (utxo, generated) in utxos {
             let confirmations = utxo.mined_height().map(|h| target_height - h).unwrap_or(0);
 
             let wallet_internal = wallet
@@ -224,23 +240,19 @@ pub(crate) fn call(
                 })?
                 .is_some_and(|m| m.scope() == Some(TransparentKeyScope::INTERNAL));
 
-            unspent_outputs.push(UnspentOutput {
-                txid: utxo.outpoint().txid().to_string(),
-                pool: "transparent".into(),
-                outindex: utxo.outpoint().n(),
+            unspent_outputs.push(transparent_unspent_output(
+                utxo.outpoint().txid().to_string(),
+                utxo.outpoint().n(),
                 confirmations,
                 is_watch_only,
-                account_uuid: account_id.expose_uuid().to_string(),
-                address: utxo
-                    .txout()
+                utxo.txout()
                     .recipient_address()
                     .map(|addr| addr.encode(wallet.params())),
-                value: value_from_zatoshis(utxo.value()),
-                value_zat: u64::from(utxo.value()),
-                memo: None,
-                memo_str: None,
+                account_id.expose_uuid().to_string(),
                 wallet_internal,
-            })
+                utxo.value(),
+                generated,
+            ))
         }
 
         let notes = wallet
@@ -332,6 +344,7 @@ pub(crate) fn call(
                 memo: Some(memo),
                 memo_str,
                 wallet_internal: is_internal,
+                generated: None,
             })
         }
 
@@ -384,6 +397,7 @@ pub(crate) fn call(
                 memo: Some(memo),
                 memo_str,
                 wallet_internal,
+                generated: None,
             })
         }
 
@@ -440,9 +454,107 @@ pub(crate) fn call(
                 memo: Some(memo),
                 memo_str,
                 wallet_internal,
+                generated: None,
             })
         }
     }
 
     Ok(ResultType(unspent_outputs))
+}
+
+/// Builds the `z_listunspent` entry for a transparent UTXO.
+///
+/// Transparent outputs always report their coinbase origin via the `generated` field,
+/// have no memo, and belong to the `transparent` pool. This is a pure function over
+/// values already extracted from the wallet, so that its JSON rendering can be
+/// unit-tested without a database.
+#[allow(clippy::too_many_arguments)]
+fn transparent_unspent_output(
+    txid: String,
+    outindex: u32,
+    confirmations: u32,
+    is_watch_only: bool,
+    address: Option<String>,
+    account_uuid: String,
+    wallet_internal: bool,
+    value: Zatoshis,
+    generated: bool,
+) -> UnspentOutput {
+    UnspentOutput {
+        txid,
+        pool: "transparent".into(),
+        outindex,
+        confirmations,
+        is_watch_only,
+        address,
+        account_uuid,
+        wallet_internal,
+        generated: Some(generated),
+        value: value_from_zatoshis(value),
+        value_zat: u64::from(value),
+        memo: None,
+        memo_str: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_protocol::value::Zatoshis;
+
+    use super::{UnspentOutput, transparent_unspent_output};
+    use crate::components::json_rpc::utils::value_from_zatoshis;
+
+    /// Renders a transparent UTXO entry with the given coinbase origin to its JSON
+    /// representation (the actual RPC output contract).
+    fn rendered_transparent(generated: bool) -> serde_json::Value {
+        serde_json::to_value(transparent_unspent_output(
+            "3ec4c1b4b1e61a13c11ec5b0ba1240cca66f0e0d5b1e0303403d0a44ae7d0219".into(),
+            0,
+            10,
+            false,
+            Some("t1UYsZVJkLPeMjxEtACvSxfWuNmddpWfxzs".into()),
+            "3ad46f88-8f11-407b-b768-a2d587e971c9".into(),
+            false,
+            Zatoshis::const_from_u64(625_000_000),
+            generated,
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn transparent_coinbase_output_is_generated() {
+        let rendered = rendered_transparent(true);
+        assert_eq!(rendered["generated"], serde_json::json!(true));
+        assert_eq!(rendered["pool"], serde_json::json!("transparent"));
+    }
+
+    #[test]
+    fn transparent_non_coinbase_output_is_not_generated() {
+        let rendered = rendered_transparent(false);
+        assert_eq!(rendered["generated"], serde_json::json!(false));
+    }
+
+    #[test]
+    fn shielded_output_omits_generated() {
+        // Shielded notes never set `generated`; the field must be omitted entirely
+        // rather than rendered as `null`.
+        let output = UnspentOutput {
+            txid: "3ec4c1b4b1e61a13c11ec5b0ba1240cca66f0e0d5b1e0303403d0a44ae7d0219".into(),
+            pool: "sapling".into(),
+            outindex: 0,
+            confirmations: 10,
+            is_watch_only: false,
+            address: None,
+            account_uuid: "3ad46f88-8f11-407b-b768-a2d587e971c9".into(),
+            wallet_internal: true,
+            generated: None,
+            value: value_from_zatoshis(Zatoshis::const_from_u64(100_000)),
+            value_zat: 100_000,
+            memo: Some("f600".into()),
+            memo_str: None,
+        };
+
+        let rendered = serde_json::to_value(output).unwrap();
+        assert!(rendered.get("generated").is_none());
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/z_get_balance_for_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_get_balance_for_account.rs
@@ -146,7 +146,7 @@ mod tests {
         let zat = Zatoshis::const_from_u64;
         let mut balance = AccountBalance::ZERO;
         balance
-            .with_unshielded_balance_mut::<_, BalanceError>(|b| {
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
                 b.add_spendable_value(zat(transparent))
             })
             .unwrap();
@@ -252,6 +252,33 @@ mod tests {
                     "transparent": {"valueZat": COIN},
                     "orchard": {"valueZat": 2 * COIN},
                 },
+                "minimum_confirmations": 1,
+            }),
+        );
+    }
+
+    // The `transparent` pool reports the combined spendable balance of regular
+    // (non-coinbase) and mature coinbase funds: this RPC does not distinguish the
+    // two buckets, so its transparent balance is their sum.
+    #[test]
+    fn transparent_pool_combines_regular_and_coinbase() {
+        let zat = Zatoshis::const_from_u64;
+        let mut balance = account_balance(0, 0, 0, 0);
+        balance
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(2 * COIN))
+            })
+            .unwrap();
+        balance
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(3 * COIN))
+            })
+            .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(response_for_balance(&balance, None)).unwrap(),
+            json!({
+                "pools": {"transparent": {"valueZat": 5 * COIN}},
                 "minimum_confirmations": 1,
             }),
         );

--- a/zallet-core/src/components/json_rpc/methods/z_get_total_balance.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_get_total_balance.rs
@@ -4,7 +4,7 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_client_backend::data_api::{WalletRead, wallet::ConfirmationsPolicy};
+use zcash_client_backend::data_api::{AccountBalance, WalletRead, wallet::ConfirmationsPolicy};
 use zcash_protocol::value::Zatoshis;
 
 use crate::components::{
@@ -53,26 +53,34 @@ pub(crate) fn call(
         None => ConfirmationsPolicy::new_symmetrical(NonZeroU32::MIN, false),
     };
 
-    let (transparent, private) = if let Some(summary) = wallet
+    match wallet
         .get_wallet_summary(confirmations_policy)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
     {
         // TODO: support `include_watch_only = false`
-        summary.account_balances().iter().fold(
-            (Some(Zatoshis::ZERO), Some(Zatoshis::ZERO)),
-            |(transparent, private), (_, balance)| {
-                (
-                    transparent + balance.unshielded_balance().total(),
-                    private
-                        + balance.sapling_balance().total()
-                        + balance.orchard_balance().total()
-                        + balance.ironwood_balance().total(),
-                )
-            },
-        )
-    } else {
-        (Some(Zatoshis::ZERO), Some(Zatoshis::ZERO))
-    };
+        Some(summary) => total_balance(summary.account_balances().values()),
+        None => total_balance(std::iter::empty::<&AccountBalance>()),
+    }
+}
+
+/// Computes the wallet-wide totals from the per-account balances.
+///
+/// The transparent total is the combined total of the regular (non-coinbase) and
+/// coinbase transparent buckets; each bucket's total spans its spendable and pending
+/// values, so immature coinbase funds are included.
+fn total_balance<'a>(balances: impl IntoIterator<Item = &'a AccountBalance>) -> Response {
+    let (transparent, private) = balances.into_iter().fold(
+        (Some(Zatoshis::ZERO), Some(Zatoshis::ZERO)),
+        |(transparent, private), balance| {
+            (
+                transparent + balance.unshielded_balance().total(),
+                private
+                    + balance.sapling_balance().total()
+                    + balance.orchard_balance().total()
+                    + balance.ironwood_balance().total(),
+            )
+        },
+    );
 
     transparent
         .zip(private)
@@ -84,4 +92,107 @@ pub(crate) fn call(
             })
         })
         .ok_or_else(|| LegacyCode::Wallet.with_static("balance overflow"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use zcash_client_backend::data_api::AccountBalance;
+    use zcash_protocol::value::{BalanceError, COIN, Zatoshis};
+
+    use super::total_balance;
+    use crate::components::json_rpc::utils::value_from_zatoshis;
+
+    fn zat(value: u64) -> Zatoshis {
+        Zatoshis::const_from_u64(value)
+    }
+
+    /// Renders the ZEC-denominated string for a zatoshi amount, exactly as the RPC
+    /// response does.
+    fn zec(value: u64) -> String {
+        value_from_zatoshis(zat(value)).to_string()
+    }
+
+    fn rendered<'a>(balances: impl IntoIterator<Item = &'a AccountBalance>) -> serde_json::Value {
+        serde_json::to_value(total_balance(balances).unwrap()).unwrap()
+    }
+
+    // An empty wallet reports zero in every field.
+    #[test]
+    fn empty_wallet_is_all_zero() {
+        assert_eq!(
+            rendered([]),
+            json!({
+                "transparent": zec(0),
+                "private": zec(0),
+                "total": zec(0),
+            }),
+        );
+    }
+
+    // The transparent total is the sum of the regular and coinbase transparent bucket
+    // totals, including immature (pending) coinbase funds.
+    #[test]
+    fn transparent_includes_regular_and_coinbase() {
+        let mut balance = AccountBalance::ZERO;
+        balance
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(2 * COIN))
+            })
+            .unwrap();
+        balance
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                // Mature (spendable) coinbase...
+                b.add_spendable_value(zat(3 * COIN))?;
+                // ...and immature (pending) coinbase both count towards the total.
+                b.add_pending_spendable_value(zat(5 * COIN))
+            })
+            .unwrap();
+
+        assert_eq!(
+            rendered([&balance]),
+            json!({
+                "transparent": zec(10 * COIN),
+                "private": zec(0),
+                "total": zec(10 * COIN),
+            }),
+        );
+    }
+
+    // The overall total is the transparent total plus the private (shielded) total,
+    // summed across accounts.
+    #[test]
+    fn total_is_transparent_plus_private() {
+        let mut account1 = AccountBalance::ZERO;
+        account1
+            .with_unshielded_regular_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(COIN))
+            })
+            .unwrap();
+        account1
+            .with_sapling_balance_mut::<_, BalanceError>(|b| b.add_spendable_value(zat(2 * COIN)))
+            .unwrap();
+
+        let mut account2 = AccountBalance::ZERO;
+        account2
+            .with_unshielded_coinbase_balance_mut::<_, BalanceError>(|b| {
+                b.add_spendable_value(zat(4 * COIN))
+            })
+            .unwrap();
+        account2
+            .with_orchard_balance_mut::<_, BalanceError>(|b| b.add_spendable_value(zat(8 * COIN)))
+            .unwrap();
+        account2
+            .with_ironwood_balance_mut::<_, BalanceError>(|b| b.add_spendable_value(zat(16 * COIN)))
+            .unwrap();
+
+        assert_eq!(
+            rendered([&account1, &account2]),
+            json!({
+                "transparent": zec(5 * COIN),
+                "private": zec(26 * COIN),
+                "total": zec(31 * COIN),
+            }),
+        );
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -451,6 +451,7 @@ async fn run<C: Chain>(
             &spending_keys,
             OvkPolicy::Sender,
             &proposal,
+            // No expiry-height override; each transaction keeps its builder-derived expiry.
             None,
         )
         .map(|txids| (wallet, proposal, txids))

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -451,6 +451,7 @@ async fn run<C: Chain>(
             &spending_keys,
             OvkPolicy::Sender,
             &proposal,
+            None,
         )
         .map(|txids| (wallet, proposal, txids))
     })

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -527,6 +527,7 @@ async fn run<C: Chain>(
             &spending_keys,
             OvkPolicy::Sender,
             &proposal,
+            // No expiry-height override; the transaction keeps its builder-derived expiry.
             None,
         )
         .map(|txids| (wallet, proposal, txids))

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -527,6 +527,7 @@ async fn run<C: Chain>(
             &spending_keys,
             OvkPolicy::Sender,
             &proposal,
+            None,
         )
         .map(|txids| (wallet, proposal, txids))
     })


### PR DESCRIPTION
Fixes #635.

## Summary

`z_getbalances` now delivers its documented transparent balance contract, and `z_listunspent` identifies coinbase UTXOs — so integrators (mining pools in particular) can finally read "how much can I pay to a transparent recipient" directly from the wallet.

- **`z_getbalances`** (`fe6ce4b`): `transparent.regular` contains only non-coinbase funds; `transparent.coinbase` is populated (immature coinbase reported as `pending`, mature as `spendable`); the account `total` now includes transparent value in its `spendable`/`pending` buckets, so `total == sum of parts` across all five pools. Previously `regular` silently included coinbase, `coinbase` was never emitted, and `total.spendable` ignored the transparent pool entirely — the combination that halted the reporting pool's payouts with `Insufficient balance (have 0, …)`.
- **`z_listunspent`** (`dd87ed2`, standalone/cherry-pickable): transparent entries gain `"generated": true|false` (coinbase origin, mirroring zcashd's `listunspent`; omitted on shielded entries), replacing the per-UTXO `getrawtransaction` round-trip integrators needed. Implemented via two disjoint `CoinbaseFilter` queries; requires no librustzcash changes.
- **Dependency** (`68ad944`): the balance split comes from zcash/librustzcash#2654; `[patch.crates-io]` (workspace root + both backend workspaces) pins that branch (`196f12439a`) until a release containing it ships. `z_gettotalbalance` semantics are intentionally unchanged (pinned by new tests).

## Verification

- `cargo test -p zallet-core`: 208 passed (14 new unit tests: full rendering matrix for the split incl. dust-counted-once and total-equals-sum-of-parts; semantics pins for `z_getbalanceforaccount`/`z_gettotalbalance`; `generated` serialization contract). Both backends `cargo check` clean against the pin.
- End-to-end on a real zebrad+zainod+zallet regtest stack (new `wallet_transparent_coinbase_balance.py`, see the accompanying integration-tests PR): immature coinbase → `coinbase.pending`; mature → `coinbase.spendable` with exact zatoshi sums; post-shield `z_sendmany` z→t output lands in `regular.spendable` only; `generated` flags correct on every entry; `z_gettotalbalance` cross-check passes.

Notes for review: `z_listunspent` transparent output ordering changed (non-coinbase before coinbase per address; no ordering was documented). Immature coinbase remains excluded from `z_listunspent` (upstream maturity clause), while `z_getbalances` now *does* show it as pending — intentional and now-documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WB1TU6tyLmMa1n4SQ9XgK
