### PR TITLE
Add a global sync lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ be considered breaking changes.
   indicating coinbase origin (mirroring `zcashd`'s `listunspent`), so
   integrators no longer need a `getrawtransaction` round-trip per UTXO to
   distinguish coinbase from spendable-to-transparent funds.
+- A global sync lock that blocks wallet usage while Zallet’s view of the chain
+  is not trustworthy. The balance and spend RPC methods (`z_getbalances`,
+  `z_getbalanceforaccount`, `z_gettotalbalance`, `z_listunspent`,
+  `z_getnotescount`, `z_sendmany`, `z_shieldcoinbase`) return an error both while
+  the wallet is still catching up to the chain tip (analogous to `zcashd`’s
+  initial block download) and while it is recovering from a chain reorganization
+  (analogous to safe mode).
+- The `sync.lock_threshold` config option, controlling how far the wallet may
+  lag the chain tip before it is considered to be catching up rather than synced
+  (default 100).
+- `getwalletstatus` now reports a `locked` field indicating whether the wallet
+  is currently usable.
 
 ### Removed
 

--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -394,3 +394,12 @@ as_of_version = "0.1.0-beta.1"
 # on the order of N * 2 MiB of memory.
 #recover_batch_size = 1000
 
+# The maximum number of blocks the wallet may lag behind the chain tip while still
+# being considered synced.
+#
+# While the wallet is further than this behind the tip (or has not yet reached the
+# tip for the first time), it is treated as still catching up, and the balance and
+# spend JSON-RPC methods return an error rather than operating on an incomplete view
+# of the chain. The default matches the reorg/finality boundary the sync engine uses.
+#lock_threshold = 100
+

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -10,7 +10,7 @@ use crate::{
         chain::{ChainFactory, check_consensus_compatibility},
         database::Database,
         json_rpc::JsonRpc,
-        sync::WalletSync,
+        sync::{WalletSync, status},
     },
     config::ZalletConfig,
     error::Error,
@@ -59,6 +59,11 @@ impl StartCmd {
         // Build the decryptor up front so the RPC server has its handle before the initial scan.
         let (decryptor_handle, decryptor_engine) = WalletSync::build_decryptor();
 
+        // The sync engine publishes its status over this channel; the RPC server reads it
+        // to gate balance and spend methods while the wallet is not trustworthy.
+        let (sync_status_writer, sync_status_reader) =
+            status::channel(config.sync.lock_threshold());
+
         // Launch RPC server.
         let rpc_task_handle = JsonRpc::spawn(
             &config,
@@ -68,6 +73,7 @@ impl StartCmd {
             chain.clone(),
             #[cfg(zallet_build = "wallet")]
             decryptor_handle.clone(),
+            sync_status_reader,
         )
         .await?;
 
@@ -84,6 +90,7 @@ impl StartCmd {
             shutdown_height,
             decryptor_handle,
             decryptor_engine,
+            sync_status_writer,
         )
         .await?;
 

--- a/zallet-core/src/components/json_rpc.rs
+++ b/zallet-core/src/components/json_rpc.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 
-use super::{TaskHandle, chain::Chain, database::Database};
+use super::{TaskHandle, chain::Chain, database::Database, sync::SyncStatusReader};
 
 #[cfg(zallet_build = "wallet")]
 use super::keystore::KeyStore;
@@ -39,6 +39,7 @@ impl JsonRpc {
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
         chain: C,
         #[cfg(zallet_build = "wallet")] decryptor: WalletDecryptorHandle,
+        sync_status: SyncStatusReader,
     ) -> Result<TaskHandle, Error> {
         let rpc = config.rpc.clone();
 
@@ -59,6 +60,7 @@ impl JsonRpc {
                 chain,
                 #[cfg(zallet_build = "wallet")]
                 decryptor,
+                sync_status,
             )
             .await
         } else {

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -7,6 +7,7 @@ use jsonrpsee::{
 use crate::components::{
     chain::Chain,
     database::{Database, DbHandle},
+    sync::SyncStatusReader,
 };
 
 #[cfg(zallet_build = "wallet")]
@@ -746,6 +747,7 @@ pub(crate) struct RpcImpl<C: Chain> {
     #[cfg(zallet_build = "wallet")]
     keystore: KeyStore,
     chain: C,
+    sync_status: SyncStatusReader,
 }
 
 impl<C: Chain> RpcImpl<C> {
@@ -754,12 +756,14 @@ impl<C: Chain> RpcImpl<C> {
         wallet: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
         chain: C,
+        sync_status: SyncStatusReader,
     ) -> Self {
         Self {
             wallet,
             #[cfg(zallet_build = "wallet")]
             keystore,
             chain,
+            sync_status,
         }
     }
 
@@ -772,6 +776,13 @@ impl<C: Chain> RpcImpl<C> {
 
     async fn chain(&self) -> RpcResult<C> {
         Ok(self.chain.clone())
+    }
+
+    /// Returns an error if the wallet is not synced enough for balance or spend methods to
+    /// operate on a trustworthy view of the chain.
+    #[cfg(zallet_build = "wallet")]
+    fn ensure_synced(&self) -> RpcResult<()> {
+        self.sync_status.ensure_available()
     }
 }
 
@@ -791,9 +802,10 @@ impl<C: Chain> WalletRpcImpl<C> {
         keystore: KeyStore,
         chain_view: C,
         decryptor: WalletDecryptorHandle,
+        sync_status: SyncStatusReader,
     ) -> Self {
         Self {
-            general: RpcImpl::new(wallet, keystore.clone(), chain_view),
+            general: RpcImpl::new(wallet, keystore.clone(), chain_view, sync_status),
             keystore,
             decryptor,
             async_ops: RwLock::new(Vec::new()),
@@ -824,7 +836,12 @@ impl<C: Chain> WalletRpcImpl<C> {
 #[async_trait]
 impl<C: Chain> RpcServer for RpcImpl<C> {
     async fn get_wallet_status(&self) -> get_wallet_status::Response {
-        get_wallet_status::call(self.wallet().await?.as_ref(), self.chain().await?).await
+        get_wallet_status::call(
+            self.wallet().await?.as_ref(),
+            self.chain().await?,
+            self.sync_status.clone(),
+        )
+        .await
     }
 
     async fn list_accounts(&self, include_addresses: Option<bool>) -> list_accounts::Response {
@@ -1014,6 +1031,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
     }
 
     async fn get_balances(&self, minconf: Option<u32>) -> get_balances::Response {
+        self.general.ensure_synced()?;
         get_balances::call(self.wallet().await?.as_ref(), minconf)
     }
 
@@ -1022,6 +1040,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         account: JsonValue,
         minconf: Option<u32>,
     ) -> z_get_balance_for_account::Response {
+        self.general.ensure_synced()?;
         z_get_balance_for_account::call(
             self.wallet().await?.as_ref(),
             &self.keystore,
@@ -1052,6 +1071,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         minconf: Option<u32>,
         include_watchonly: Option<bool>,
     ) -> z_get_total_balance::Response {
+        self.general.ensure_synced()?;
         z_get_total_balance::call(self.wallet().await?.as_ref(), minconf, include_watchonly)
     }
 
@@ -1063,6 +1083,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         addresses: Option<Vec<String>>,
         as_of_height: Option<i64>,
     ) -> list_unspent::Response {
+        self.general.ensure_synced()?;
         list_unspent::call(
             self.wallet().await?.as_ref(),
             minconf,
@@ -1078,6 +1099,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         minconf: Option<u32>,
         as_of_height: Option<i64>,
     ) -> get_notes_count::Response {
+        self.general.ensure_synced()?;
         get_notes_count::call(self.wallet().await?.as_ref(), minconf, as_of_height)
     }
 
@@ -1117,6 +1139,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
                     self.wallet().await?,
                     self.keystore.clone(),
                     self.chain().await?,
+                    self.general.sync_status.clone(),
                     fromaddress,
                     amounts,
                     minconf,
@@ -1141,6 +1164,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             self.wallet().await?,
             self.keystore.clone(),
             self.chain().await?,
+            self.general.sync_status.clone(),
             fromaddress,
             toaddress,
             fee,

--- a/zallet-core/src/components/json_rpc/methods/get_wallet_status.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_wallet_status.rs
@@ -13,6 +13,7 @@ use crate::{
         chain::{Chain, ChainView},
         database::DbConnection,
         json_rpc::server::LegacyCode,
+        sync::{SyncStatus, SyncStatusReader},
     },
     network::Network,
 };
@@ -53,6 +54,14 @@ pub(crate) struct GetWalletStatus {
     /// is equal to `wallet_tip.height`).
     #[serde(skip_serializing_if = "Option::is_none")]
     sync_work_remaining: Option<SyncWorkRemaining>,
+
+    /// Whether the wallet is currently locked because it is not synced with the chain.
+    ///
+    /// While locked, the balance and spend JSON-RPC methods return an error instead of
+    /// operating on an incomplete or untrustworthy view of the chain. This is the case
+    /// both while the wallet is still catching up to the chain tip and while it is
+    /// recovering from a detected chain reorganization.
+    locked: bool,
 }
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
@@ -85,7 +94,11 @@ struct Progress {
     denominator: u64,
 }
 
-pub(crate) async fn call<C: Chain>(wallet: &DbConnection, chain: C) -> Response {
+pub(crate) async fn call<C: Chain>(
+    wallet: &DbConnection,
+    chain: C,
+    sync_status: SyncStatusReader,
+) -> Response {
     let node_tip = chain
         .snapshot()
         .await
@@ -99,6 +112,10 @@ pub(crate) async fn call<C: Chain>(wallet: &DbConnection, chain: C) -> Response 
         .with(status_data)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
+    // The wallet is locked whenever the sync engine reports it is not fully synced
+    // (catching up to the tip, or recovering from a detected divergence).
+    let locked = !matches!(sync_status.status(), SyncStatus::Synced);
+
     Ok(GetWalletStatus {
         node_tip: ChainTip {
             blockhash: node_tip.hash().to_string(),
@@ -107,6 +124,7 @@ pub(crate) async fn call<C: Chain>(wallet: &DbConnection, chain: C) -> Response 
         wallet_tip: wallet_data.as_ref().map(|d| d.chain_tip()),
         fully_synced_height: wallet_data.as_ref().and_then(|d| d.fully_synced_height()),
         sync_work_remaining: wallet_data.as_ref().and_then(|d| d.sync_work_remaining()),
+        locked,
     })
 }
 

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -48,6 +48,7 @@ use crate::{
             server::LegacyCode,
         },
         keystore::KeyStore,
+        sync::SyncStatusReader,
     },
     fl,
     prelude::*,
@@ -135,6 +136,7 @@ pub(crate) async fn call<C: Chain>(
     mut wallet: DbHandle,
     keystore: KeyStore,
     chain: C,
+    sync_status: SyncStatusReader,
     fromaddress: String,
     amounts: Vec<AmountParameter>,
     minconf: Option<u32>,
@@ -364,6 +366,13 @@ pub(crate) async fn call<C: Chain>(
             )));
         }
     }
+
+    // The proposal has been built and validated. Before fetching key material and handing
+    // off the execution future, refuse the spend if the wallet is not synced enough to
+    // trust its view of the chain. This check is synchronous — it runs during the
+    // `call().await` in the dispatch layer, before the async operation is queued — so the
+    // caller sees the failure immediately rather than as a failed background operation.
+    sync_status.ensure_available()?;
 
     let derivation = account.source().key_derivation().ok_or_else(|| {
         LegacyCode::InvalidAddressOrKey

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -43,6 +43,7 @@ use crate::{
             utils::{JsonZec, value_from_zatoshis},
         },
         keystore::KeyStore,
+        sync::SyncStatusReader,
     },
     prelude::*,
 };
@@ -148,6 +149,7 @@ pub(crate) async fn call<C: Chain>(
     mut wallet: DbHandle,
     keystore: KeyStore,
     chain: C,
+    sync_status: SyncStatusReader,
     fromaddress: String,
     toaddress: String,
     fee: Option<JsonValue>,
@@ -279,6 +281,13 @@ pub(crate) async fn call<C: Chain>(
         shielding_utxos,
         shielding_value: value_from_zatoshis(shielding_value_zats),
     };
+
+    // The proposal has been built. Before fetching key material and handing off the
+    // execution future, refuse the spend if the wallet is not synced enough to trust its
+    // view of the chain. This check is synchronous — it runs during the `call().await` in
+    // the dispatch layer, before the async operation is queued — so the caller sees the
+    // failure immediately rather than as a failed background operation.
+    sync_status.ensure_available()?;
 
     // Derive the spending key for the source account.
     let derivation = account.source().key_derivation().ok_or_else(|| {

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use tokio::task::JoinHandle;
 
 use crate::{
-    components::{chain::Chain, database::Database},
+    components::{chain::Chain, database::Database, sync::SyncStatusReader},
     config::RpcSection,
     error::{Error, ErrorKind},
     fl,
@@ -39,6 +39,7 @@ pub(crate) async fn spawn<C: Chain>(
     #[cfg(zallet_build = "wallet")] keystore: KeyStore,
     chain: C,
     #[cfg(zallet_build = "wallet")] decryptor: WalletDecryptorHandle,
+    sync_status: SyncStatusReader,
 ) -> Result<ServerTask, Error> {
     // Caller should make sure `bind` only contains a single address (for now).
     assert_eq!(config.bind.len(), 1);
@@ -46,13 +47,19 @@ pub(crate) async fn spawn<C: Chain>(
 
     // Initialize the RPC methods.
     #[cfg(zallet_build = "wallet")]
-    let wallet_rpc_impl =
-        WalletRpcImpl::new(wallet.clone(), keystore.clone(), chain.clone(), decryptor);
+    let wallet_rpc_impl = WalletRpcImpl::new(
+        wallet.clone(),
+        keystore.clone(),
+        chain.clone(),
+        decryptor,
+        sync_status.clone(),
+    );
     let rpc_impl = RpcImpl::new(
         wallet,
         #[cfg(zallet_build = "wallet")]
         keystore,
         chain,
+        sync_status,
     );
 
     let timeout = config.timeout();

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -77,6 +77,9 @@ use crate::{config::ZalletConfig, error::Error, fl, network::Network};
 mod error;
 pub(crate) use error::SyncError;
 
+pub(crate) mod status;
+pub(crate) use status::{SyncStatus, SyncStatusReader, SyncStatusWriter};
+
 mod locator;
 mod steps;
 
@@ -105,6 +108,7 @@ impl WalletSync {
         shutdown_height: Option<BlockHeight>,
         decryptor: WalletDecryptorHandle,
         decryptor_engine: WalletDecryptorEngine,
+        status: SyncStatusWriter,
     ) -> Result<(TaskHandle, TaskHandle, TaskHandle, TaskHandle), Error> {
         let params = config.consensus.network();
         let recover_batch_size = config.sync.recover_batch_size();
@@ -126,6 +130,7 @@ impl WalletSync {
             db_data.as_mut(),
             decryptor.clone(),
             shutdown_height,
+            &status,
         )
         .await?;
 
@@ -144,6 +149,7 @@ impl WalletSync {
             let chain = chain.clone();
             let lower_boundary = current_boundary.clone();
             let decryptor = decryptor.clone();
+            let status = status.clone();
             crate::spawn!("Steady state sync", async move {
                 steady_state(
                     chain,
@@ -154,6 +160,7 @@ impl WalletSync {
                     tip_change_signal_source,
                     decryptor,
                     shutdown_height,
+                    status,
                 )
                 .await?;
                 Ok(())
@@ -173,6 +180,7 @@ impl WalletSync {
                     decryptor,
                     recover_batch_size,
                     shutdown_height,
+                    status,
                 )
                 .await?;
                 Ok(())
@@ -252,6 +260,7 @@ async fn initialize<C: Chain>(
     db_data: &mut DbConnection,
     decryptor: WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
+    status: &SyncStatusWriter,
 ) -> Result<(ChainBlock, BlockHeight), SyncError> {
     info!("Initializing wallet for syncing");
 
@@ -273,6 +282,7 @@ async fn initialize<C: Chain>(
         let current_tip = chain_view.tip().await.map_err(SyncError::Chain)?;
         info!("Latest block height is {}", current_tip.height());
         db_data.update_chain_tip(current_tip.height())?;
+        status.set_tip(current_tip.height());
 
         // Set the starting boundary between the `steady_state` and `recover_history` tasks.
         let starting_boundary = update_boundary(BlockHeight::from_u32(0), current_tip.height());
@@ -369,6 +379,10 @@ async fn initialize<C: Chain>(
             Err(error) => return Err(error),
         }
     };
+
+    // Publish the height to which the wallet is now fully scanned, so the RPC layer can
+    // tell whether the wallet has caught up enough to be usable.
+    status.set_fully_synced(db_data.block_fully_scanned()?.map(|m| m.block_height()));
 
     info!(
         "Initial boundary between recovery and steady-state sync is {}",
@@ -502,6 +516,7 @@ async fn steady_state<C: Chain>(
     tip_change_signal: Arc<Notify>,
     decryptor: WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
+    status: SyncStatusWriter,
 ) -> Result<(), SyncError> {
     info!("Steady-state sync task started");
 
@@ -519,6 +534,7 @@ async fn steady_state<C: Chain>(
             &tip_change_signal,
             &decryptor,
             shutdown_height,
+            &status,
         )
         .await
         {
@@ -574,6 +590,9 @@ async fn steady_state<C: Chain>(
                     );
                     let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
                     let fork_point = locate_fork_point(&chain_view, db_data, candidate_tip).await?;
+                    // Enter the recovering (safe-mode) state for the rewind and rescan;
+                    // `steady_state_iteration` clears it once we reach the chain tip again.
+                    status.begin_recovery(fork_point.height());
                     db_data.truncate_to_height(fork_point.height())?;
                     prev_tip = fork_point;
                     continue;
@@ -597,6 +616,7 @@ async fn steady_state_iteration<C: Chain>(
     tip_change_signal: &Notify,
     decryptor: &WalletDecryptorHandle,
     shutdown_height: Option<BlockHeight>,
+    status: &SyncStatusWriter,
 ) -> Result<ControlFlow<BlockHeight>, SyncError> {
     let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
     let current_tip = chain_view.tip().await.map_err(SyncError::Chain)?;
@@ -620,6 +640,7 @@ async fn steady_state_iteration<C: Chain>(
             })
             .expect("closure always returns Some");
         tip_change_signal.notify_one();
+        status.set_tip(current_tip.height());
 
         // Find where the wallet's history rejoins the backend's best chain.
         let fork_point = locate_fork_point(&chain_view, db_data, *prev_tip).await?;
@@ -642,6 +663,9 @@ async fn steady_state_iteration<C: Chain>(
                 fork_point.height(),
                 fork_point.hash()
             );
+            // Enter the recovering (safe-mode) state for the duration of the rewind and
+            // rescan; it is cleared below once we reach the chain tip again.
+            status.begin_recovery(fork_point.height());
             db_data.truncate_to_height(fork_point.height())?;
             *prev_tip = fork_point;
         };
@@ -685,6 +709,17 @@ async fn steady_state_iteration<C: Chain>(
         return Ok(ControlFlow::Break(boundary));
     }
 
+    // The wallet has applied every block up to the current tip. Publish how far it is
+    // fully scanned (which also reflects `recover_history`'s backfill), mark that steady
+    // state has reached the tip, and clear any recovering state now that the rewind (if
+    // any) has been rescanned.
+    status.set_fully_synced(db_data.block_fully_scanned()?.map(|m| m.block_height()));
+    status.mark_tip_reached();
+    // TODO(zcash/zallet#195): when this actually clears an in-progress recovery (i.e. on
+    // the `Recovering` → synced edge, not on every tip-reached), trigger an online backup
+    // so the recovered state is durably captured before any subsequent failure.
+    status.end_recovery();
+
     // If we have caught up to the chain tip, stream the mempool state into the wallet.
     match chain_view
         .get_mempool_stream()
@@ -720,6 +755,7 @@ async fn steady_state_iteration<C: Chain>(
 ///
 /// This function only operates on finalized chain state, and does not handle reorgs.
 #[tracing::instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
 async fn recover_history<C: Chain>(
     chain: C,
     params: &Network,
@@ -728,6 +764,7 @@ async fn recover_history<C: Chain>(
     decryptor: WalletDecryptorHandle,
     batch_size: u32,
     shutdown_height: Option<BlockHeight>,
+    status: SyncStatusWriter,
 ) -> Result<(), SyncError> {
     info!("History recovery sync task started");
 
@@ -787,6 +824,10 @@ async fn recover_history<C: Chain>(
                 // this range and let the next loop re-evaluate.
                 break;
             }
+
+            // Backfilling historic ranges advances the fully-scanned height; republish it
+            // so the RPC layer sees the wallet approach a complete view of the chain.
+            status.set_fully_synced(db_data.block_fully_scanned()?.map(|m| m.block_height()));
 
             // If scanning these blocks caused a suggested range to be added that has a
             // higher priority than the current range, invalidate the current ranges.

--- a/zallet-core/src/components/sync/status.rs
+++ b/zallet-core/src/components/sync/status.rs
@@ -1,0 +1,308 @@
+//! The sync engine's published status, and the gate that uses it.
+//!
+//! [`SyncStatus`] models the two conditions under which the wallet should not be used,
+//! mirroring `zcashd`:
+//!
+//! - [`SyncStatus::CatchingUp`] — the wallet has not yet scanned up to the chain tip, so
+//!   its balance is incomplete (analogous to initial block download).
+//! - [`SyncStatus::Recovering`] — the sync engine detected that the wallet’s view had
+//!   diverged from the chain (a reorg that occurred while Zallet was offline, or a live
+//!   reorg) and is rolling back and rescanning (analogous to safe mode).
+//!
+//! The status is owned and published by the sync engine — the only component that can
+//! observe a recovery in progress — and read by the JSON-RPC layer. It is published over
+//! a [`watch`] channel, so reading it is a cheap, non-blocking borrow with no network
+//! round-trip.
+
+use std::sync::Arc;
+
+use tokio::sync::watch;
+use zcash_protocol::consensus::BlockHeight;
+
+// `ensure_available` is only used by the wallet build’s balance and spend RPC methods.
+#[cfg(zallet_build = "wallet")]
+use {crate::components::json_rpc::server::LegacyCode, jsonrpsee::core::RpcResult};
+
+/// Whether the wallet is usable, and if not, why.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SyncStatus {
+    /// The wallet has not yet scanned up to the chain tip; its balance is incomplete.
+    CatchingUp {
+        fully_synced: Option<BlockHeight>,
+        tip: BlockHeight,
+    },
+    /// The wallet is synced to the chain tip and its view is trustworthy.
+    Synced,
+    /// A chain divergence was detected; the engine is rolling back and rescanning.
+    Recovering { rolled_back_to: BlockHeight },
+}
+
+/// The raw signals the sync engine maintains, from which [`SyncStatus`] is derived.
+#[derive(Clone, Debug)]
+struct SyncSignals {
+    /// The latest chain tip height observed from the indexer.
+    tip: BlockHeight,
+    /// The height to which the wallet is fully scanned (`block_fully_scanned`).
+    fully_synced: Option<BlockHeight>,
+    /// Whether steady-state sync has reached the chain tip at least once.
+    tip_reached: bool,
+    /// Set to the rollback target while a divergence is being repaired.
+    recovering: Option<BlockHeight>,
+}
+
+impl SyncSignals {
+    /// Derives the externally-visible status.
+    ///
+    /// `tolerance` is the maximum number of blocks the wallet may trail the tip while
+    /// still counting as synced. A wallet that is still backfilling historical state has
+    /// `fully_synced` far below the tip, so it derives [`SyncStatus::CatchingUp`].
+    fn status(&self, tolerance: u32) -> SyncStatus {
+        // A detected divergence takes priority: even if we happen to be near the tip, the
+        // wallet's view is being repaired and must not be used.
+        if let Some(rolled_back_to) = self.recovering {
+            return SyncStatus::Recovering { rolled_back_to };
+        }
+        let within_tip = self
+            .fully_synced
+            .is_some_and(|fs| u32::from(self.tip).saturating_sub(u32::from(fs)) <= tolerance);
+        if self.tip_reached && within_tip {
+            SyncStatus::Synced
+        } else {
+            SyncStatus::CatchingUp {
+                fully_synced: self.fully_synced,
+                tip: self.tip,
+            }
+        }
+    }
+}
+
+/// Writer half, held by the sync engine and shared across its tasks.
+///
+/// [`watch::Sender::send_modify`] takes `&self`, so the sync tasks can share this (via the
+/// inner [`Arc`]) and update it concurrently; the channel serializes updates.
+#[derive(Clone)]
+pub(crate) struct SyncStatusWriter(Arc<watch::Sender<SyncSignals>>);
+
+impl SyncStatusWriter {
+    /// Records the latest observed chain tip height.
+    pub(crate) fn set_tip(&self, tip: BlockHeight) {
+        self.0.send_modify(|s| s.tip = tip);
+    }
+
+    /// Records the height to which the wallet is now fully scanned.
+    pub(crate) fn set_fully_synced(&self, fully_synced: Option<BlockHeight>) {
+        self.0.send_modify(|s| s.fully_synced = fully_synced);
+    }
+
+    /// Marks that steady-state sync has reached the chain tip.
+    pub(crate) fn mark_tip_reached(&self) {
+        self.0.send_modify(|s| s.tip_reached = true);
+    }
+
+    /// Engages the recovering (safe-mode) state while a divergence is repaired.
+    pub(crate) fn begin_recovery(&self, rolled_back_to: BlockHeight) {
+        self.0.send_modify(|s| s.recovering = Some(rolled_back_to));
+    }
+
+    /// Clears the recovering state once the wallet has caught back up.
+    pub(crate) fn end_recovery(&self) {
+        self.0.send_modify(|s| s.recovering = None);
+    }
+}
+
+/// Reader half, held by the JSON-RPC layer.
+#[derive(Clone)]
+pub(crate) struct SyncStatusReader {
+    rx: watch::Receiver<SyncSignals>,
+    tolerance: u32,
+}
+
+impl SyncStatusReader {
+    /// The current sync status.
+    pub(crate) fn status(&self) -> SyncStatus {
+        self.rx.borrow().status(self.tolerance)
+    }
+
+    /// Returns an error if the wallet is not synced enough to be used.
+    ///
+    /// Used to gate balance and spend methods: catching up maps to the "still in initial
+    /// download" error, and recovering to the "forbidden by safe mode" error.
+    #[cfg(zallet_build = "wallet")]
+    pub(crate) fn ensure_available(&self) -> RpcResult<()> {
+        match self.status() {
+            SyncStatus::Synced => Ok(()),
+            SyncStatus::CatchingUp { fully_synced, tip } => {
+                let behind = fully_synced.map_or_else(
+                    || u32::from(tip),
+                    |fs| u32::from(tip).saturating_sub(u32::from(fs)),
+                );
+                Err(LegacyCode::ClientInInitialDownload.with_message(format!(
+                    "Wallet is still catching up ({behind} blocks behind the chain tip); \
+                     balance and spend operations are unavailable until it is synced"
+                )))
+            }
+            SyncStatus::Recovering { rolled_back_to } => {
+                Err(LegacyCode::ForbiddenBySafeMode.with_message(format!(
+                    "Wallet is recovering from a chain reorganization (rolled back to \
+                     {rolled_back_to}); balance and spend operations are unavailable until \
+                     it has resynced"
+                )))
+            }
+        }
+    }
+}
+
+/// Creates a linked writer/reader pair, initially [`SyncStatus::CatchingUp`].
+///
+/// `tolerance` is the maximum number of blocks the wallet may trail the chain tip while
+/// still being considered synced (the `sync.lock_threshold` config option).
+pub(crate) fn channel(tolerance: u32) -> (SyncStatusWriter, SyncStatusReader) {
+    let (tx, rx) = watch::channel(SyncSignals {
+        tip: BlockHeight::from_u32(0),
+        fully_synced: None,
+        tip_reached: false,
+        recovering: None,
+    });
+    (
+        SyncStatusWriter(Arc::new(tx)),
+        SyncStatusReader { rx, tolerance },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_protocol::consensus::BlockHeight;
+
+    use super::{SyncSignals, SyncStatus};
+
+    fn h(height: u32) -> BlockHeight {
+        BlockHeight::from_u32(height)
+    }
+
+    fn signals() -> SyncSignals {
+        SyncSignals {
+            tip: h(1000),
+            fully_synced: Some(h(1000)),
+            tip_reached: true,
+            recovering: None,
+        }
+    }
+
+    #[test]
+    fn synced_when_at_tip_and_reached() {
+        assert_eq!(signals().status(100), SyncStatus::Synced);
+        // Within tolerance still counts as synced.
+        let s = SyncSignals {
+            fully_synced: Some(h(950)),
+            ..signals()
+        };
+        assert_eq!(s.status(100), SyncStatus::Synced);
+    }
+
+    #[test]
+    fn catching_up_before_tip_reached() {
+        let s = SyncSignals {
+            tip_reached: false,
+            ..signals()
+        };
+        assert!(matches!(s.status(100), SyncStatus::CatchingUp { .. }));
+    }
+
+    #[test]
+    fn catching_up_when_backfilling_history() {
+        // Tip reached, but historical state is unscanned, so `fully_synced` trails far
+        // behind the tip.
+        let s = SyncSignals {
+            fully_synced: Some(h(200)),
+            ..signals()
+        };
+        assert!(matches!(s.status(100), SyncStatus::CatchingUp { .. }));
+    }
+
+    #[test]
+    fn catching_up_when_never_synced() {
+        let s = SyncSignals {
+            fully_synced: None,
+            ..signals()
+        };
+        assert!(matches!(s.status(100), SyncStatus::CatchingUp { .. }));
+    }
+
+    #[test]
+    fn recovering_takes_priority_over_being_at_tip() {
+        let s = SyncSignals {
+            recovering: Some(h(900)),
+            ..signals()
+        };
+        assert_eq!(
+            s.status(100),
+            SyncStatus::Recovering {
+                rolled_back_to: h(900)
+            }
+        );
+    }
+
+    #[test]
+    fn synced_at_exact_tolerance_boundary_but_not_one_past() {
+        // Trailing the tip by exactly `tolerance` still counts as synced (tip 1000,
+        // fully_synced 900, tolerance 100).
+        let at = SyncSignals {
+            fully_synced: Some(h(900)),
+            ..signals()
+        };
+        assert_eq!(at.status(100), SyncStatus::Synced);
+        // One block further behind tips over into catching up.
+        let past = SyncSignals {
+            fully_synced: Some(h(899)),
+            ..signals()
+        };
+        assert!(matches!(past.status(100), SyncStatus::CatchingUp { .. }));
+    }
+
+    #[test]
+    fn channel_starts_catching_up() {
+        let (_writer, reader) = super::channel(100);
+        assert!(matches!(reader.status(), SyncStatus::CatchingUp { .. }));
+    }
+
+    #[test]
+    fn writer_updates_flow_through_to_the_reader() {
+        let (writer, reader) = super::channel(100);
+
+        writer.set_tip(h(1000));
+        writer.set_fully_synced(Some(h(1000)));
+        writer.mark_tip_reached();
+        assert_eq!(reader.status(), SyncStatus::Synced);
+
+        // A recovery overrides the synced view until it is cleared.
+        writer.begin_recovery(h(900));
+        assert_eq!(
+            reader.status(),
+            SyncStatus::Recovering {
+                rolled_back_to: h(900)
+            }
+        );
+
+        writer.end_recovery();
+        assert_eq!(reader.status(), SyncStatus::Synced);
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn ensure_available_maps_each_state_to_its_error_code() {
+        let (writer, reader) = super::channel(100);
+
+        // Initial state is catching up → `ClientInInitialDownload`.
+        assert_eq!(reader.ensure_available().unwrap_err().code(), -10);
+
+        // Synced → available.
+        writer.set_tip(h(1000));
+        writer.set_fully_synced(Some(h(1000)));
+        writer.mark_tip_reached();
+        assert!(reader.ensure_available().is_ok());
+
+        // Recovering → `ForbiddenBySafeMode`.
+        writer.begin_recovery(h(900));
+        assert_eq!(reader.ensure_available().unwrap_err().code(), -2);
+    }
+}

--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -827,6 +827,15 @@ pub struct SyncSection {
     /// Mainnet blocks can currently be up to 2 MiB each, so a batch of N blocks can require
     /// on the order of N * 2 MiB of memory.
     pub recover_batch_size: Option<NonZeroU32>,
+
+    /// The maximum number of blocks the wallet may lag behind the chain tip while still
+    /// being considered synced.
+    ///
+    /// While the wallet is further than this behind the tip (or has not yet reached the
+    /// tip for the first time), it is treated as still catching up, and the balance and
+    /// spend JSON-RPC methods return an error rather than operating on an incomplete view
+    /// of the chain. The default matches the reorg/finality boundary the sync engine uses.
+    pub lock_threshold: Option<u32>,
 }
 
 impl SyncSection {
@@ -836,6 +845,14 @@ impl SyncSection {
     /// Default is 1000.
     pub fn recover_batch_size(&self) -> u32 {
         self.recover_batch_size.map_or(1000, NonZeroU32::get)
+    }
+
+    /// The maximum number of blocks the wallet may lag behind the chain tip while still
+    /// being considered synced.
+    ///
+    /// Default is 100.
+    pub fn lock_threshold(&self) -> u32 {
+        self.lock_threshold.unwrap_or(100)
     }
 }
 
@@ -897,6 +914,7 @@ impl ZalletConfig {
             rpc("bind", &conf.rpc.bind),
             rpc("timeout", conf.rpc.timeout().as_secs()),
             sync("recover_batch_size", conf.sync.recover_batch_size()),
+            sync("lock_threshold", conf.sync.lock_threshold()),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -1305,5 +1323,25 @@ zebra_state_path = "/home/user/.cache/zebra"
     #[test]
     fn sync_section_rejects_zero_batch_size() {
         assert!(toml::from_str::<super::SyncSection>("recover_batch_size = 0").is_err());
+    }
+
+    #[test]
+    fn sync_section_uses_default_lock_threshold_when_unset() {
+        let section: super::SyncSection = toml::from_str("").unwrap();
+        assert_eq!(section.lock_threshold(), 100);
+    }
+
+    #[test]
+    fn sync_section_parses_lock_threshold_override() {
+        let section: super::SyncSection = toml::from_str("lock_threshold = 42").unwrap();
+        assert_eq!(section.lock_threshold(), 42);
+    }
+
+    #[test]
+    fn sync_section_accepts_zero_lock_threshold() {
+        // Unlike `recover_batch_size`, a threshold of 0 is meaningful (synced only when
+        // fully scanned exactly to the tip), so it must be accepted.
+        let section: super::SyncSection = toml::from_str("lock_threshold = 0").unwrap();
+        assert_eq!(section.lock_threshold(), 0);
     }
 }


### PR DESCRIPTION
Add a global sync lock that blocks wallet usage while Zallet’s view of the
chain is not trustworthy, mirroring `zcashd`’s two guards — initial block
download and safe mode. Fixes #180.

## What it does

The sync engine publishes a `SyncStatus` over a `watch` channel — it is the
only component that can observe a recovery in progress — and the JSON-RPC layer
reads it as a cheap, non-blocking borrow (no network round-trip):

- **`CatchingUp`** — the wallet has not yet scanned up to the chain tip, so its
  balance is incomplete (analogous to initial block download). Mapped to
  `ClientInInitialDownload (-10)`.
- **`Recovering`** — the engine is rolling back and rescanning after detecting
  that the wallet’s view diverged from the chain (analogous to safe mode).
  Mapped to `ForbiddenBySafeMode (-2)`.
- **`Synced`** — the wallet’s view is trustworthy.

The engine drives the transitions as it scans, reorgs, and recovers, so the
lock releases naturally once the wallet reaches the tip. The balance reads
(`z_getbalances`, `z_getbalanceforaccount`, `z_gettotalbalance`,
`z_listunspent`, `z_getnotescount`) gate at the handler; the spends
(`z_sendmany`, `z_shieldcoinbase`) gate synchronously once the proposal is built
and before the execution future is queued, so a locked wallet fails the request
immediately rather than as a failed background operation. `getwalletstatus`
reports a `locked` field from the same status, and the new `sync.lock_threshold`
config option sets how far the wallet may lag the tip before it is considered to
be catching up (default 100).

## Relationship to the design questions in #180

**IBD vs. Safe Mode (what the lock is over).** Both are modeled explicitly:
`CatchingUp` (the wallet hasn’t scanned up to the tip — initial block download)
and `Recovering` (a detected chain divergence is being rolled back and rescanned
— safe mode), returning `ClientInInitialDownload (-10)` and
`ForbiddenBySafeMode (-2)` respectively. In `zcashd`, IBD blocks most RPCs until
near the tip, while Safe Mode disables a per-command set of wallet-balance-relying
RPCs. This PR gates the same set — the balance reads (`z_getbalances`,
`z_getbalanceforaccount`, `z_gettotalbalance`, `z_listunspent`,
`z_getnotescount`) and the spends (`z_sendmany`, `z_shieldcoinbase`) — for *both*
states, since in either case the wallet’s balance view is not trustworthy.
(`getwalletinfo` also reports balances but is currently stubbed to zero — #55 —
so it will join the gated set when it is implemented.)

**“Require full sync” mode.** The lock implements the highest-reliability option
from the thread: while the wallet is not fully scanned to within
`sync.lock_threshold` blocks of the tip (using `block_fully_scanned`, the
in-order fully-scanned height), balance and spend RPCs error rather than operate
on an incomplete view. This deliberately sidesteps the spend-before-sync
balance-invariant problem for the gated methods.

**The on-restart reorg recovery** the issue describes (truncate back and resync)
is now handled by the sync engine’s own `locate_fork_point` → `truncate_to_height`
path, which rolls back to the actual fork point rather than a fixed depth; this
PR surfaces that as the `Recovering` state rather than reimplementing it.

**Deferred, with rationale:**

- *Selectable spendability modes* (pure spend-before-sync, or SBS + a spendability
  oracle, vs. require-full-sync). The oracle doesn’t exist and SBS is the
  underlying default; a mode selector is a larger feature, and this lock is
  forward-compatible as one such mode.
- *Configurable / multiple locks.* This ships a single lock over a fixed,
  security-relevant set with one knob (`sync.lock_threshold`). Per-method or
  multi-lock granularity adds config surface with no concrete use case yet.
- *Online backup on exiting safe mode* (@daira, #195). Blocked on #195; the
  natural hook is the `end_recovery` transition, where a `TODO(#195)` marker now
  records the intent.
- *The broader “when is Zallet ready for use” discussion* is out of scope here;
  this lock is a concrete step consistent with any eventual answer.

## Testing

- New unit tests in `sync::status`:
  - `ensure_available` maps each state to its error code (`CatchingUp` → `-10`,
    `Synced` → `Ok`, `Recovering` → `-2`).
  - writer methods flow through the `watch` channel to the reader, including a
    recovery overriding and then clearing the synced view.
  - the channel starts locked (`CatchingUp`), not `Synced`.
  - the `lock_threshold` tolerance boundary is exact (trailing by exactly the
    threshold is still `Synced`; one more is `CatchingUp`).
  - plus the existing derivation tests for `SyncStatus`.
- New `SyncSection` config tests: `lock_threshold` default (100), override, and
  that `0` is accepted (unlike `recover_batch_size`, which rejects it).
- `zallet-core`: `clippy --all-targets -- -D warnings` clean, and again with
  `--features zcashd-import`.
- `book_rpc_reference` and the `cli_tests` golden configs (incl. the regenerated
  `example_config`) pass.
- Not unit-tested (would need a full RPC harness with a live `Chain`/database):
  the RPC-dispatch gate wiring — a one-line `ensure_synced()?` whose logic is
  covered by the `ensure_available` test — and the engine transition points in
  `sync.rs`.
- Manual end-to-end against a live external Zaino (offline reorg → `Recovering`
  / `CatchingUp` → balance/spend rejected → `Synced`) still to be exercised.
