### PR TITLE
Verify security-relevant wallet.db records against derived key material before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ be considered breaking changes.
 
 ### Fixed
 
+- `z_sendmany` and `z_shieldcoinbase` now verify, after building a transaction
+  and before broadcasting it, that every transparent output either exactly
+  matches a requested payment or has an address that re-derives from the
+  wallet-seed-derived account key at the derivation path the wallet database
+  records for it. Shielded outputs are constructed in-process from the spending
+  key material, but transparent change and ephemeral (ZIP 320) output addresses
+  are read from database records that are not integrity-protected, so a
+  modified record could previously redirect change to an arbitrary address
+  while the requested payments (and thus the operation) still succeeded. A
+  transaction that fails this check is reported as wallet database corruption
+  or tampering and is never handed to the broadcast step.
 - The keystore now verifies decrypted key material against the database row it
   was looked up by: seeds and mnemonics must reproduce the seed fingerprint
   their row is keyed by, and standalone transparent keys must reproduce the
@@ -133,7 +144,7 @@ be considered breaking changes.
   frontier as empty instead of reading the real (non-empty) tree, corrupting
   the wallet's local shardtree state on the very next batch (surfacing as a
   checkpoint or root conflict in `zcash_client_sqlite`, or an `Inserted root
-  conflicts with existing root` error from `shardtree`). The tree is now read
+conflicts with existing root` error from `shardtree`). The tree is now read
   from the backend the same way as Sapling and Orchard, via
   `ReadRequest::IronwoodTree`.
 
@@ -163,6 +174,7 @@ be considered breaking changes.
   - `z_shieldcoinbase`
 
 ### Changed
+
 - **This release is not compatible with wallets created by earlier alpha
   releases.** The embedded Zaino chain indexer made a backwards-incompatible
   change to its database format (zingolabs/zaino#914), which this release pulls
@@ -196,6 +208,7 @@ be considered breaking changes.
   embedding them in the HTTP URL.
 
 ### Fixed
+
 - `walletlock` now awaits aborted relock tasks before returning, preventing a race
   where a rapid `walletpassphrase` after `walletlock` could leave the wallet locked
   despite reporting success.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ be considered breaking changes.
 
 ### Fixed
 
+- The keystore now verifies decrypted key material against the database row it
+  was looked up by: seeds and mnemonics must reproduce the seed fingerprint
+  their row is keyed by, and standalone transparent keys must reproduce the
+  stored public key. Previously the ciphertexts were not bound to their row
+  keys, so anyone with write access to `wallet.db` could substitute their own
+  encrypted seed under an existing fingerprint (age recipients are public) and
+  subsequent account derivation would silently use the substituted material.
+  Such a mismatch is now reported as wallet database corruption or tampering.
 - `z_importkey` now writes the imported account and its encrypted spending key
   in a single database transaction. A failure partway through the import can no
   longer leave the spending key stored (and exportable via `z_exportkey`) while

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -197,6 +197,16 @@ err-wallet-locked = Wallet is locked
 err-account-not-found = Account does not exist
 err-account-no-payment-source = Account has no payment source.
 
+## Transaction verification errors
+
+err-transparent-output-not-wallet-derived =
+    The built transaction pays a transparent output ({$output}) that is neither a requested
+    payment nor an address derived from the account's own key. The wallet database is
+    corrupted or has been tampered with. The transaction has not been broadcast.
+err-transparent-payment-missing =
+    The built transaction is missing a requested payment output (to {$address}). The wallet
+    database is corrupted or has been tampered with. The transaction has not been broadcast.
+
 # errors in migration of configuration data from the zcashd `zcash.conf` config file format
 
 err-migrate-allow-warnings = To allow a migration with warnings, use '{-allow-warnings}'

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -187,6 +187,9 @@ err-config-backend-mismatch = The config file selects the '{$configured}' chain 
 err-keystore-missing-recipients = The wallet has not been set up to store key material securely.
 rec-keystore-missing-recipients = Have you run '{$init_cmd}'?
 err-keystore-already-initialized = Keystore age recipients already initialized
+err-keystore-key-material-mismatch =
+    Decrypted key material does not match the fingerprint it is stored under. The wallet
+    database is corrupted or has been tampered with.
 err-wallet-locked = Wallet is locked
 
 ## Account errors

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -23,8 +23,11 @@ use zcash_client_backend::{
     },
     wallet::OvkPolicy,
 };
-use zcash_client_sqlite::ReceivedNoteId;
-use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
+use zcash_client_sqlite::{AccountUuid, ReceivedNoteId};
+use zcash_keys::{
+    address::Address,
+    keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
+};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
     PoolType, ShieldedPool,
@@ -39,8 +42,8 @@ use crate::{
             asyncop::{ContextInfo, OperationId},
             payments::{
                 AmountParameter, IncompatiblePrivacyPolicy, PrivacyPolicy, SendResult,
-                broadcast_transactions, build_request, enforce_privacy_policy,
-                get_account_for_address, get_legacy_pool_account,
+                build_request, enforce_privacy_policy, get_account_for_address,
+                get_legacy_pool_account, verify_and_broadcast_transactions,
             },
             server::LegacyCode,
         },
@@ -405,6 +408,8 @@ pub(crate) async fn call<C: Chain>(
         run(
             wallet,
             chain,
+            account.id(),
+            usk.to_unified_full_viewing_key(),
             proposal,
             #[cfg(feature = "zcashd-import")]
             SpendingKeys::new(usk, standalone_keys),
@@ -417,6 +422,10 @@ pub(crate) async fn call<C: Chain>(
 /// Construct and send the transaction, returning the resulting txid.
 /// Errors in transaction construction will throw.
 ///
+/// `ufvk` must be derived from the wallet seed: the built transactions' transparent
+/// outputs are verified against it before broadcast, because their addresses come from
+/// wallet database records that are not integrity-protected.
+///
 /// Notes:
 /// 1. #1159 Currently there is no limit set on the number of elements, which could
 ///    make the tx too large.
@@ -426,11 +435,13 @@ pub(crate) async fn call<C: Chain>(
 async fn run<C: Chain>(
     mut wallet: DbHandle,
     chain: C,
+    account_id: AccountUuid,
+    ufvk: UnifiedFullViewingKey,
     proposal: Proposal<StandardFeeRule, ReceivedNoteId>,
     spending_keys: SpendingKeys,
 ) -> RpcResult<SendResult> {
     let prover = LocalTxProver::bundled();
-    let (wallet, txids) = crate::spawn_blocking!("z_sendmany prover", move || {
+    let (wallet, proposal, txids) = crate::spawn_blocking!("z_sendmany prover", move || {
         let params = *wallet.params();
         create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             wallet.as_mut(),
@@ -441,14 +452,15 @@ async fn run<C: Chain>(
             OvkPolicy::Sender,
             &proposal,
         )
-        .map(|txids| (wallet, txids))
+        .map(|txids| (wallet, proposal, txids))
     })
     .await
     // TODO: Map errors to `zcashd` shape.
     .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?
     .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?;
 
-    broadcast_transactions(&wallet, chain, txids.into()).await
+    verify_and_broadcast_transactions(&wallet, chain, account_id, &ufvk, &proposal, txids.into())
+        .await
 }
 
 #[cfg(test)]

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -24,7 +24,10 @@ use zcash_client_backend::{
     wallet::OvkPolicy,
 };
 use zcash_client_sqlite::AccountUuid;
-use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
+use zcash_keys::{
+    address::Address,
+    keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
+};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::Zatoshis;
 
@@ -35,7 +38,7 @@ use crate::{
         database::{DbConnection, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
-            payments::{PrivacyPolicy, SendResult, broadcast_transactions, parse_memo},
+            payments::{PrivacyPolicy, SendResult, parse_memo, verify_and_broadcast_transactions},
             server::LegacyCode,
             utils::{JsonZec, value_from_zatoshis},
         },
@@ -318,6 +321,8 @@ pub(crate) async fn call<C: Chain>(
         run(
             wallet,
             chain,
+            account_id,
+            usk.to_unified_full_viewing_key(),
             proposal,
             #[cfg(feature = "zcashd-import")]
             SpendingKeys::new(usk, standalone_keys),
@@ -499,14 +504,20 @@ fn enumerate_eligible(
 }
 
 /// Construct and broadcast the shielding transaction.
+///
+/// `ufvk` must be derived from the wallet seed: the built transactions' transparent
+/// outputs are verified against it before broadcast, because their addresses come from
+/// wallet database records that are not integrity-protected.
 async fn run<C: Chain>(
     mut wallet: DbHandle,
     chain: C,
+    account_id: AccountUuid,
+    ufvk: UnifiedFullViewingKey,
     proposal: Proposal<StandardFeeRule, Infallible>,
     spending_keys: SpendingKeys,
 ) -> RpcResult<SendResult> {
     let prover = LocalTxProver::bundled();
-    let (wallet, txids) = crate::spawn_blocking!("z_shieldcoinbase runner", move || {
+    let (wallet, proposal, txids) = crate::spawn_blocking!("z_shieldcoinbase runner", move || {
         let params = *wallet.params();
         create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             wallet.as_mut(),
@@ -517,7 +528,7 @@ async fn run<C: Chain>(
             OvkPolicy::Sender,
             &proposal,
         )
-        .map(|txids| (wallet, txids))
+        .map(|txids| (wallet, proposal, txids))
     })
     .await
     .map_err(|e| {
@@ -527,7 +538,8 @@ async fn run<C: Chain>(
         LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
     })?;
 
-    broadcast_transactions(&wallet, chain, txids.into()).await
+    verify_and_broadcast_transactions(&wallet, chain, account_id, &ufvk, &proposal, txids.into())
+        .await
 }
 
 #[cfg(test)]

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -5,20 +5,23 @@ use jsonrpsee::core::JsonValue;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use transparent::{address::TransparentAddress, keys::AccountPubKey};
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{Account as _, WalletRead},
     proposal::Proposal,
+    wallet::TransparentAddressSource,
     zip321::{Payment, TransactionRequest},
 };
-use zcash_client_sqlite::wallet::Account;
-use zcash_keys::address::Address;
+use zcash_client_sqlite::{AccountUuid, wallet::Account};
+use zcash_keys::{address::Address, keys::UnifiedFullViewingKey};
 use zcash_protocol::{PoolType, TxId, memo::MemoBytes, value::Zatoshis};
 use zip32::{AccountId, fingerprint::SeedFingerprint};
 
 use crate::{
     components::{chain::Chain, database::DbConnection},
     fl,
+    network::Network,
     prelude::APP,
 };
 
@@ -811,25 +814,235 @@ pub(super) fn get_legacy_pool_account(wallet: &DbConnection) -> RpcResult<Accoun
     )))
 }
 
-/// Broadcasts the specified transactions to the network, if configured to do so.
-pub(super) async fn broadcast_transactions<C: Chain>(
+/// Why a transparent output of a built transaction failed verification against the
+/// account's seed-derived key material.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum TransparentOutputError<E> {
+    /// The output's script does not have a recognizable transparent address form.
+    UnrecognizedScript { vout: usize },
+    /// The wallet has no derivation record for the output's address.
+    UnknownAddress(TransparentAddress),
+    /// The wallet's record for the output's address does not claim derivation from the
+    /// account key.
+    #[cfg(feature = "transparent-key-import")]
+    NotDerived(TransparentAddress),
+    /// Re-derivation at the recorded derivation path does not reproduce the output's
+    /// address.
+    DerivationMismatch(TransparentAddress),
+    /// The account key has no transparent component to derive from.
+    NoTransparentKey(TransparentAddress),
+    /// A requested payment output is absent from the transaction.
+    MissingPayment(TransparentAddress),
+    /// The derivation-record lookup failed.
+    Lookup(E),
+}
+
+/// Checks that every transparent output of a built transaction is accounted for.
+///
+/// Shielded outputs are constructed in-process from the spending key material passed to
+/// the transaction builder, but transparent change and ephemeral (ZIP 320) output
+/// addresses are read from wallet database records that are not integrity-protected.
+/// Each transparent output must therefore either exactly match one of `expected_payments`
+/// (consuming it, so a payment vouches for at most one output), or re-derive from
+/// `account_pubkey` — the account's seed-derived transparent key — at the derivation path
+/// the wallet records for its address. The record itself is untrusted; only the
+/// re-derivation equality establishes that the funds remain under the account's key.
+///
+/// All of `expected_payments` must be consumed: a transaction that fails to pay a
+/// requested recipient is as unaccountable as one that pays an unrecognized output.
+pub(super) fn check_transparent_outputs<E>(
+    outputs: impl IntoIterator<Item = (Option<TransparentAddress>, Zatoshis)>,
+    mut expected_payments: Vec<(TransparentAddress, Zatoshis)>,
+    account_pubkey: Option<&AccountPubKey>,
+    mut address_source: impl FnMut(&TransparentAddress) -> Result<Option<TransparentAddressSource>, E>,
+) -> Result<(), TransparentOutputError<E>> {
+    for (vout, (addr, value)) in outputs.into_iter().enumerate() {
+        let addr = addr.ok_or(TransparentOutputError::UnrecognizedScript { vout })?;
+
+        if let Some(index) = expected_payments
+            .iter()
+            .position(|(expected_addr, expected_value)| {
+                *expected_addr == addr && *expected_value == value
+            })
+        {
+            expected_payments.swap_remove(index);
+            continue;
+        }
+
+        match address_source(&addr).map_err(TransparentOutputError::Lookup)? {
+            None => return Err(TransparentOutputError::UnknownAddress(addr)),
+            Some(TransparentAddressSource::Derived {
+                scope,
+                address_index,
+            }) => {
+                let derived = account_pubkey
+                    .ok_or(TransparentOutputError::NoTransparentKey(addr))?
+                    .derive_address_pubkey(scope, address_index)
+                    .map_err(|_| TransparentOutputError::DerivationMismatch(addr))?;
+                if TransparentAddress::from_pubkey(&derived) != addr {
+                    return Err(TransparentOutputError::DerivationMismatch(addr));
+                }
+            }
+            // Sources without derivation information (standalone imported keys) cannot be
+            // tied to the account key. Change and ephemeral outputs are always derived, so
+            // fail closed.
+            #[cfg(feature = "transparent-key-import")]
+            Some(_) => return Err(TransparentOutputError::NotDerived(addr)),
+        }
+    }
+
+    if let Some((addr, _)) = expected_payments.first() {
+        return Err(TransparentOutputError::MissingPayment(*addr));
+    }
+
+    Ok(())
+}
+
+/// The transparent (address, amount) pairs that the given proposal explicitly pays to
+/// requested recipients, one list per proposal step.
+///
+/// Transparent-pool payments resolve to the receiver the transaction builder pays: a
+/// unified address's transparent receiver, a bare transparent address, or the P2PKH
+/// address underlying a TEX address. Ephemeral (ZIP 320) intermediate outputs are not
+/// payments — they appear in a step's proposed change and must instead verify as
+/// wallet-derived.
+fn proposed_transparent_payments<FeeRuleT, NoteRef>(
+    params: &Network,
+    proposal: &Proposal<FeeRuleT, NoteRef>,
+) -> RpcResult<Vec<Vec<(TransparentAddress, Zatoshis)>>> {
+    proposal
+        .steps()
+        .iter()
+        .map(|step| {
+            let mut payments = vec![];
+            for (payment_index, pool) in step.payment_pools() {
+                if pool == &PoolType::Transparent {
+                    let payment = step
+                        .transaction_request()
+                        .payments()
+                        .get(payment_index)
+                        .ok_or_else(|| {
+                            LegacyCode::Wallet.with_static(
+                                "Internal error: proposal step references a nonexistent payment.",
+                            )
+                        })?;
+                    let value = payment.amount().ok_or_else(|| {
+                        LegacyCode::Wallet
+                            .with_static("Internal error: proposal step payment has no amount.")
+                    })?;
+                    let addr = match Address::try_from_zcash_address(
+                        params,
+                        payment.recipient_address().clone(),
+                    ) {
+                        Ok(Address::Transparent(addr)) => addr,
+                        Ok(Address::Tex(data)) => TransparentAddress::PublicKeyHash(data),
+                        Ok(Address::Unified(ua)) => *ua.transparent().ok_or_else(|| {
+                            LegacyCode::Wallet.with_static(
+                                "Internal error: transparent-pool payment to a unified address \
+                                 without a transparent receiver.",
+                            )
+                        })?,
+                        Ok(Address::Sapling(_)) | Err(_) => {
+                            return Err(LegacyCode::Wallet.with_static(
+                                "Internal error: transparent-pool payment to a non-transparent \
+                                 address.",
+                            ));
+                        }
+                    };
+                    payments.push((addr, value));
+                }
+            }
+            Ok(payments)
+        })
+        .collect()
+}
+
+/// Verifies the built transactions against the proposal and the account's seed-derived
+/// key material, then broadcasts them to the network, if configured to do so.
+///
+/// A transaction containing a transparent output that verifies neither as a payment
+/// requested by the proposal nor as an address derived from `ufvk` (see
+/// [`check_transparent_outputs`]) is never handed to the broadcast step. `ufvk` must be
+/// derived from the wallet seed, not read from the database.
+pub(super) async fn verify_and_broadcast_transactions<C: Chain, FeeRuleT, NoteRef>(
     wallet: &DbConnection,
     chain: C,
+    account_id: AccountUuid,
+    ufvk: &UnifiedFullViewingKey,
+    proposal: &Proposal<FeeRuleT, NoteRef>,
     txids: Vec<TxId>,
 ) -> RpcResult<SendResult> {
-    if APP.config().external.broadcast() {
-        for txid in &txids {
-            let tx = wallet
-                .get_transaction(*txid)
-                .map_err(|e| {
-                    LegacyCode::Database.with_message(format!("Failed to get transaction: {e}"))
-                })?
-                .ok_or_else(|| {
-                    LegacyCode::Wallet
-                        .with_message(format!("Wallet does not contain transaction {txid}"))
-                })?;
+    let params = *wallet.params();
+    let expected_payments = proposed_transparent_payments(&params, proposal)?;
 
-            chain.broadcast_transaction(&tx).await.map_err(|e| {
+    // The builder creates one transaction per proposal step, in step order.
+    if txids.len() != expected_payments.len() {
+        return Err(LegacyCode::Wallet.with_static(
+            "Internal error: built transaction count does not match proposal step count.",
+        ));
+    }
+
+    let mut transactions = Vec::with_capacity(txids.len());
+    for (txid, expected) in txids.iter().zip(expected_payments) {
+        let tx = wallet
+            .get_transaction(*txid)
+            .map_err(|e| {
+                LegacyCode::Database.with_message(format!("Failed to get transaction: {e}"))
+            })?
+            .ok_or_else(|| {
+                LegacyCode::Wallet
+                    .with_message(format!("Wallet does not contain transaction {txid}"))
+            })?;
+
+        let outputs = tx
+            .transparent_bundle()
+            .map(|bundle| {
+                bundle
+                    .vout
+                    .iter()
+                    .map(|txout| (txout.recipient_address(), txout.value()))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        check_transparent_outputs(outputs, expected, ufvk.transparent(), |addr| {
+            wallet
+                .get_transparent_address_metadata(account_id, addr)
+                .map(|meta| meta.map(|m| m.source().clone()))
+        })
+        .map_err(|e| match e {
+            TransparentOutputError::Lookup(e) => LegacyCode::Database.with_message(e.to_string()),
+            TransparentOutputError::UnrecognizedScript { vout } => {
+                LegacyCode::Wallet.with_message(fl!(
+                    "err-transparent-output-not-wallet-derived",
+                    output = format!("output index {vout}"),
+                ))
+            }
+            TransparentOutputError::MissingPayment(addr) => LegacyCode::Wallet.with_message(fl!(
+                "err-transparent-payment-missing",
+                address = Address::Transparent(addr).encode(&params),
+            )),
+            TransparentOutputError::UnknownAddress(addr)
+            | TransparentOutputError::DerivationMismatch(addr)
+            | TransparentOutputError::NoTransparentKey(addr) => {
+                LegacyCode::Wallet.with_message(fl!(
+                    "err-transparent-output-not-wallet-derived",
+                    output = Address::Transparent(addr).encode(&params),
+                ))
+            }
+            #[cfg(feature = "transparent-key-import")]
+            TransparentOutputError::NotDerived(addr) => LegacyCode::Wallet.with_message(fl!(
+                "err-transparent-output-not-wallet-derived",
+                output = Address::Transparent(addr).encode(&params),
+            )),
+        })?;
+
+        transactions.push(tx);
+    }
+
+    if APP.config().external.broadcast() {
+        for tx in &transactions {
+            chain.broadcast_transaction(tx).await.map_err(|e| {
                 LegacyCode::Wallet
                     .with_message(format!("SendTransaction: Transaction commit failed:: {e}"))
             })?;
@@ -905,6 +1118,320 @@ pub(crate) mod arb {
     pub(crate) fn amount_with_memo(address: &str, zec: &str, memo: &str) -> AmountParameter {
         serde_json::from_value(json!({ "address": address, "amount": zec, "memo": memo }))
             .expect("valid AmountParameter")
+    }
+}
+
+#[cfg(test)]
+mod transparent_output_tests {
+    use std::convert::Infallible;
+
+    use proptest::prelude::*;
+    use transparent::{
+        address::TransparentAddress,
+        keys::{AccountPubKey, NonHardenedChildIndex, TransparentKeyScope},
+    };
+    use zcash_client_backend::wallet::TransparentAddressSource;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::{
+        consensus,
+        value::{MAX_MONEY, Zatoshis},
+    };
+    use zip32::AccountId;
+
+    use super::{TransparentOutputError, check_transparent_outputs};
+
+    /// The account-level transparent public key derived from `seed` and `account`; the
+    /// trusted key the checks under test re-derive against. No wallet database: the check
+    /// is a pure function of the outputs, the expected payments, this key, and the
+    /// (untrusted) derivation records fed to it, which is what makes it unit-testable
+    /// here rather than in `integration-tests`.
+    ///
+    /// Returns `None` for the seeds ZIP 32 rejects, so a property can skip them.
+    fn account_pubkey_from(seed: &[u8; 32], account: u32) -> Option<AccountPubKey> {
+        let account = AccountId::try_from(account).ok()?;
+        let usk =
+            UnifiedSpendingKey::from_seed(&consensus::Network::TestNetwork, seed, account).ok()?;
+        usk.to_unified_full_viewing_key().transparent().cloned()
+    }
+
+    /// The address the wallet would legitimately place at (`scope`, `index`) under `key`.
+    fn derived_addr(
+        key: &AccountPubKey,
+        scope: TransparentKeyScope,
+        index: NonHardenedChildIndex,
+    ) -> Option<TransparentAddress> {
+        key.derive_address_pubkey(scope, index)
+            .ok()
+            .map(|pk| TransparentAddress::from_pubkey(&pk))
+    }
+
+    /// A derivation-record lookup that claims every address lives at (`scope`, `index`).
+    /// The record is untrusted input to the check, so a property may claim whatever an
+    /// attacker could write.
+    fn claims(
+        scope: TransparentKeyScope,
+        index: NonHardenedChildIndex,
+    ) -> impl FnMut(&TransparentAddress) -> Result<Option<TransparentAddressSource>, Infallible>
+    {
+        move |_| {
+            Ok(Some(TransparentAddressSource::Derived {
+                scope,
+                address_index: index,
+            }))
+        }
+    }
+
+    /// A derivation-record lookup with no record for any address.
+    fn no_record(_: &TransparentAddress) -> Result<Option<TransparentAddressSource>, Infallible> {
+        Ok(None)
+    }
+
+    /// ZIP 32 account indices are non-hardened, so they occupy the low 31 bits.
+    fn arb_account() -> impl Strategy<Value = u32> {
+        0u32..(1 << 31)
+    }
+
+    /// Every scope the wallet derives transparent addresses under, including the
+    /// ephemeral (ZIP 320) scope.
+    fn arb_scope() -> impl Strategy<Value = TransparentKeyScope> {
+        prop_oneof![
+            Just(TransparentKeyScope::EXTERNAL),
+            Just(TransparentKeyScope::INTERNAL),
+            Just(TransparentKeyScope::EPHEMERAL),
+        ]
+    }
+
+    fn arb_index() -> impl Strategy<Value = NonHardenedChildIndex> {
+        (0u32..(1 << 31)).prop_map(NonHardenedChildIndex::const_from_index)
+    }
+
+    fn arb_value() -> impl Strategy<Value = Zatoshis> {
+        (0u64..=MAX_MONEY).prop_map(Zatoshis::const_from_u64)
+    }
+
+    proptest! {
+        // Each case derives key material, which is expensive, so take fewer samples than
+        // the default 256. The properties hold for every key, not for rare corners of the
+        // seed space, so a modest sample establishes them.
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        /// An output whose recorded (scope, index) re-derives to its own address is the
+        /// wallet's, whatever the scope: internal change, an ephemeral (ZIP 320) output,
+        /// or an external receiver.
+        #[test]
+        fn derived_output_accepted_at_its_recorded_path(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            value in arb_value(),
+        ) {
+            let Some(key) = account_pubkey_from(&seed, account) else { return Ok(()) };
+            let Some(addr) = derived_addr(&key, scope, index) else { return Ok(()) };
+
+            prop_assert_eq!(
+                check_transparent_outputs(
+                    [(Some(addr), value)],
+                    vec![],
+                    Some(&key),
+                    claims(scope, index),
+                ),
+                Ok(()),
+            );
+        }
+
+        /// The attack this check exists for: a change or ephemeral output substituted
+        /// with an address under someone else's key is rejected, even though its
+        /// derivation record is internally consistent.
+        #[test]
+        fn substituted_output_address_rejected(
+            wallet_seed in any::<[u8; 32]>(),
+            attacker_seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            value in arb_value(),
+        ) {
+            prop_assume!(wallet_seed != attacker_seed);
+            let Some(wallet_key) = account_pubkey_from(&wallet_seed, account) else {
+                return Ok(());
+            };
+            let Some(attacker_key) = account_pubkey_from(&attacker_seed, account) else {
+                return Ok(());
+            };
+            let Some(attacker_addr) = derived_addr(&attacker_key, scope, index) else {
+                return Ok(());
+            };
+
+            prop_assert_eq!(
+                check_transparent_outputs(
+                    [(Some(attacker_addr), value)],
+                    vec![],
+                    Some(&wallet_key),
+                    claims(scope, index),
+                ),
+                Err(TransparentOutputError::DerivationMismatch(attacker_addr)),
+            );
+        }
+
+        /// A record claiming a different index than the one the address was derived at is
+        /// rejected: the check trusts the re-derivation equality, not the record.
+        #[test]
+        fn record_claiming_wrong_index_rejected(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            other_index in arb_index(),
+            value in arb_value(),
+        ) {
+            prop_assume!(index != other_index);
+            let Some(key) = account_pubkey_from(&seed, account) else { return Ok(()) };
+            let Some(addr) = derived_addr(&key, scope, index) else { return Ok(()) };
+            let Some(other_addr) = derived_addr(&key, scope, other_index) else {
+                return Ok(());
+            };
+            prop_assume!(addr != other_addr);
+
+            prop_assert_eq!(
+                check_transparent_outputs(
+                    [(Some(addr), value)],
+                    vec![],
+                    Some(&key),
+                    claims(scope, other_index),
+                ),
+                Err(TransparentOutputError::DerivationMismatch(addr)),
+            );
+        }
+
+        /// An output exactly matching a requested payment is accepted without consulting
+        /// any derivation record, and each payment vouches for exactly one output: a
+        /// duplicate of the same output does not ride along.
+        #[test]
+        fn requested_payment_accepted_exactly_once(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            value in arb_value(),
+        ) {
+            let Some(key) = account_pubkey_from(&seed, account) else { return Ok(()) };
+            // Any address serves as a recipient; one not under the wallet's key is the
+            // interesting case.
+            let Some(addr) = derived_addr(&key, scope, index) else { return Ok(()) };
+
+            prop_assert_eq!(
+                check_transparent_outputs(
+                    [(Some(addr), value)],
+                    vec![(addr, value)],
+                    None,
+                    no_record,
+                ),
+                Ok(()),
+            );
+
+            prop_assert_eq!(
+                check_transparent_outputs(
+                    [(Some(addr), value), (Some(addr), value)],
+                    vec![(addr, value)],
+                    None,
+                    no_record,
+                ),
+                Err(TransparentOutputError::UnknownAddress(addr)),
+            );
+        }
+
+        /// An output with no derivation record at all is rejected, as is an output
+        /// paying a requested recipient a different amount than requested.
+        #[test]
+        fn unrecorded_output_rejected(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            value in arb_value(),
+            other_value in arb_value(),
+        ) {
+            let Some(key) = account_pubkey_from(&seed, account) else { return Ok(()) };
+            let Some(addr) = derived_addr(&key, scope, index) else { return Ok(()) };
+
+            prop_assert_eq!(
+                check_transparent_outputs([(Some(addr), value)], vec![], Some(&key), no_record),
+                Err(TransparentOutputError::UnknownAddress(addr)),
+            );
+
+            prop_assume!(value != other_value);
+            prop_assert!(
+                check_transparent_outputs(
+                    [(Some(addr), other_value)],
+                    vec![(addr, value)],
+                    Some(&key),
+                    no_record,
+                )
+                .is_err(),
+            );
+        }
+
+        /// A transaction missing a requested payment output is rejected.
+        #[test]
+        fn missing_requested_payment_rejected(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            value in arb_value(),
+        ) {
+            let Some(key) = account_pubkey_from(&seed, account) else { return Ok(()) };
+            let Some(addr) = derived_addr(&key, scope, index) else { return Ok(()) };
+
+            prop_assert_eq!(
+                check_transparent_outputs::<Infallible>(
+                    [],
+                    vec![(addr, value)],
+                    Some(&key),
+                    no_record,
+                ),
+                Err(TransparentOutputError::MissingPayment(addr)),
+            );
+        }
+
+        /// A derived record cannot vouch for anything when the account has no
+        /// transparent key component to re-derive from.
+        #[test]
+        fn output_without_transparent_key_rejected(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            scope in arb_scope(),
+            index in arb_index(),
+            value in arb_value(),
+        ) {
+            let Some(key) = account_pubkey_from(&seed, account) else { return Ok(()) };
+            let Some(addr) = derived_addr(&key, scope, index) else { return Ok(()) };
+
+            prop_assert_eq!(
+                check_transparent_outputs(
+                    [(Some(addr), value)],
+                    vec![],
+                    None,
+                    claims(scope, index),
+                ),
+                Err(TransparentOutputError::NoTransparentKey(addr)),
+            );
+        }
+    }
+
+    /// An output whose script has no transparent address form cannot be verified.
+    #[test]
+    fn unrecognized_script_rejected() {
+        assert_eq!(
+            check_transparent_outputs::<Infallible>(
+                [(None, Zatoshis::ZERO)],
+                vec![],
+                None,
+                no_record,
+            ),
+            Err(TransparentOutputError::UnrecognizedScript { vout: 0 }),
+        );
     }
 }
 

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -741,6 +741,14 @@ impl KeyStore {
         let mnemonic = decrypt_string(&identities, &encrypted_mnemonic)
             .map_err(|e| ErrorKind::Generic.context(e))?;
 
+        // The ciphertext is not bound to the fingerprint the row is keyed by, so verify
+        // that the decrypted mnemonic reproduces the fingerprint used for the lookup.
+        if !mnemonic_matches_fingerprint(&mnemonic, seed_fp)? {
+            return Err(ErrorKind::Generic
+                .context(fl!("err-keystore-key-material-mismatch"))
+                .into());
+        }
+
         Ok(mnemonic)
     }
 
@@ -789,8 +797,18 @@ impl KeyStore {
             })
             .await?;
 
-        decrypt_secret_bytes(&identities, &encrypted_legacy_seed)
-            .map_err(|e| ErrorKind::Generic.context(e).into())
+        let legacy_seed = decrypt_secret_bytes(&identities, &encrypted_legacy_seed)
+            .map_err(|e| ErrorKind::Generic.context(e))?;
+
+        // The ciphertext is not bound to the fingerprint the row is keyed by, so verify
+        // that the decrypted seed reproduces the fingerprint used for the lookup.
+        if !seed_matches_fingerprint(legacy_seed.expose_secret(), seed_fp) {
+            return Err(ErrorKind::Generic
+                .context(fl!("err-keystore-key-material-mismatch"))
+                .into());
+        }
+
+        Ok(legacy_seed)
     }
 
     /// Exports the mnemonic phrase corresponding to the given seed fingerprint.
@@ -882,27 +900,41 @@ impl KeyStore {
             return Err(ErrorKind::Generic.context(fl!("err-wallet-locked")).into());
         }
 
-        let encrypted_key_bytes = self
+        let (pubkey_bytes, encrypted_key_bytes) = self
             .with_db(|conn, network| {
                 let addr_str = Address::Transparent(*address).encode(network);
-                let encrypted_key_bytes = conn
+                let row = conn
                     .query_row(
-                        "SELECT encrypted_transparent_privkey
+                        "SELECT ztk.pubkey, encrypted_transparent_privkey
                          FROM ext_zallet_keystore_standalone_transparent_keys ztk
                          JOIN addresses a ON ztk.pubkey = a.imported_transparent_receiver_pubkey
                          WHERE a.cached_transparent_receiver_address = :address",
                         named_params! {
                             ":address": addr_str,
                         },
-                        |row| row.get::<_, Vec<u8>>("encrypted_transparent_privkey"),
+                        |row| {
+                            Ok((
+                                row.get::<_, Vec<u8>>("pubkey")?,
+                                row.get::<_, Vec<u8>>("encrypted_transparent_privkey")?,
+                            ))
+                        },
                     )
                     .map_err(|e| ErrorKind::Generic.context(e))?;
-                Ok(encrypted_key_bytes)
+                Ok(row)
             })
             .await?;
 
         let secret_key =
             decrypt_standalone_transparent_privkey(&identities, &encrypted_key_bytes[..])?;
+
+        // The ciphertext is not bound to the pubkey the row is keyed by, so verify that
+        // the decrypted key reproduces the pubkey used for the lookup.
+        let pubkey = secret_key.public_key(&secp256k1::Secp256k1::signing_only());
+        if pubkey.serialize()[..] != pubkey_bytes[..] {
+            return Err(ErrorKind::Generic
+                .context(fl!("err-keystore-key-material-mismatch"))
+                .into());
+        }
 
         Ok(secret_key)
     }
@@ -1058,6 +1090,33 @@ fn encrypt_string(
     Ok(ciphertext)
 }
 
+/// Returns whether the given seed bytes have the given [ZIP 32] seed fingerprint.
+///
+/// Keystore rows are keyed by seed fingerprint, but their ciphertexts are not bound to
+/// that key (age recipients are public), so decrypted seed material must be checked
+/// against the fingerprint it was looked up by before use.
+///
+/// [ZIP 32]: https://zips.z.cash/zip-0032#seed-fingerprints
+fn seed_matches_fingerprint(seed: &[u8], seed_fp: &SeedFingerprint) -> bool {
+    SeedFingerprint::from_seed(seed).is_some_and(|fp| fp.to_bytes() == seed_fp.to_bytes())
+}
+
+/// Returns whether the seed derived from the given mnemonic phrase has the given [ZIP 32]
+/// seed fingerprint.
+///
+/// [ZIP 32]: https://zips.z.cash/zip-0032#seed-fingerprints
+fn mnemonic_matches_fingerprint(
+    mnemonic: &SecretString,
+    seed_fp: &SeedFingerprint,
+) -> Result<bool, Error> {
+    let mut seed_bytes = Mnemonic::<English>::from_phrase(mnemonic.expose_secret())
+        .map_err(|e| ErrorKind::Generic.context(e))?
+        .to_seed("");
+    let matches = seed_matches_fingerprint(&seed_bytes, seed_fp);
+    seed_bytes.zeroize();
+    Ok(matches)
+}
+
 fn decrypt_string(
     identities: &[Box<dyn age::Identity + Send + Sync>],
     ciphertext: &[u8],
@@ -1162,4 +1221,75 @@ fn decrypt_standalone_transparent_privkey(
         .map_err(|e| ErrorKind::Generic.context(e))?;
 
     Ok(secret_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use bip0039::{English, Mnemonic};
+    use proptest::prelude::*;
+    use secrecy::SecretString;
+    use zip32::fingerprint::SeedFingerprint;
+
+    use super::{mnemonic_matches_fingerprint, seed_matches_fingerprint};
+
+    proptest! {
+        #[test]
+        fn seed_matches_its_own_fingerprint(seed in proptest::collection::vec(any::<u8>(), 32..=252)) {
+            let seed_fp = SeedFingerprint::from_seed(&seed).expect("valid length");
+            prop_assert!(seed_matches_fingerprint(&seed, &seed_fp));
+        }
+
+        #[test]
+        fn seed_does_not_match_other_fingerprint(
+            seed in proptest::collection::vec(any::<u8>(), 32..=252),
+            other_fp in any::<[u8; 32]>(),
+        ) {
+            let seed_fp = SeedFingerprint::from_seed(&seed).expect("valid length");
+            let other_fp = SeedFingerprint::from_bytes(other_fp);
+            prop_assert_eq!(
+                seed_matches_fingerprint(&seed, &other_fp),
+                other_fp.to_bytes() == seed_fp.to_bytes(),
+            );
+        }
+
+        #[test]
+        fn invalid_length_seed_matches_no_fingerprint(
+            seed in proptest::collection::vec(any::<u8>(), 0..32),
+            seed_fp in any::<[u8; 32]>(),
+        ) {
+            prop_assert!(!seed_matches_fingerprint(&seed, &SeedFingerprint::from_bytes(seed_fp)));
+        }
+    }
+
+    proptest! {
+        // Deriving a seed from a mnemonic uses PBKDF2, which is slow in unoptimized
+        // builds, so run fewer cases than the default.
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn mnemonic_matches_only_its_own_fingerprint(
+            entropy in any::<[u8; 32]>(),
+            other_fp in any::<[u8; 32]>(),
+        ) {
+            let mnemonic = Mnemonic::<English>::from_entropy(entropy).expect("valid entropy");
+            let seed_fp = SeedFingerprint::from_seed(&mnemonic.to_seed("")).expect("valid length");
+            let phrase = SecretString::new(mnemonic.into_phrase());
+
+            prop_assert!(mnemonic_matches_fingerprint(&phrase, &seed_fp).expect("valid phrase"));
+
+            let other_fp = SeedFingerprint::from_bytes(other_fp);
+            prop_assert_eq!(
+                mnemonic_matches_fingerprint(&phrase, &other_fp).expect("valid phrase"),
+                other_fp.to_bytes() == seed_fp.to_bytes(),
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_phrase_is_an_error() {
+        let phrase = SecretString::new("not a mnemonic".into());
+        assert!(
+            mnemonic_matches_fingerprint(&phrase, &SeedFingerprint::from_bytes([0; 32])).is_err()
+        );
+    }
 }


### PR DESCRIPTION
wallet.db records are trusted as-written, but several feed directly into key handling and transaction construction. This PR verifies the ones that can be checked against material the wallet already holds at the point of use.

Closes https://github.com/zcash/zallet/issues/642
[COR-1594](https://linear.app/zodl/issue/COR-1594/improve-zallet-unlock-error-handling)