### PR TITLE
config: Document the experimental/deprecated feature lifecycle

### DIFF
--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -141,6 +141,31 @@ network = "main"
 #
 # Settings for Zallet features.
 #
+# Zallet's behaviour evolves over time: new functionality starts out as an
+# experimental feature that must be explicitly enabled, and functionality on its way
+# out becomes a deprecated feature that must be explicitly re-enabled. This section
+# records the non-default choices this wallet has made, along with the Zallet version
+# they were made against (`as_of_version`), which enables Zallet to detect when a
+# feature named in this config has changed state across an upgrade, rather than
+# silently changing the wallet's behaviour.
+#
+# The lifecycle of a feature:
+#
+# 1. New unstable functionality is added behind a flag in `[features.experimental]`.
+# Setting the flag opts this wallet in; experimental features may change
+# incompatibly or be removed without a deprecation cycle.
+# 2. If the feature is stabilised, its behaviour becomes the default and the flag is
+# retired. A config that still sets the flag is out of date.
+# 3. If existing functionality is deprecated, it becomes disabled by default and
+# gains a flag in `[features.deprecated]` that temporarily re-enables it, giving
+# you time to migrate away.
+# 4. When a deprecated feature is removed, its flag is retired; re-enabling is no
+# longer possible.
+#
+# Retired flags left in this config are how Zallet knows to alert you (instead of
+# wallet behaviour just changing out from under you), so do not remove a flag from
+# this section until you have acted on the corresponding change.
+#
 [features]
 
 # The most recent Zallet version for which this configuration file has been updated.
@@ -196,11 +221,22 @@ as_of_version = "0.1.0-beta.1"
 #
 # Deprecated Zallet features that you are temporarily re-enabling.
 #
+# A deprecated feature is disabled by default and scheduled for removal in a future
+# Zallet version. Setting its flag to `true` here re-enables it for this wallet.
+# Treat that as a stopgap while you migrate away: the flag stops being usable once
+# the feature is removed, and the removal will be flagged via
+# `features.as_of_version` when you upgrade.
+#
 [features.deprecated]
 
 
 #
 # Experimental Zallet features that you are using before they are stable.
+#
+# An experimental feature is disabled by default, and may change incompatibly or be
+# removed entirely without a deprecation cycle. Setting its flag to `true` here opts
+# this wallet in. When the feature is stabilised or abandoned, the flag is retired,
+# and the change will be flagged via `features.as_of_version` when you upgrade.
 #
 [features.experimental]
 

--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -422,6 +422,31 @@ impl ExternalSection {
 }
 
 /// Settings for Zallet features.
+///
+/// Zallet's behaviour evolves over time: new functionality starts out as an
+/// experimental feature that must be explicitly enabled, and functionality on its way
+/// out becomes a deprecated feature that must be explicitly re-enabled. This section
+/// records the non-default choices this wallet has made, along with the Zallet version
+/// they were made against (`as_of_version`), which enables Zallet to detect when a
+/// feature named in this config has changed state across an upgrade, rather than
+/// silently changing the wallet's behaviour.
+///
+/// The lifecycle of a feature:
+///
+/// 1. New unstable functionality is added behind a flag in `[features.experimental]`.
+///    Setting the flag opts this wallet in; experimental features may change
+///    incompatibly or be removed without a deprecation cycle.
+/// 2. If the feature is stabilised, its behaviour becomes the default and the flag is
+///    retired. A config that still sets the flag is out of date.
+/// 3. If existing functionality is deprecated, it becomes disabled by default and
+///    gains a flag in `[features.deprecated]` that temporarily re-enables it, giving
+///    you time to migrate away.
+/// 4. When a deprecated feature is removed, its flag is retired; re-enabling is no
+///    longer possible.
+///
+/// Retired flags left in this config are how Zallet knows to alert you (instead of
+/// wallet behaviour just changing out from under you), so do not remove a flag from
+/// this section until you have acted on the corresponding change.
 #[derive(Clone, Debug, Deserialize, Serialize, Documented, DocumentedFields)]
 #[serde(deny_unknown_fields)]
 pub struct FeaturesSection {
@@ -521,6 +546,12 @@ impl Default for FeaturesSection {
 }
 
 /// Deprecated Zallet features that you are temporarily re-enabling.
+///
+/// A deprecated feature is disabled by default and scheduled for removal in a future
+/// Zallet version. Setting its flag to `true` here re-enables it for this wallet.
+/// Treat that as a stopgap while you migrate away: the flag stops being usable once
+/// the feature is removed, and the removal will be flagged via
+/// `features.as_of_version` when you upgrade.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Documented, DocumentedFields)]
 pub struct DeprecatedFeaturesSection {
     /// Any other deprecated feature flags.
@@ -532,6 +563,11 @@ pub struct DeprecatedFeaturesSection {
 }
 
 /// Experimental Zallet features that you are using before they are stable.
+///
+/// An experimental feature is disabled by default, and may change incompatibly or be
+/// removed entirely without a deprecation cycle. Setting its flag to `true` here opts
+/// this wallet in. When the feature is stabilised or abandoned, the flag is retired,
+/// and the change will be flagged via `features.as_of_version` when you upgrade.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Documented, DocumentedFields)]
 pub struct ExperimentalFeaturesSection {
     /// Any other experimental feature flags.


### PR DESCRIPTION
## Summary

Documents the process the `[features]` config section exists to support. The section already had per-field docs, but nothing explaining the *lifecycle* those fields participate in — which #187 asks for ("the fields are not yet fully documented such that users will know how to use them and how to expect them to change").

- Expands the rustdoc on `FeaturesSection` with the feature lifecycle (experimental → stabilised/removed; active → deprecated → removed), what `as_of_version` detects across upgrades, and why retired flags should be left in the config until acted on (that is how Zallet alerts you instead of silently changing behaviour).
- Adds matching orientation docs to `DeprecatedFeaturesSection` and `ExperimentalFeaturesSection`.

Because config rustdoc is the source for `zallet example-config`, this prose flows into the generated output (fixture regenerated with `TRYCMD=overwrite`) and therefore into the book's configuration reference (#603) — documented once, surfaced everywhere.

Verified against `config.rs` (the `as_of_version` compatibility-check behaviour) and the existing `legacy_pool_seed_fingerprint` background docs.

Closes #187. Part of #600.

## Test plan

- [x] `cargo test --manifest-path backends/zebra/Cargo.toml --features zcashd-import --test cli_tests` passes (fixture matches regenerated output)
- [x] `cargo fmt --all -- --check` clean; `cargo clippy -p zallet-core --all-targets` zero warnings; `cargo doc --no-deps -p zallet-core` zero warnings

## AI disclosure

Written with AI assistance (Claude Opus 4.8, via Claude Code); `Co-Authored-By` metadata is on the commit. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
