### PR TITLE
Replace the temporary rage git pin with the released age 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,8 +103,9 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.11.3"
-source = "git+https://github.com/str4d/rage.git?rev=d28f10ee776ce7391f7065695997f998631b113a#d28f10ee776ce7391f7065695997f998631b113a"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "age-core",
  "base64 0.22.1",
@@ -140,8 +141,9 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.11.0"
-source = "git+https://github.com/str4d/rage.git?rev=d28f10ee776ce7391f7065695997f998631b113a#d28f10ee776ce7391f7065695997f998631b113a"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ripemd = "0.1"
 sha2 = "0.10"
 
 # Key storage
-age = { version = "0.11", features = ["armor", "cli-common", "plugin"] }
+age = { version = "0.12", features = ["armor", "cli-common", "plugin"] }
 bech32 = "0.11"
 bip0039 = "0.12"
 
@@ -160,12 +160,6 @@ anyhow = "1.0"
 tonic = "0.14"
 
 [patch.crates-io]
-# Temporary pin to rage/main: the keystore uses age APIs (`EncryptedIdentity`,
-# `Send + Sync` bounds on `IdentityFile::into_identities`) that the 0.11.x
-# maintenance releases exclude. Replace with the crates.io release once
-# rage 0.12 ships.
-age = { git = "https://github.com/str4d/rage.git", rev = "d28f10ee776ce7391f7065695997f998631b113a" }
-
 # Temporary patch for `WalletDb::transactionally_with_extension` (adds atomic
 # z_importkey account+key writes), merged upstream but not yet released. The API
 # lives in zcash_client_sqlite, but the repo is a workspace: pinning only that

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -103,8 +103,9 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.11.3"
-source = "git+https://github.com/str4d/rage.git?rev=d28f10ee776ce7391f7065695997f998631b113a#d28f10ee776ce7391f7065695997f998631b113a"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "age-core",
  "base64 0.22.1",
@@ -140,8 +141,9 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.11.0"
-source = "git+https://github.com/str4d/rage.git?rev=d28f10ee776ce7391f7065695997f998631b113a#d28f10ee776ce7391f7065695997f998631b113a"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -72,12 +72,6 @@ once_cell = "1.2"
 tempfile = "3"
 
 [patch.crates-io]
-# Temporary pin to rage/main: the keystore uses age APIs (`EncryptedIdentity`,
-# `Send + Sync` bounds on `IdentityFile::into_identities`) that the 0.11.x
-# maintenance releases exclude. Replace with the crates.io release once
-# rage 0.12 ships.
-age = { git = "https://github.com/str4d/rage.git", rev = "d28f10ee776ce7391f7065695997f998631b113a" }
-
 # Temporary patch for `WalletDb::transactionally_with_extension` (adds atomic
 # z_importkey account+key writes), merged upstream but not yet released. The API
 # lives in zcash_client_sqlite, but the repo is a workspace: pinning only that

--- a/backends/zaino/supply-chain/config.toml
+++ b/backends/zaino/supply-chain/config.toml
@@ -22,12 +22,6 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
-[policy.age]
-audit-as-crates-io = true
-
-[policy.age-core]
-audit-as-crates-io = true
-
 [policy.equihash]
 
 [policy.f4jumble]
@@ -110,14 +104,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.aes-gcm]]
 version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.age]]
-version = "0.11.3@git:d28f10ee776ce7391f7065695997f998631b113a"
-criteria = "safe-to-deploy"
-
-[[exemptions.age-core]]
-version = "0.11.0@git:d28f10ee776ce7391f7065695997f998631b113a"
 criteria = "safe-to-deploy"
 
 [[exemptions.aho-corasick]]

--- a/backends/zaino/supply-chain/imports.lock
+++ b/backends/zaino/supply-chain/imports.lock
@@ -1,6 +1,20 @@
 
 # cargo-vet imports lock
 
+[[publisher.age]]
+version = "0.12.1"
+when = "2026-07-14"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
+[[publisher.age-core]]
+version = "0.12.0"
+when = "2026-07-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.bumpalo]]
 version = "3.20.3"
 when = "2026-05-22"
@@ -14,20 +28,6 @@ when = "2021-10-11"
 user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
-
-[[publisher.equihash]]
-version = "0.3.0"
-when = "2026-04-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.f4jumble]]
-version = "0.1.1"
-when = "2024-12-13"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
 
 [[publisher.halo2_gadgets]]
 version = "0.5.0"
@@ -328,27 +328,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_client_backend]]
-version = "0.24.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_encoding]]
-version = "0.4.0"
-when = "2026-04-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_history]]
 version = "0.5.0"
 when = "2026-07-09"
@@ -446,13 +425,6 @@ when = "2025-09-17"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
-
-[[publisher.zip321]]
-version = "0.9.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -103,8 +103,9 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.11.3"
-source = "git+https://github.com/str4d/rage.git?rev=d28f10ee776ce7391f7065695997f998631b113a#d28f10ee776ce7391f7065695997f998631b113a"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "age-core",
  "base64 0.22.1",
@@ -140,8 +141,9 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.11.0"
-source = "git+https://github.com/str4d/rage.git?rev=d28f10ee776ce7391f7065695997f998631b113a#d28f10ee776ce7391f7065695997f998631b113a"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -52,7 +52,7 @@ zebra-state = { version = "10", features = ["indexer"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.9", features = ["testing"] }
-age = { version = "0.11", features = ["armor", "cli-common", "plugin"] }
+age = { version = "0.12", features = ["armor", "cli-common", "plugin"] }
 once_cell = "1.2"
 regex = "1.4"
 tempfile = "3"
@@ -75,12 +75,6 @@ rpc-cli = ["zallet-core/rpc-cli"]
 tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
-# Temporary pin to rage/main: the keystore uses age APIs (`EncryptedIdentity`,
-# `Send + Sync` bounds on `IdentityFile::into_identities`) that the 0.11.x
-# maintenance releases exclude. Replace with the crates.io release once
-# rage 0.12 ships.
-age = { git = "https://github.com/str4d/rage.git", rev = "d28f10ee776ce7391f7065695997f998631b113a" }
-
 # Temporary patch for `WalletDb::transactionally_with_extension` (adds atomic
 # z_importkey account+key writes), merged upstream but not yet released. The API
 # lives in zcash_client_sqlite, but the repo is a workspace: pinning only that

--- a/backends/zebra/supply-chain/config.toml
+++ b/backends/zebra/supply-chain/config.toml
@@ -22,12 +22,6 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
-[policy.age]
-audit-as-crates-io = true
-
-[policy.age-core]
-audit-as-crates-io = true
-
 [policy.equihash]
 
 [policy.f4jumble]
@@ -98,14 +92,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.aes-gcm]]
 version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.age]]
-version = "0.11.3@git:d28f10ee776ce7391f7065695997f998631b113a"
-criteria = "safe-to-deploy"
-
-[[exemptions.age-core]]
-version = "0.11.0@git:d28f10ee776ce7391f7065695997f998631b113a"
 criteria = "safe-to-deploy"
 
 [[exemptions.aho-corasick]]

--- a/backends/zebra/supply-chain/imports.lock
+++ b/backends/zebra/supply-chain/imports.lock
@@ -1,6 +1,20 @@
 
 # cargo-vet imports lock
 
+[[publisher.age]]
+version = "0.12.1"
+when = "2026-07-14"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
+[[publisher.age-core]]
+version = "0.12.0"
+when = "2026-07-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.bumpalo]]
 version = "3.20.3"
 when = "2026-05-22"
@@ -14,20 +28,6 @@ when = "2021-10-11"
 user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
-
-[[publisher.equihash]]
-version = "0.3.0"
-when = "2026-04-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.f4jumble]]
-version = "0.1.1"
-when = "2024-12-13"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
 
 [[publisher.halo2_gadgets]]
 version = "0.5.0"
@@ -328,27 +328,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_client_backend]]
-version = "0.24.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_encoding]]
-version = "0.4.0"
-when = "2026-04-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_history]]
 version = "0.5.0"
 when = "2026-07-09"
@@ -446,13 +425,6 @@ when = "2025-09-17"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
-
-[[publisher.zip321]]
-version = "0.9.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -627,6 +627,18 @@ criteria = "safe-to-deploy"
 delta = "0.11.1 -> 0.11.2"
 notes = "Only changes to generated code are clippy lints."
 
+[[trusted.age]]
+criteria = "safe-to-deploy"
+user-id = 6289 # Jack Grigg (str4d)
+start = "2019-10-06"
+end = "2027-07-17"
+
+[[trusted.age-core]]
+criteria = "safe-to-deploy"
+user-id = 6289 # Jack Grigg (str4d)
+start = "2020-02-02"
+end = "2027-07-17"
+
 [[trusted.equihash]]
 criteria = "safe-to-deploy"
 user-id = 6289 # Jack Grigg (str4d)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,12 +22,6 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
-[policy.age]
-audit-as-crates-io = true
-
-[policy.age-core]
-audit-as-crates-io = true
-
 [policy.equihash]
 
 [policy.f4jumble]
@@ -78,14 +72,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.aes-gcm]]
 version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.age]]
-version = "0.11.3@git:d28f10ee776ce7391f7065695997f998631b113a"
-criteria = "safe-to-deploy"
-
-[[exemptions.age-core]]
-version = "0.11.0@git:d28f10ee776ce7391f7065695997f998631b113a"
 criteria = "safe-to-deploy"
 
 [[exemptions.aho-corasick]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,26 +1,26 @@
 
 # cargo-vet imports lock
 
+[[publisher.age]]
+version = "0.12.1"
+when = "2026-07-14"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
+[[publisher.age-core]]
+version = "0.12.0"
+when = "2026-07-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.bumpalo]]
 version = "3.20.3"
 when = "2026-05-22"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
-
-[[publisher.equihash]]
-version = "0.3.0"
-when = "2026-04-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.f4jumble]]
-version = "0.1.1"
-when = "2024-12-13"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
 
 [[publisher.halo2_gadgets]]
 version = "0.5.0"
@@ -321,27 +321,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_client_backend]]
-version = "0.24.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_encoding]]
-version = "0.4.0"
-when = "2026-04-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_keys]]
 version = "0.14.0"
 when = "2026-06-03"
@@ -432,13 +411,6 @@ when = "2025-09-17"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
-
-[[publisher.zip321]]
-version = "0.9.0-rc.1"
-when = "2026-07-12"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"


### PR DESCRIPTION
rage 0.12 has been released, carrying the APIs the keystore relies on (`EncryptedIdentity`, `Send + Sync` bounds on `IdentityFile::into_identities`) that motivated the temporary `[patch.crates-io]` pin to rage `main`. The pinned revision `d28f10ee` is an ancestor of the `v0.12.1` tag, so switching to the crates.io release requires no code changes.

- All three workspaces (root, `backends/zebra`, `backends/zaino`) now depend on `age 0.12` from crates.io; the git pins and their explanatory comments are removed, and the lockfiles resolve `age 0.12.1` / `age-core 0.12.0`. `utils/check-lockstep.sh` passes.
- cargo-vet: the `@git`-suffixed exemptions and `audit-as-crates-io` policies for `age`/`age-core` are replaced by `[[trusted.age]]` / `[[trusted.age-core]]` entries for str4d as publisher. `cargo vet --locked` passes in all three workspaces.
- `cargo check --all-features` passes in all three workspaces. `cargo deny` licenses/bans/sources pass; the two advisory failures (RUSTSEC-2026-0204, RUSTSEC-2026-0173) are pre-existing on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbEidoB2RKxwfWLNy2Ci5w