### PR TITLE
book: Regenerate RPC reference snapshot for z_exportviewingkey (main is red)

### DIFF
--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -151,6 +151,31 @@ instead, or you may lose access to funds.
 - `address` (string, required) The Sapling payment address corresponding to the
   spending key to export.
 
+## `z_exportviewingkey`
+
+*Only available in wallet builds of Zallet.*
+
+Reveals the viewing key corresponding to 'zaddr'.
+
+#### Arguments
+
+- `zaddr` (string, required) The Sapling payment address or unified
+  address.
+- `ivk` (boolean, optional, default=`false`) When `true`, export the
+  unified incoming viewing key (UIVK) for the account holding `zaddr`
+  instead of the full viewing key.
+
+#### Returns
+A string containing the viewing key:
+- For a Sapling payment address, the Sapling extended full viewing key
+  (`zxviews…`).
+- For a unified address, the unified full viewing key (`uview…`) of the
+  account holding the address.
+- When `ivk` is `true`, the unified incoming viewing key (`uivk…`) of
+  the account holding the address, for either address kind. Note that
+  a UIVK grants incoming viewing capability for every pool in the
+  account, even when `zaddr` is a Sapling address.
+
 ## `z_getaccount`
 
 Returns details about the given account.


### PR DESCRIPTION
## Summary

`main` is currently red: the `book_rpc_reference_is_current` pinning test (added in #627) fails because `book/src/rpc/methods.md` is missing the `z_exportviewingkey` method, which is present in the `Rpc`/`WalletRpc` trait rustdoc.

**How it slipped in:** `z_exportviewingkey` was added by #461 and merged to `main` *after* #627's branch point. #627 generated the snapshot from the older `main` and merged cleanly (the two PRs touch different files, so no textual conflict), landing a snapshot that no longer matches the trait. The test therefore fails on `main` and on every open PR whose CI merges `main` — e.g. #631, whose tutorial diff doesn't touch any RPC code but still hits this.

**Fix:** regenerated the snapshot with `ZALLET_BLESS=1 cargo test -p zallet-core --test book_rpc_reference`. The diff is purely the added `z_exportviewingkey` section — no other method changed.

Closes #655.

## Test plan

- [x] `cargo test -p zallet-core --test book_rpc_reference` passes against current `main`
- [x] Diff is additive only (the one new method)

## Note for maintainers

This is the snapshot analogue of the classic "two PRs, no textual conflict, semantic conflict" gap: a PR adding an RPC method and the snapshot PR can each pass CI independently and merge clean, yet leave `main` red. Prevention options: (a) generate `methods.md` at build time into `OUT_DIR` and compare there (no committed artifact to go stale), or (b) require the snapshot regen to accompany any RPC-doc change. Tracked in #655.

## AI disclosure

Prepared with AI assistance (Claude Opus 4.8, via Claude Code); `Co-Authored-By` metadata is on the commit. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
