### PR TITLE
rpc: Opt a UA z_sendmany source into transparent spending per the privacy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ be considered breaking changes.
 
 ### Changed
 
+- `z_sendmany` with a unified-address `fromaddress` can now spend the account's
+  transparent funds when the caller's privacy policy permits it, matching
+  `zcashd`'s documented privacy-policy semantics for a UA source. Under
+  `AllowRevealedSenders` or `AllowFullyTransparent` it spends the non-coinbase
+  UTXOs of the transparent receiver in the provided UA; under
+  `AllowLinkingAccountAddresses` or `NoPrivacy` it spends the non-coinbase UTXOs
+  of any of the account's transparent receivers, linking them on-chain when more
+  than one is needed. Previously a UA `fromaddress` was always shielded-only, so
+  a regular account had no way to gather its transparent change in one
+  transaction; only the legacy-pool `ANY_TADDR` source could spend from multiple
+  transparent addresses.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -596,10 +596,20 @@ pub(crate) trait WalletRpc {
     ///     on-chain, so such a call requires a privacy policy of
     ///     `AllowLinkingAccountAddresses` (or of `NoPrivacy`, if it also has a transparent
     ///     recipient or transparent change). Use `z_shieldcoinbase` to shield coinbase
-    ///     UTXOs from multiple transparent addresses.
-    ///   If a unified address is provided for this argument, the TXOs to be spent will be
-    ///   selected from those associated with the account corresponding to that unified
-    ///   address, from value pools corresponding to the receivers included in the UA.
+    ///     UTXOs from multiple transparent addresses. For a regular (non-legacy-pool)
+    ///     account, the equivalent is to pass one of the account's unified addresses as
+    ///     `fromaddress` with a privacy policy of `AllowLinkingAccountAddresses` (or
+    ///     `NoPrivacy`, when the transaction also has a transparent recipient or transparent
+    ///     change).
+    ///   If a unified address is provided for this argument, the TXOs to be spent are
+    ///   selected from the account corresponding to that unified address. Its shielded funds
+    ///   are always available. Transparent funds become available as the privacy policy
+    ///   permits: under `AllowRevealedSenders` or `AllowFullyTransparent`, the non-coinbase
+    ///   UTXOs of the transparent receiver in the provided UA; under
+    ///   `AllowLinkingAccountAddresses` or `NoPrivacy`, the non-coinbase UTXOs of any of the
+    ///   account's transparent receivers (which links them on-chain when more than one is
+    ///   spent). A transaction that both spends from multiple transparent addresses and has a
+    ///   transparent recipient or transparent change requires `NoPrivacy`.
     /// - `amounts` (array, required) An array of JSON objects representing the amounts to
     ///   send, with the following fields:
     ///   - `address` (string, required) A taddr, zaddr, or Unified Address.

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -40,7 +40,7 @@ use crate::{
             payments::{
                 AmountParameter, IncompatiblePrivacyPolicy, PrivacyPolicy, SendResult,
                 broadcast_transactions, build_request, enforce_privacy_policy,
-                get_account_for_address, get_legacy_pool_account,
+                get_account_for_address, get_legacy_pool_account, parse_privacy_policy,
             },
             server::LegacyCode,
         },
@@ -67,24 +67,57 @@ pub(super) const PARAM_FEE_DESC: &str = "If set, it must be null.";
 pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
     "Policy for what information leakage is acceptable.";
 
-/// The sources of funds a transfer from `source` may draw upon.
+/// The sources of funds a transfer from `source` may draw upon, given the caller's
+/// `privacy_policy`.
 ///
-/// Spending from a bare transparent address draws only on that address's UTXOs: the funds are
-/// already public, and confining selection to the named address avoids linking it to the
-/// account's other transparent receivers. Every other source stays shielded-only, so a
-/// shielded send can never silently reach into transparent funds.
+/// Spending from a bare transparent address draws only on that address's UTXOs, regardless of
+/// the privacy policy: the funds are already public, and confining selection to the named
+/// address avoids linking it to the account's other transparent receivers.
+///
+/// A unified address source spends the account's shielded funds by default, but the privacy
+/// policy can opt it into transparent spending as well, mirroring `zcashd`'s documented
+/// semantics for a UA `fromaddress`:
+///
+/// - `AllowLinkingAccountAddresses` (or `NoPrivacy`) lets it spend *any* of the account's
+///   transparent receivers, whichever the proposer picks to cover the request, linking them
+///   on-chain when more than one is needed ([`TransparentSpendPolicy::any_account_addr`]).
+/// - `AllowRevealedSenders` (or `AllowFullyTransparent`) lets it spend only the UTXOs of *that
+///   UA's own* transparent receiver, if it has one; a UA without a transparent receiver has
+///   nothing for this tier to confine to, so it stays shielded-only.
+/// - Anything stricter (the default `FullPrivacy`, `AllowRevealedAmounts`,
+///   `AllowRevealedRecipients`) stays shielded-only, unchanged.
+///
+/// Every other source (Sapling, TEX) stays shielded-only.
 ///
 /// Coinbase UTXOs are excluded: `TransparentSpendPolicy` defaults to
 /// `CoinbasePolicy::NonCoinbase`, and consensus requires coinbase to be spent to a single
 /// shielded output, which is `z_shieldcoinbase`'s job.
 ///
-/// The privacy policy deliberately does not narrow this: the selector returns its best
-/// proposal, and `enforce_privacy_policy` rejects it afterwards if it leaks more than the
-/// caller permitted.
-fn spend_policy_for(source: &Address) -> SpendPolicy {
+/// The privacy policy never *narrows* selection within the permitted sources — the
+/// selector returns its best proposal and `enforce_privacy_policy` rejects it afterwards if it
+/// leaks more than the caller allowed. But for a UA source it does gate whether the transparent
+/// source is opted into at all, and it must: the [`GreedyInputSelector`] gathers transparent
+/// UTXOs up front, targeting the full request amount, whenever a [`TransparentSpendPolicy`] is
+/// present, and only then covers the remainder from shielded notes. A policy-blind transparent
+/// opt-in would therefore make the default fully-shielded send propose transparent inputs and
+/// then fail `enforce_privacy_policy` after the fact, so the opt-in itself is derived from the
+/// requested policy while privacy enforcement stays post-hoc.
+fn spend_policy_for(source: &Address, privacy_policy: PrivacyPolicy) -> SpendPolicy {
     match source {
         Address::Transparent(taddr) => SpendPolicy::shielded_pools([])
             .with_transparent(TransparentSpendPolicy::from_one_address(*taddr)),
+        Address::Unified(ua) => {
+            if privacy_policy.allow_linking_account_addresses() {
+                SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr())
+            } else if let (true, Some(&taddr)) =
+                (privacy_policy.allow_revealed_senders(), ua.transparent())
+            {
+                SpendPolicy::default()
+                    .with_transparent(TransparentSpendPolicy::from_one_address(taddr))
+            } else {
+                SpendPolicy::default()
+            }
+        }
         _ => SpendPolicy::default(),
     }
 }
@@ -151,6 +184,11 @@ pub(crate) async fn call<C: Chain>(
 
     let request = build_request(&amounts)?;
 
+    // Parse the privacy policy before deriving the spend policy: for a unified-address source
+    // the requested policy gates whether transparent spending is opted into at all (see
+    // `spend_policy_for`).
+    let privacy_policy = parse_privacy_policy(privacy_policy.as_deref())?;
+
     let (account, spend_policy) = match fromaddress.as_str() {
         // Select from the legacy transparent address pool, which this wallet holds in a
         // single account. Enabled by `features.legacy_pool_seed_fingerprint`.
@@ -168,18 +206,9 @@ pub(crate) async fn call<C: Chain>(
 
             let account = get_account_for_address(wallet.as_ref(), &address)?;
 
-            (account, spend_policy_for(&address))
+            (account, spend_policy_for(&address, privacy_policy))
         }
     };
-
-    let privacy_policy = match privacy_policy.as_deref() {
-        Some("LegacyCompat") => Err(LegacyCode::InvalidParameter
-            .with_static("LegacyCompat privacy policy is unsupported in Zallet")),
-        Some(s) => PrivacyPolicy::from_str(s).ok_or_else(|| {
-            LegacyCode::InvalidParameter.with_message(format!("Unknown privacy policy {s}"))
-        }),
-        None => Ok(PrivacyPolicy::FullPrivacy),
-    }?;
 
     // Sanity check for transaction size
     // TODO: https://github.com/zcash/zallet/issues/255
@@ -466,8 +495,20 @@ mod tests {
     use zip32::AccountId;
 
     use super::{
-        SpendPolicy, legacy_pool_spend_policy, spend_policy_for, transparent_change_policy_for,
+        PrivacyPolicy, SpendPolicy, legacy_pool_spend_policy, spend_policy_for,
+        transparent_change_policy_for,
     };
+
+    /// Every privacy policy, from strictest to loosest.
+    const ALL_POLICIES: &[PrivacyPolicy] = &[
+        PrivacyPolicy::FullPrivacy,
+        PrivacyPolicy::AllowRevealedAmounts,
+        PrivacyPolicy::AllowRevealedRecipients,
+        PrivacyPolicy::AllowRevealedSenders,
+        PrivacyPolicy::AllowFullyTransparent,
+        PrivacyPolicy::AllowLinkingAccountAddresses,
+        PrivacyPolicy::NoPrivacy,
+    ];
 
     /// `ANY_TADDR` draws on the legacy pool's transparent funds, on any address within it, and
     /// on nothing else.
@@ -524,6 +565,23 @@ mod tests {
         Some(ua)
     }
 
+    /// A unified address carrying only shielded receivers (no transparent receiver), derived
+    /// from `seed` and `account`.
+    ///
+    /// `UnifiedAddressRequest::SHIELDED` omits the P2PKH receiver, so `ua.transparent()` is
+    /// `None`. This is the input that distinguishes the two `AllowRevealedSenders` and
+    /// `AllowLinkingAccountAddresses` tiers: the former needs the UA's own transparent
+    /// receiver to confine to, the latter draws on the account's receivers regardless.
+    fn shielded_only_ua_from(seed: &[u8; 32], account: u32) -> Option<UnifiedAddress> {
+        let account = AccountId::try_from(account).ok()?;
+        let usk = UnifiedSpendingKey::from_seed(&Network::TestNetwork, seed, account).ok()?;
+        let (ua, _) = usk
+            .to_unified_full_viewing_key()
+            .default_address(UnifiedAddressRequest::SHIELDED)
+            .ok()?;
+        Some(ua)
+    }
+
     /// ZIP 32 account indices are non-hardened, so they occupy the low 31 bits.
     fn arb_account() -> impl Strategy<Value = u32> {
         0u32..(1 << 31)
@@ -535,8 +593,10 @@ mod tests {
         // corners of the seed space, so a modest sample establishes them.
         #![proptest_config(ProptestConfig::with_cases(32))]
 
-        /// Whatever key it was derived from, a transparent source draws only on that one
-        /// address's UTXOs, and on no shielded note.
+        /// Whatever key it was derived from, and whatever the privacy policy, a bare
+        /// transparent source draws only on that one address's UTXOs, and on no shielded note.
+        /// The privacy policy does not enter into a bare taddr's confinement: those funds are
+        /// already public, so there is nothing for a looser policy to unlock.
         #[test]
         fn transparent_source_spends_only_that_address_and_no_shielded_pool(
             seed in any::<[u8; 32]>(),
@@ -545,67 +605,210 @@ mod tests {
             let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
             let Some(&taddr) = ua.transparent() else { return Ok(()) };
 
-            let policy = spend_policy_for(&Address::Transparent(taddr));
+            for &privacy_policy in ALL_POLICIES {
+                let policy = spend_policy_for(&Address::Transparent(taddr), privacy_policy);
 
-            // A transparent send must not reach into the account's shielded funds. The
-            // permitted-pool SET being empty says this exhaustively: it forbids every
-            // shielded pool, including any added to `ShieldedPool` after this was written,
-            // which enumerating the variants here would not.
-            prop_assert!(
-                policy.shielded().is_empty(),
-                "a transparent source must permit no shielded pool, got {:?}",
-                policy.shielded(),
-            );
+                // A transparent send must not reach into the account's shielded funds. The
+                // permitted-pool SET being empty says this exhaustively: it forbids every
+                // shielded pool, including any added to `ShieldedPool` after this was written,
+                // which enumerating the variants here would not.
+                prop_assert!(
+                    policy.shielded().is_empty(),
+                    "a transparent source must permit no shielded pool, got {:?} (policy {})",
+                    policy.shielded(),
+                    privacy_policy,
+                );
 
-            let transparent = policy
-                .transparent()
-                .expect("a transparent source permits transparent spending");
+                let transparent = policy
+                    .transparent()
+                    .expect("a transparent source permits transparent spending");
 
-            // Only the named address, so spending it does not link the source to the
-            // account's other transparent receivers.
-            match transparent.source() {
-                TransparentSource::FromAddresses(addrs) => prop_assert_eq!(
-                    addrs.iter().copied().collect::<Vec<_>>(),
-                    vec![taddr],
-                    "selection must be confined to the named address",
-                ),
-                other => prop_assert!(
-                    false,
-                    "expected a single-address source, got {other:?}",
-                ),
+                // Only the named address, so spending it does not link the source to the
+                // account's other transparent receivers.
+                match transparent.source() {
+                    TransparentSource::FromAddresses(addrs) => prop_assert_eq!(
+                        addrs.iter().copied().collect::<Vec<_>>(),
+                        vec![taddr],
+                        "selection must be confined to the named address",
+                    ),
+                    other => prop_assert!(
+                        false,
+                        "expected a single-address source, got {other:?}",
+                    ),
+                }
+
+                // Coinbase must be spent to a single shielded output (`z_shieldcoinbase`'s
+                // job), so a general transfer never draws on it.
+                prop_assert_eq!(transparent.coinbase(), CoinbasePolicy::NonCoinbase);
             }
-
-            // Coinbase must be spent to a single shielded output (`z_shieldcoinbase`'s
-            // job), so a general transfer never draws on it.
-            prop_assert_eq!(transparent.coinbase(), CoinbasePolicy::NonCoinbase);
         }
 
-        /// The property whose absence made transparent spending impossible, inverted: a
-        /// shielded source must never be able to select a transparent input, even though the
-        /// unified address it names does carry a transparent receiver.
+        /// Under a privacy policy stricter than `AllowRevealedSenders` — the default
+        /// `FullPrivacy`, `AllowRevealedAmounts`, or `AllowRevealedRecipients` — a unified
+        /// address source stays shielded-only, exactly as it did before transparent spending
+        /// from a UA existed. None of these policies permit revealing that the account owns
+        /// transparent funds, so the transparent source is not opted into and the greedy
+        /// selector never gathers a transparent UTXO.
         #[test]
-        fn shielded_source_permits_no_transparent_spending(
+        fn ua_source_under_strict_policy_permits_no_transparent_spending(
             seed in any::<[u8; 32]>(),
             account in arb_account(),
         ) {
             let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let default = SpendPolicy::default();
 
-            let policy = spend_policy_for(&Address::Unified(ua));
+            let strict = [
+                PrivacyPolicy::FullPrivacy,
+                PrivacyPolicy::AllowRevealedAmounts,
+                PrivacyPolicy::AllowRevealedRecipients,
+            ];
 
+            for privacy_policy in strict {
+                let policy = spend_policy_for(&Address::Unified(ua.clone()), privacy_policy);
+
+                prop_assert!(
+                    policy.transparent().is_none(),
+                    "a UA source under {} must not permit transparent spending",
+                    privacy_policy,
+                );
+
+                // Shielded selection is left exactly as the default. Comparing against the
+                // default's pool set keeps that true for any pool added later, rather than
+                // pinning today's set.
+                prop_assert_eq!(policy.shielded(), default.shielded());
+            }
+        }
+
+        /// Under `AllowRevealedSenders` or `AllowFullyTransparent`, a unified address source
+        /// spends the non-coinbase UTXOs of *that UA's own* transparent receiver, and no
+        /// others: these policies reveal the sender but do not authorize linking the account's
+        /// transparent receivers, so selection is confined to the one receiver the caller
+        /// named. Shielded selection is untouched.
+        #[test]
+        fn ua_source_under_revealed_senders_spends_only_that_uas_receiver(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let Some(&taddr) = ua.transparent() else { return Ok(()) };
+            let default = SpendPolicy::default();
+
+            for privacy_policy in [
+                PrivacyPolicy::AllowRevealedSenders,
+                PrivacyPolicy::AllowFullyTransparent,
+            ] {
+                let policy = spend_policy_for(&Address::Unified(ua.clone()), privacy_policy);
+
+                // Shielded selection remains the account's full shielded default; the
+                // transparent opt-in adds to it rather than replacing it.
+                prop_assert_eq!(policy.shielded(), default.shielded());
+
+                let transparent = policy
+                    .transparent()
+                    .expect("AllowRevealedSenders opts a UA with a t-receiver into transparent spending");
+
+                match transparent.source() {
+                    TransparentSource::FromAddresses(addrs) => prop_assert_eq!(
+                        addrs.iter().copied().collect::<Vec<_>>(),
+                        vec![taddr],
+                        "selection must be confined to the UA's own transparent receiver",
+                    ),
+                    other => prop_assert!(
+                        false,
+                        "expected the UA's single receiver as source, got {other:?}",
+                    ),
+                }
+
+                prop_assert_eq!(transparent.coinbase(), CoinbasePolicy::NonCoinbase);
+            }
+        }
+
+        /// Under `AllowLinkingAccountAddresses` or `NoPrivacy`, a unified address source draws
+        /// on *any* of the account's transparent receivers, whichever the proposer picks —
+        /// `TransparentSource::AnyAccountAddr`, the same source `ANY_TADDR` uses. These
+        /// policies authorize linking the account's transparent receivers on-chain, so the
+        /// UA the caller named is merely a handle to the account, not a confinement. Shielded
+        /// selection is untouched.
+        #[test]
+        fn ua_source_under_linking_policy_spends_any_account_receiver(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let default = SpendPolicy::default();
+
+            for privacy_policy in [
+                PrivacyPolicy::AllowLinkingAccountAddresses,
+                PrivacyPolicy::NoPrivacy,
+            ] {
+                let policy = spend_policy_for(&Address::Unified(ua.clone()), privacy_policy);
+
+                prop_assert_eq!(policy.shielded(), default.shielded());
+
+                let transparent = policy
+                    .transparent()
+                    .expect("AllowLinkingAccountAddresses opts a UA source into transparent spending");
+
+                prop_assert!(
+                    matches!(transparent.source(), TransparentSource::AnyAccountAddr),
+                    "a linking policy must draw on any of the account's receivers, got {:?}",
+                    transparent.source(),
+                );
+
+                prop_assert_eq!(transparent.coinbase(), CoinbasePolicy::NonCoinbase);
+            }
+        }
+
+        /// The two tiers diverge on a UA that carries no transparent receiver of its own.
+        ///
+        /// `AllowRevealedSenders` confines the transparent spend to *the named UA's* receiver,
+        /// so a UA without one has nothing to confine to and stays shielded-only. But
+        /// `AllowLinkingAccountAddresses` draws on the *account's* transparent receivers, which
+        /// exist independently of which UA the caller named, so it still opts into
+        /// `AnyAccountAddr` even though the named UA is purely shielded.
+        #[test]
+        fn shielded_only_ua_source_opts_in_only_under_a_linking_policy(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = shielded_only_ua_from(&seed, account) else { return Ok(()) };
+            let default = SpendPolicy::default();
             prop_assert!(
-                policy.transparent().is_none(),
-                "a shielded source must not permit transparent spending",
+                ua.transparent().is_none(),
+                "the SHIELDED request must yield a UA with no transparent receiver",
             );
 
-            // Shielded selection is left exactly as it was before transparent spending
-            // existed. Comparing against the default's pool set keeps that true for any
-            // pool added later, rather than pinning today's three.
-            let unchanged = SpendPolicy::default();
-            prop_assert_eq!(policy.shielded(), unchanged.shielded());
+            // `AllowRevealedSenders`: no receiver to confine to, so shielded-only.
+            let revealed = spend_policy_for(
+                &Address::Unified(ua.clone()),
+                PrivacyPolicy::AllowRevealedSenders,
+            );
+            prop_assert!(
+                revealed.transparent().is_none(),
+                "a shielded-only UA has no transparent receiver for AllowRevealedSenders to spend",
+            );
+            prop_assert_eq!(revealed.shielded(), default.shielded());
+
+            // `AllowLinkingAccountAddresses`: the account's receivers exist regardless, so the
+            // transparent source is opted in as `AnyAccountAddr`.
+            let linking = spend_policy_for(
+                &Address::Unified(ua),
+                PrivacyPolicy::AllowLinkingAccountAddresses,
+            );
+            let transparent = linking
+                .transparent()
+                .expect("a linking policy opts in via the account's receivers, not the UA's");
+            prop_assert!(
+                matches!(transparent.source(), TransparentSource::AnyAccountAddr),
+                "a linking policy draws on the account's receivers, got {:?}",
+                transparent.source(),
+            );
         }
 
         /// Change may be returned to the transparent pool exactly when the source could spend
-        /// transparent funds in the first place.
+        /// transparent funds in the first place: a bare taddr under any policy; a UA only once
+        /// a linking policy opts it into transparent spending. A UA under `FullPrivacy` spends
+        /// only shielded funds, so its change is shielded.
         #[test]
         fn transparent_change_permitted_exactly_when_transparent_funds_are_spendable(
             seed in any::<[u8; 32]>(),
@@ -614,19 +817,39 @@ mod tests {
             let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
             let Some(&taddr) = ua.transparent() else { return Ok(()) };
 
-            let transparent_source = spend_policy_for(&Address::Transparent(taddr));
-            prop_assert_eq!(
-                transparent_change_policy_for(&transparent_source),
-                TransparentChangePolicy::TransparentChangeAllowed,
-                "a fully transparent send keeps its change transparent",
-            );
+            // A bare taddr keeps its change transparent under every policy.
+            for &privacy_policy in ALL_POLICIES {
+                let taddr_source = spend_policy_for(&Address::Transparent(taddr), privacy_policy);
+                prop_assert_eq!(
+                    transparent_change_policy_for(&taddr_source),
+                    TransparentChangePolicy::TransparentChangeAllowed,
+                    "a fully transparent send keeps its change transparent",
+                );
+            }
 
-            let shielded_source = spend_policy_for(&Address::Unified(ua));
+            // A UA source under `FullPrivacy` spends only shielded funds, so change is shielded.
+            let shielded_source =
+                spend_policy_for(&Address::Unified(ua.clone()), PrivacyPolicy::FullPrivacy);
             prop_assert_eq!(
                 transparent_change_policy_for(&shielded_source),
                 TransparentChangePolicy::ShieldChange,
                 "a shielded send must not acquire a transparent change output",
             );
+
+            // A UA source under a linking policy can spend transparent funds, so it may keep
+            // transparent change.
+            for privacy_policy in [
+                PrivacyPolicy::AllowLinkingAccountAddresses,
+                PrivacyPolicy::NoPrivacy,
+            ] {
+                let linking_source =
+                    spend_policy_for(&Address::Unified(ua.clone()), privacy_policy);
+                prop_assert_eq!(
+                    transparent_change_policy_for(&linking_source),
+                    TransparentChangePolicy::TransparentChangeAllowed,
+                    "a UA source permitted to spend transparent funds may keep transparent change",
+                );
+            }
         }
     }
 }

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -429,9 +429,6 @@ pub(super) fn required_privacy_policy<FeeRuleT, NoteRef>(
 /// Parses the optional `privacy_policy` JSON-RPC argument into a [`PrivacyPolicy`],
 /// defaulting to [`PrivacyPolicy::FullPrivacy`] when absent and rejecting the unsupported
 /// `"LegacyCompat"` policy.
-// Extracted ahead of its caller; not yet wired into a JSON-RPC method on this branch, hence
-// `allow(dead_code)`.
-#[allow(dead_code)]
 pub(super) fn parse_privacy_policy(privacy_policy: Option<&str>) -> RpcResult<PrivacyPolicy> {
     match privacy_policy {
         Some("LegacyCompat") => Err(LegacyCode::InvalidParameter
@@ -776,7 +773,10 @@ pub(super) fn get_legacy_pool_account(wallet: &DbConnection) -> RpcResult<Accoun
             LegacyCode::WalletAccountsUnsupported.with_static(
                 "The legacy pool of funds is disabled. To enable it, set \
                  `features.legacy_pool_seed_fingerprint` in the Zallet config file to the \
-                 seed fingerprint of the `zcashd` wallet migrated into this wallet.",
+                 seed fingerprint of the `zcashd` wallet migrated into this wallet. To spend \
+                 the transparent funds of a regular account instead, pass one of its unified \
+                 addresses as fromaddress with privacyPolicy AllowLinkingAccountAddresses (or \
+                 NoPrivacy if the transaction also has transparent recipients or change).",
             )
         })?;
 


### PR DESCRIPTION
Fixes #644.

## Design evaluation (is the lack of `ANY_TADDR` a gap?)

Research across #138, #384, and #217 settles it as follows:

- **`ANY_TADDR`'s legacy-pool gating is by design.** #384 defines the legacy pool as *one specific account of one specific seed* (the migrated `zcashd` wallet at ZIP 32 index `0x7FFFFFFF`), and nuttycom closed #138 with exactly that resolution. Relaxing the index check would make a regular account of the named seed impersonate the legacy pool, which #384's semantics deliberately exclude. This PR does not touch it.
- **The actual gap is the unified-address source.** str4d in #138: *"Note that for UAs we do get these semantics for transparent, because the multiple transparent spend authorities are all derived from the same account."* And Zallet's `z_sendmany` help text already documents `AllowLinkingAccountAddresses` as *"Allow selecting transparent coins from the full account, rather than just the funds sent to the transparent receiver in the provided Unified Address"* — `zcashd`'s exact semantics. But `spend_policy_for` mapped every UA source to shielded-only, so the documented capability was unreachable outside the legacy pool. A clean wallet consequently scattered its transparent change (by design) and then refused to gather it (the bug).

## What this changes

For a UA `fromaddress`, the caller's privacy policy now opts the source into transparent spending, mirroring `zcashd`:

| requested policy | transparent funds selectable |
|---|---|
| `FullPrivacy` (default), `AllowRevealedAmounts`, `AllowRevealedRecipients` | none (unchanged) |
| `AllowRevealedSenders`, `AllowFullyTransparent` | the provided UA's own transparent receiver |
| `AllowLinkingAccountAddresses`, `NoPrivacy` | any of the account's transparent receivers (`TransparentSpendPolicy::any_account_addr`, the same source `ANY_TADDR` uses) |

The opt-in must be derived from the requested policy rather than left to post-hoc enforcement: the `GreedyInputSelector` gathers transparent UTXOs up front (targeting the full request amount) whenever a `TransparentSpendPolicy` is present, so a policy-blind opt-in would make the default fully-shielded send propose transparent inputs and then fail `enforce_privacy_policy`. Enforcement itself stays post-hoc and unchanged. Bare-taddr sources and `ANY_TADDR` are unchanged; the legacy-pool-disabled error now points regular accounts at the UA route.

For the miner's t→t payout in #644 (multiple linked input addresses + transparent recipients), the call is now:

```
z_sendmany "<account UA>" '[...]' 1 null 'NoPrivacy'
```

(`NoPrivacy` because linking multiple input addresses *and* revealing transparent recipients is the lattice meet of `AllowLinkingAccountAddresses` and `AllowRevealedRecipients`.) No manufactured legacy account required. Note one behavioral caveat inherited from the greedy selector: transparent funds are drawn first, and if they cannot cover the request, shielded notes cover the remainder — callers who need a guaranteed all-transparent transaction (e.g. exchange payouts) should ensure the account's transparent balance covers amount + fee. The longer-term explicit fund-source selection belongs to `z_sendfromaccount` (#217).

## Testing

- `cargo test -p zallet-core --lib`: 197 passed (new proptests cover each policy tier, the shielded-only-UA divergence between the `AllowRevealedSenders` and `AllowLinkingAccountAddresses` tiers, bare-taddr confinement under every policy, and the change-policy derivation).
- `cargo clippy -p zallet-core --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WB1TU6tyLmMa1n4SQ9XgK