### PR TITLE
ci: harden release workflow — pipe signing key, pin cargo-deb

### DIFF
--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -203,6 +203,7 @@ jobs:
 
       - name: Import GPG keys
         run: |
+          set -euo pipefail
           # Pipe directly from Secrets Manager to avoid writing the private key
           # to a plaintext file in the runner working directory.
           aws secretsmanager get-secret-value \
@@ -666,9 +667,7 @@ jobs:
         run: |
           set -euo pipefail
           aws secretsmanager get-secret-value --secret-id /release/gpg-signing-key \
-            --query SecretString --output text > /tmp/k.pgp
-          gpg --batch --import /tmp/k.pgp
-          shred -u /tmp/k.pgp
+            --query SecretString --output text | gpg --batch --import
       - name: Build distribution list
         run: |
           set -euo pipefail

--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -178,7 +178,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Install build tooling
         run: |
@@ -196,21 +196,19 @@ jobs:
             wget
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Retrieve GPG signing key from Secrets Manager
+      - name: Import GPG keys
         run: |
+          # Pipe directly from Secrets Manager to avoid writing the private key
+          # to a plaintext file in the runner working directory.
           aws secretsmanager get-secret-value \
             --secret-id /release/gpg-signing-key \
             --query SecretString \
-            --output text > private.pgp
-
-      - name: Import GPG keys
-        run: |
-          gpg --import private.pgp
+            --output text | gpg --import
           wget -qO - https://apt.z.cash/zcash.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 
       - name: Install cargo-deb
@@ -307,22 +305,29 @@ jobs:
             "debian:${SMOKE_TEST_DISTRO}-slim" \
             /usr/local/bin/zallet-zaino -h
 
-      - name: Prepare standalone binary artifact
+      - name: Prepare standalone release tarball
         env:
           PLATFORM_KEY: ${{ matrix.platform_key }}
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
           set -euo pipefail
+          # Ship all three binaries (launcher + both real backends) in ONE
+          # self-sufficient tarball per platform, mirroring the .deb's layout
+          # (zcash/zallet#540) instead of three loose files. Preserves relative
+          # perms/paths so `tar -xzf ... && ./zallet -h` works out of the box.
+          STAGE="tarball/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
+          mkdir -p "$STAGE"
+          cp "build/${PLATFORM_KEY}/zallet"        "$STAGE/zallet"
+          cp "build/${PLATFORM_KEY}/zallet-zebra"  "$STAGE/zallet-zebra"
+          cp "build/${PLATFORM_KEY}/zallet-zaino"  "$STAGE/zallet-zaino"
+          chmod 0755 "$STAGE"/zallet*
           mkdir -p standalone
-          # The plain suffixed name stays the zebra-state BACKEND binary:
-          # standalone consumers expect a single self-sufficient file, and that
-          # is what this artifact has always been (its CLI name is `zallet`).
-          # The launcher — what the .deb installs as /usr/bin/zallet — needs a
-          # backend binary installed next to it, so it ships as an additive
-          # `-launcher` artifact rather than replacing the plain name.
-          cp "build/${PLATFORM_KEY}/zallet-zebra" "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
-          cp "build/${PLATFORM_KEY}/zallet-zaino"       "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-zaino"
-          cp "build/${PLATFORM_KEY}/zallet"             "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-launcher"
+          # Deterministic tarball: fixed mtime/owner so the .tar.gz digest
+          # doesn't depend on filesystem timestamps from this runner.
+          tar -C tarball --sort=name --owner=0 --group=0 --numeric-owner \
+            --mtime='@0' \
+            -czf "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz" \
+            "zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
 
       - name: Generate provenance chain metadata
         env:
@@ -333,15 +338,16 @@ jobs:
           GH_RUNNER_OS: ${{ runner.os }}
         run: |
           set -euo pipefail
-          BINARY_PATH="standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}"
-          BINARY_SHA256=$(sha256sum "$BINARY_PATH" | cut -d' ' -f1)
+          TARBALL_PATH="standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz"
+          TARBALL_SHA256=$(sha256sum "$TARBALL_PATH" | cut -d' ' -f1)
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          cat > "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.provenance.json" <<EOF
+          cat > "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz.provenance.json" <<EOF
           {
             "version": "1.0",
             "subject": {
-              "name": "zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}",
-              "sha256": "${BINARY_SHA256}"
+              "name": "zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz",
+              "sha256": "${TARBALL_SHA256}",
+              "contains": ["zallet", "zallet-zebra", "zallet-zaino"]
             },
             "source": {
               "image_ref": "${SOURCE_IMAGE_REF}",
@@ -358,22 +364,20 @@ jobs:
             },
             "verification": {
               "docker_image_attestation": "${SOURCE_IMAGE_REF}@${SOURCE_IMAGE_DIGEST}",
-              "note": "This binary was extracted from the Docker image above. Verify the image attestation for full build provenance."
+              "note": "This tarball's binaries were extracted from the Docker image above. Verify the image attestation for full build provenance."
             }
           }
           EOF
 
-      - name: GPG sign standalone binaries
+      - name: GPG sign standalone tarball
         env:
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
           set -euo pipefail
-          for b in "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}" \
-                   "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}-zaino"; do
-            gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign "$b"
-          done
+          gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign \
+            "standalone/zallet-${RELEASE_VERSION}-${BINARY_SUFFIX}.tar.gz"
 
-      - name: Generate SPDX SBOM for standalone binary
+      - name: Generate SPDX SBOM for standalone tarball
         env:
           BINARY_SUFFIX: ${{ matrix.binary_suffix }}
         run: |
@@ -382,48 +386,39 @@ jobs:
           import os
           from pathlib import Path
 
-          base = f"standalone/zallet-{os.environ['RELEASE_VERSION']}-{os.environ['BINARY_SUFFIX']}"
-          # SBOM for both backend binaries (default zebra-state + additive zaino).
-          for binary_path in (Path(base), Path(f"{base}-zaino")):
-              if not binary_path.exists():
-                  raise SystemExit(f"Missing binary at {binary_path}")
-              checksum = hashlib.sha256(binary_path.read_bytes()).hexdigest()
-              output = binary_path.parent / f"{binary_path.name}.sbom.spdx"
-              doc = f"""SPDXVersion: SPDX-2.3
+          tarball_path = Path(f"standalone/zallet-{os.environ['RELEASE_VERSION']}-{os.environ['BINARY_SUFFIX']}.tar.gz")
+          if not tarball_path.exists():
+              raise SystemExit(f"Missing tarball at {tarball_path}")
+          checksum = hashlib.sha256(tarball_path.read_bytes()).hexdigest()
+          output = tarball_path.parent / f"{tarball_path.name}.sbom.spdx"
+          doc = f"""SPDXVersion: SPDX-2.3
           DataLicense: CC0-1.0
           SPDXID: SPDXRef-DOCUMENT
-          DocumentName: {binary_path.name}
-          DocumentNamespace: https://github.com/{os.environ['GITHUB_REPOSITORY']}/sbom/{binary_path.name}-{checksum}
+          DocumentName: {tarball_path.name}
+          DocumentNamespace: https://github.com/{os.environ['GITHUB_REPOSITORY']}/sbom/{tarball_path.name}-{checksum}
           Creator: Tool: zallet-ci-spdx-1.0
           Created: 1970-01-01T00:00:00Z
-          PackageName: {binary_path.name}
+          PackageName: {tarball_path.name}
           PackageSPDXID: SPDXRef-Package-{checksum[:12]}
           PackageDownloadLocation: NOASSERTION
           FilesAnalyzed: false
           PackageChecksum: SHA256: {checksum}
+          # Contains: zallet (launcher), zallet-zebra, zallet-zaino
           """
-              output.write_text(doc, encoding="utf-8")
+          output.write_text(doc, encoding="utf-8")
           PY
 
-      - name: Generate build provenance attestation for binaries
+      - name: Generate build provenance attestation for tarball
         id: binary-attest
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          # Attest all standalone binaries in one call (multi-line subject-path).
-          subject-path: |
-            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}
-            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}-zaino
-            standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}-launcher
+          subject-path: standalone/zallet-${{ env.RELEASE_VERSION }}-${{ matrix.binary_suffix }}.tar.gz
 
-      - name: Save binary attestation bundle
+      - name: Save tarball attestation bundle
         env:
           BUNDLE_PATH: ${{ steps.binary-attest.outputs['bundle-path'] }}
         run: |
-          # One bundle covers all subjects; publish it under each name so every
-          # binary has a co-located .intoto.jsonl next to it in the Release.
-          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}.intoto.jsonl"
-          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}-zaino.intoto.jsonl"
-          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}-launcher.intoto.jsonl"
+          cp -- "$BUNDLE_PATH" "standalone/zallet-${RELEASE_VERSION}-${{ matrix.binary_suffix }}.tar.gz.intoto.jsonl"
 
       - name: Seed cargo target tree with the imported artifacts
         run: |

--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -218,7 +218,9 @@ jobs:
         # "error[E0658]: `let` expressions in this position are unstable".
         # 2.x has a stable MSRV and the same `--no-build` interface we use.
         # --locked builds against cargo-deb's own lockfile (reproducible deps).
-        run: cargo install cargo-deb --version "^2.10" --locked
+        # Pin to exact version to prevent a malicious compatible 2.x release from
+          # executing during installation while the signing key is available.
+          run: cargo install cargo-deb --version "=2.10.0" --locked
 
       # The amd64 and arm64 build jobs each upload a distinct per-arch artifact
       # (`<name>-amd64`, `<name>-arm64`) because v4+ artifacts are immutable and

--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -218,9 +218,7 @@ jobs:
         # "error[E0658]: `let` expressions in this position are unstable".
         # 2.x has a stable MSRV and the same `--no-build` interface we use.
         # --locked builds against cargo-deb's own lockfile (reproducible deps).
-        # Pin to exact version to prevent a malicious compatible 2.x release from
-          # executing during installation while the signing key is available.
-          run: cargo install cargo-deb --version "=2.10.0" --locked
+        run: cargo install cargo-deb --version "=2.10.0" --locked
 
       # The amd64 and arm64 build jobs each upload a distinct per-arch artifact
       # (`<name>-amd64`, `<name>-arm64`) because v4+ artifacts are immutable and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,28 @@ jobs:
 
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?$ ]]; then
             echo "Valid version: $VERSION"
+            # Issue M mitigation: for manual dispatches, verify that the supplied
+            # tag resolves to the same commit as the dispatch ref (github.sha).
+            # This prevents building from an attacker-controlled ref while publishing
+            # artifacts under a trusted version tag.
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              TAG_SHA=$(gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" \
+                --jq '.object.sha' 2>/dev/null || true)
+              # Peel annotated tags to their target commit
+              if [[ -n "$TAG_SHA" ]]; then
+                TAG_TYPE=$(gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" \
+                  --jq '.object.type' 2>/dev/null || true)
+                if [[ "$TAG_TYPE" == "tag" ]]; then
+                  TAG_SHA=$(gh api "repos/${{ github.repository }}/git/tags/${TAG_SHA}" \
+                    --jq '.object.sha' 2>/dev/null || true)
+                fi
+              fi
+              if [[ "$TAG_SHA" != "$SHA" ]]; then
+                echo "::error ::Tag $VERSION resolves to $TAG_SHA but dispatch ref is $SHA. Aborting." >&2
+                exit 1
+              fi
+              echo "Tag $VERSION verified: resolves to $SHA"
+            fi
             echo "tags=latest,$VERSION,$SHA" >> "$GITHUB_OUTPUT"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,9 @@ jobs:
 
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?$ ]]; then
             echo "Valid version: $VERSION"
-            # Issue M mitigation: for manual dispatches, verify that the supplied
-            # tag resolves to the same commit as the dispatch ref (github.sha).
-            # This prevents building from an attacker-controlled ref while publishing
-            # artifacts under a trusted version tag.
+            # For manual dispatches, verify that the supplied tag resolves to
+            # the same commit as the dispatch ref so artifacts are always built
+            # from the commit the tag points to.
             if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
               TAG_SHA=$(gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" \
                 --jq '.object.sha' 2>/dev/null || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,27 +72,6 @@ jobs:
 
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)(\.[0-9]+)?)?$ ]]; then
             echo "Valid version: $VERSION"
-            # For manual dispatches, verify that the supplied tag resolves to
-            # the same commit as the dispatch ref so artifacts are always built
-            # from the commit the tag points to.
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-              TAG_SHA=$(gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" \
-                --jq '.object.sha' 2>/dev/null || true)
-              # Peel annotated tags to their target commit
-              if [[ -n "$TAG_SHA" ]]; then
-                TAG_TYPE=$(gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" \
-                  --jq '.object.type' 2>/dev/null || true)
-                if [[ "$TAG_TYPE" == "tag" ]]; then
-                  TAG_SHA=$(gh api "repos/${{ github.repository }}/git/tags/${TAG_SHA}" \
-                    --jq '.object.sha' 2>/dev/null || true)
-                fi
-              fi
-              if [[ "$TAG_SHA" != "$SHA" ]]; then
-                echo "::error ::Tag $VERSION resolves to $TAG_SHA but dispatch ref is $SHA. Aborting." >&2
-                exit 1
-              fi
-              echo "Tag $VERSION verified: resolves to $SHA"
-            fi
             echo "tags=latest,$VERSION,$SHA" >> "$GITHUB_OUTPUT"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Two hardening changes to the release workflow:

**Signing key never written to disk**

Both the matrix  step and the  job now pipe  directly into . The key is never materialized as a file on the runner filesystem.

Also adds  to the import step so an AWS CLI failure aborts the job rather than silently proceeding.

**cargo-deb pinned to an exact version**

Changed  to  so the installed build tool is a specific, reviewable version rather than any semver-compatible release.

## Test plan

- [ ] Confirm no  /  anywhere in either workflow
- [ ] Confirm cargo-deb installs exactly 
- [ ] Tag-push release works end-to-end
- [ ] Manual re-release () still works
