### PR TITLE
security hardening improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ be considered breaking changes.
   responses (which can carry secrets) are no longer written to logs.
 - The `builder.limits.orchard_actions` transaction-size limit now applies to
   each shielded pool's spends and outputs, not only Orchard's.
+- Empty JSON-RPC passwords are now rejected, both by `add-rpc-user` and when
+  loading a bare `rpc.auth` password from the config.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,23 @@ be considered breaking changes.
   initialized wallet, or a running `zallet start`. The command argument may
   now be passed bare (`zallet rpc help getwalletinfo`) in addition to the
   JSON-quoted form.
+- The `FullPrivacy` policy (and every stricter-than-`AllowRevealedAmounts`
+  policy) now rejects value crossing between any pair of shielded pools,
+  including crossings into or out of the Ironwood pool, instead of only
+  Sapling/Orchard crossings.
+- `generate-encryption-identity --passphrase` now rejects an empty passphrase,
+  which would have produced an effectively unencrypted identity file.
+- The data directory is now restricted to mode 0700 and the wallet database
+  file to 0600 on Unix.
+- JSON-RPC calls are now logged by method name only; call parameters and
+  responses (which can carry secrets) are no longer written to logs.
+- The `builder.limits.orchard_actions` transaction-size limit now applies to
+  each shielded pool's spends and outputs, not only Orchard's.
+- `zallet rpc help` is now answered locally instead of being sent to the
+  wallet's JSON-RPC server, so it no longer requires a config file, an
+  initialized wallet, or a running `zallet start`. The command argument may
+  now be passed bare (`zallet rpc help getwalletinfo`) in addition to the
+  JSON-quoted form.
 - The standalone release binaries are now published as one signed archive per
   platform, `zallet-<version>-<arch>.tar.gz`, containing all three binaries
   (`zallet`, `zallet-zebra`, `zallet-zaino`). Previously each binary was a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ be considered breaking changes.
 
 ### Removed
 
+- The `ZALLET_IDENTITY_PASSPHRASE` environment variable is no longer read by
+  `generate-encryption-identity`; environment variables are visible to other
+  processes on many platforms. Use the new `--passphrase-file` option (`-` for
+  standard input, or a file descriptor such as `/dev/fd/3`) instead.
 - The `migrate-zcashd-wallet --buffer-wallet-transactions` flag has been removed.
   All wallet transactions are now always imported directly, so the flag no longer
   has any effect.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,6 +5798,7 @@ dependencies = [
  "sha2 0.10.9",
  "shadow-rs",
  "shardtree",
+ "subtle",
  "syn",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ rand = "0.8"
 
 # Secret management
 secrecy = { version = "0.8", features = ["serde"] }
+subtle = "2"
 
 # CLI
 abscissa_core = "0.9"

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -6947,6 +6947,7 @@ dependencies = [
  "sha2 0.10.9",
  "shadow-rs",
  "shardtree",
+ "subtle",
  "syn 2.0.119",
  "tempfile",
  "time",

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -6546,6 +6546,7 @@ dependencies = [
  "sha2 0.10.9",
  "shadow-rs",
  "shardtree",
+ "subtle",
  "syn 2.0.118",
  "tempfile",
  "time",

--- a/backends/zebra/tests/acceptance.rs
+++ b/backends/zebra/tests/acceptance.rs
@@ -358,24 +358,36 @@ fn generate_encryption_identity_creates_missing_parent_dir() {
     );
 }
 
-/// With `-p` and `ZALLET_IDENTITY_PASSPHRASE` set, the identity file is written
-/// passphrase-encrypted (ASCII-armored) and the command succeeds. Spawned
-/// directly so the child gets the env var without `std::env::set_var` (which is
-/// `unsafe` under edition 2024, and this file is `#![forbid(unsafe_code)]`).
+/// With `-p` and `--passphrase-file -`, the passphrase is read from standard
+/// input, and the identity file is written passphrase-encrypted
+/// (ASCII-armored).
 #[cfg(zallet_build = "wallet")]
 #[test]
 fn generate_encryption_identity_passphrase_writes_armored_file() {
+    use std::io::Write as _;
+
     let datadir = tempdir().unwrap();
     let identity_file = datadir.path().join("encryption-identity.txt");
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_zallet-zebra"))
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_zallet-zebra"))
         .arg("--datadir")
         .arg(datadir.path())
         .arg("generate-encryption-identity")
         .arg("-p")
-        .env("ZALLET_IDENTITY_PASSPHRASE", "test-passphrase")
-        .output()
+        .arg("--passphrase-file")
+        .arg("-")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
         .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"test-passphrase\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
     assert!(
         output.status.success(),
         "stderr: {}",

--- a/book/src/cli/generate-encryption-identity.md
+++ b/book/src/cli/generate-encryption-identity.md
@@ -43,15 +43,18 @@ Public key: age1...
 
 With `-p/--passphrase`, the identity is passphrase-encrypted and ASCII-armored. In
 interactive use you are prompted for the passphrase (with confirmation). In non-interactive
-contexts (for example, automated test setup), the passphrase is read from the
-`ZALLET_IDENTITY_PASSPHRASE` environment variable instead:
+contexts (for example, automated test setup), pass `--passphrase-file` to read the first
+line of a file instead. Use `-` for standard input, or a file descriptor such as
+`/dev/fd/3`:
 
 ```
-$ ZALLET_IDENTITY_PASSPHRASE=... zallet -d /path/to/zallet/datadir generate-encryption-identity -p
+$ echo "$PASSPHRASE" | zallet -d /path/to/zallet/datadir generate-encryption-identity -p --passphrase-file -
 Public key: age1...
 ```
 
-The environment variable, when set, is read once and is not persisted by Zallet.
+Command-line arguments and environment variables are visible to other processes on many
+platforms, so the passphrase itself is never accepted through either; prefer a pipe or
+file descriptor over a regular file on disk.
 
 ## Plugins
 

--- a/book/src/concepts/encryption.md
+++ b/book/src/concepts/encryption.md
@@ -21,8 +21,8 @@ The identity file can itself be protected with a passphrase (created with
 identity, the key store starts **locked**: operations that need spending keys
 fail with "Wallet is locked" until it is unlocked with the `walletpassphrase`
 RPC method (`walletlock` re-locks it). In non-interactive contexts the
-passphrase can be supplied via the `ZALLET_IDENTITY_PASSPHRASE` environment
-variable.
+passphrase can be supplied at creation time via `--passphrase-file` (a pipe,
+file descriptor, or `-` for standard input).
 
 Consequences worth internalizing:
 

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -148,8 +148,9 @@ required):
   Confirm passphrase:
   Public key: age1...
   ```
-  In non-interactive contexts, the passphrase is read from the
-  `ZALLET_IDENTITY_PASSPHRASE` environment variable instead of prompting.
+  In non-interactive contexts, pass `--passphrase-file` to read the
+  passphrase from a pipe, file descriptor, or standard input (`-`) instead
+  of prompting.
 
 > [Reference](../cli/generate-encryption-identity.md)
 

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -62,6 +62,7 @@ rand.workspace = true
 
 # Secret management
 secrecy.workspace = true
+subtle.workspace = true
 
 # CLI
 abscissa_core.workspace = true

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -423,8 +423,8 @@ err-ux-C = {"                    "}
 
 ## Limit errors
 
-err-excess-orchard-actions =
-    Including {$count} Orchard {$kind} would exceed the current limit of
+err-excess-shielded-actions =
+    Including {$count} {$pool} {$kind} would exceed the current limit of
     {$limit} actions, which exists to prevent memory exhaustion. Restart with
     '{$config}' where {$bound} to allow the wallet to attempt to construct this
     transaction.

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -54,6 +54,7 @@ cmd-generate-encryption-identity-exists = An encryption identity already exists 
 cmd-generate-encryption-identity-passphrase-prompt = Enter passphrase to encrypt the identity:
 cmd-generate-encryption-identity-passphrase-confirm = Confirm passphrase:
 cmd-generate-encryption-identity-passphrase-mismatch = Passphrases do not match
+cmd-generate-encryption-identity-passphrase-empty = Passphrase must not be empty; an empty passphrase would leave the identity effectively unencrypted.
 
 cmd-migrate-wallet-passphrase-prompt = Enter the passphrase for the encrypted zcashd wallet:
 cmd-migrate-wallet-passphrase-wrong = The passphrase was incorrect; please try again.

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -55,6 +55,7 @@ cmd-generate-encryption-identity-passphrase-prompt = Enter passphrase to encrypt
 cmd-generate-encryption-identity-passphrase-confirm = Confirm passphrase:
 cmd-generate-encryption-identity-passphrase-mismatch = Passphrases do not match
 cmd-generate-encryption-identity-passphrase-empty = Passphrase must not be empty; an empty passphrase would leave the identity effectively unencrypted.
+cmd-generate-encryption-identity-passphrase-file-failed = Failed to read passphrase from {$path}: {$error}
 
 cmd-migrate-wallet-passphrase-prompt = Enter the passphrase for the encrypted zcashd wallet:
 cmd-migrate-wallet-passphrase-wrong = The passphrase was incorrect; please try again.

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -136,6 +136,7 @@ err-init-cannot-find-home-dir =
     Cannot find home directory for the default datadir. Use '{-datadir}' to set
     the datadir directly.
 err-init-failed-to-create-lockfile = Failed to create a lockfile at {$path}: {$error}
+err-init-failed-to-restrict-permissions = Failed to restrict permissions on {$path}: {$error}
 err-init-failed-to-read-lockfile = Failed to read lockfile at {$path}: {$error}
 err-init-zallet-already-running =
     Cannot obtain a lock on data directory {$datadir}. {-zallet} is probably already running.

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -43,6 +43,7 @@ flags-header = Options
 ## Command prompts & output
 
 cmd-add-rpc-user-prompt = Enter password:
+cmd-add-rpc-user-password-empty = Password must not be empty.
 cmd-add-rpc-user-instructions = Add this to your {-zallet_toml} file:
 cmd-seed-fingerprint = Seed fingerprint: {$seedfp}
 cmd-import-mnemonic-prompt = Enter mnemonic:

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -221,11 +221,20 @@ pub(crate) struct GenerateEncryptionIdentityCmd {
 
     /// Encrypt the identity with a passphrase (ASCII-armored).
     ///
-    /// In non-interactive contexts, the passphrase is read from the
-    /// `ZALLET_IDENTITY_PASSPHRASE` environment variable; otherwise
-    /// you will be prompted for it.
+    /// You will be prompted for the passphrase (with confirmation),
+    /// unless `--passphrase-file` is given.
     #[arg(short, long)]
     pub(crate) passphrase: bool,
+
+    /// Read the passphrase from the first line of the given file instead
+    /// of prompting.
+    ///
+    /// For non-interactive use. Prefer a pipe or file descriptor (`-` for
+    /// standard input, or e.g. `/dev/fd/3`) over a regular file; never pass
+    /// secrets via command-line arguments or environment variables, which
+    /// are visible to other processes.
+    #[arg(long, requires = "passphrase", value_name = "PATH")]
+    pub(crate) passphrase_file: Option<String>,
 }
 
 /// `init-wallet-encryption` subcommand

--- a/zallet-core/src/commands.rs
+++ b/zallet-core/src/commands.rs
@@ -49,6 +49,20 @@ pub const CONFIG_FILE: &str = "zallet.toml";
 
 /// Ensures only a single Zallet process is using the data directory.
 pub(crate) fn lock_datadir(datadir: &Path) -> Result<fmutex::Guard<'static>, Error> {
+    // The datadir holds the wallet database and encryption identity; keep it
+    // private to the owner.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(datadir, fs::Permissions::from_mode(0o700)).map_err(|e| {
+            ErrorKind::Init.context(fl!(
+                "err-init-failed-to-restrict-permissions",
+                path = datadir.display().to_string(),
+                error = e.to_string(),
+            ))
+        })?;
+    }
+
     let lockfile_path = resolve_datadir_path(datadir, Path::new(".lock"));
 
     {

--- a/zallet-core/src/commands/add_rpc_user.rs
+++ b/zallet-core/src/commands/add_rpc_user.rs
@@ -16,6 +16,12 @@ impl AsyncRunnable for AddRpcUserCmd {
                 .map_err(|e| ErrorKind::Generic.context(e))?,
         );
 
+        if password.expose_secret().is_empty() {
+            return Err(ErrorKind::Generic
+                .context(fl!("cmd-add-rpc-user-password-empty"))
+                .into());
+        }
+
         let pwhash = PasswordHash::from_bare(password.expose_secret());
 
         eprintln!("{}", fl!("cmd-add-rpc-user-instructions"));

--- a/zallet-core/src/commands/generate_encryption_identity.rs
+++ b/zallet-core/src/commands/generate_encryption_identity.rs
@@ -20,9 +20,6 @@ use crate::{
     prelude::*,
 };
 
-/// Environment variable from which the passphrase is read in non-interactive contexts.
-const PASSPHRASE_ENV: &str = "ZALLET_IDENTITY_PASSPHRASE";
-
 impl AsyncRunnable for GenerateEncryptionIdentityCmd {
     async fn run(&self) -> Result<(), Error> {
         let config = APP.config();
@@ -34,7 +31,7 @@ impl AsyncRunnable for GenerateEncryptionIdentityCmd {
         // Build the file body, either as a plain identity or passphrase-encrypted
         // (equivalent to `rage -p`).
         let passphrase = if self.passphrase {
-            Some(read_passphrase()?)
+            Some(read_passphrase(self.passphrase_file.as_deref())?)
         } else {
             None
         };
@@ -208,12 +205,11 @@ fn encrypt_identity(rendered: &str, passphrase: SecretString) -> Result<Zeroizin
 
 /// Obtains the passphrase used to encrypt the identity.
 ///
-/// In non-interactive contexts the passphrase is read from the
-/// [`PASSPHRASE_ENV`] environment variable; otherwise the user is prompted for
-/// it (with confirmation).
-fn read_passphrase() -> Result<SecretString, Error> {
-    if let Ok(passphrase) = std::env::var(PASSPHRASE_ENV) {
-        return validate_passphrase(SecretString::from(passphrase));
+/// With `passphrase_file` set, the passphrase is read from that source;
+/// otherwise the user is prompted for it (with confirmation).
+fn read_passphrase(passphrase_file: Option<&str>) -> Result<SecretString, Error> {
+    if let Some(source) = passphrase_file {
+        return validate_passphrase(read_passphrase_line(source)?);
     }
 
     // Take ownership of each prompt's buffer in a `SecretString` immediately, so
@@ -235,6 +231,46 @@ fn read_passphrase() -> Result<SecretString, Error> {
     }
 
     validate_passphrase(passphrase)
+}
+
+/// Reads the first line of the given passphrase source (`-` for standard
+/// input), without its line terminator.
+fn read_passphrase_line(source: &str) -> Result<SecretString, Error> {
+    use std::io::BufRead;
+
+    let read_failed = |e: std::io::Error| -> Error {
+        ErrorKind::Generic
+            .context(fl!(
+                "cmd-generate-encryption-identity-passphrase-file-failed",
+                path = source.to_string(),
+                error = e.to_string(),
+            ))
+            .into()
+    };
+
+    // The buffer holds the passphrase in the clear, so zeroize it on drop.
+    let mut buf = Zeroizing::new(Vec::new());
+    if source == "-" {
+        std::io::stdin()
+            .lock()
+            .read_until(b'\n', &mut buf)
+            .map_err(read_failed)?;
+    } else {
+        let file = std::fs::File::open(source).map_err(read_failed)?;
+        std::io::BufReader::new(file)
+            .read_until(b'\n', &mut buf)
+            .map_err(read_failed)?;
+    }
+
+    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+        buf.pop();
+    }
+
+    Ok(SecretString::from(
+        std::str::from_utf8(&buf)
+            .map_err(|e| ErrorKind::Generic.context(e))?
+            .to_owned(),
+    ))
 }
 
 /// Rejects passphrases that would not meaningfully encrypt the identity.

--- a/zallet-core/src/commands/generate_encryption_identity.rs
+++ b/zallet-core/src/commands/generate_encryption_identity.rs
@@ -213,7 +213,7 @@ fn encrypt_identity(rendered: &str, passphrase: SecretString) -> Result<Zeroizin
 /// it (with confirmation).
 fn read_passphrase() -> Result<SecretString, Error> {
     if let Ok(passphrase) = std::env::var(PASSPHRASE_ENV) {
-        return Ok(SecretString::from(passphrase));
+        return validate_passphrase(SecretString::from(passphrase));
     }
 
     // Take ownership of each prompt's buffer in a `SecretString` immediately, so
@@ -234,6 +234,20 @@ fn read_passphrase() -> Result<SecretString, Error> {
             .into());
     }
 
+    validate_passphrase(passphrase)
+}
+
+/// Rejects passphrases that would not meaningfully encrypt the identity.
+///
+/// An empty passphrase produces a file that parses as passphrase-encrypted (so the
+/// keystore treats the wallet as encrypted) while being trivially decryptable.
+fn validate_passphrase(passphrase: SecretString) -> Result<SecretString, Error> {
+    if passphrase.expose_secret().is_empty() {
+        return Err(ErrorKind::Generic
+            .context(fl!("cmd-generate-encryption-identity-passphrase-empty"))
+            .into());
+    }
+
     Ok(passphrase)
 }
 
@@ -249,7 +263,7 @@ mod tests {
 
     use age::secrecy::SecretString;
 
-    use super::{encode_identity, write_identity_file};
+    use super::{encode_identity, validate_passphrase, write_identity_file};
 
     /// Decrypts a passphrase-encrypted, armored identity body, returning the
     /// recovered plaintext.
@@ -311,6 +325,12 @@ mod tests {
 
         let result = decrypt(&body, SecretString::from("the wrong passphrase".to_owned()));
         assert!(matches!(result, Err(age::DecryptError::DecryptionFailed)));
+    }
+
+    #[test]
+    fn empty_passphrase_is_rejected() {
+        assert!(validate_passphrase(SecretString::from(String::new())).is_err());
+        assert!(validate_passphrase(SecretString::from("a passphrase".to_owned())).is_ok());
     }
 
     #[test]

--- a/zallet-core/src/components/database.rs
+++ b/zallet-core/src/components/database.rs
@@ -65,9 +65,42 @@ impl Database {
     pub(crate) async fn open(config: &ZalletConfig) -> Result<Self, Error> {
         let path = config.wallet_db_path();
 
-        let db_exists = fs::try_exists(&path)
-            .await
-            .map_err(|e| ErrorKind::Init.context(e))?;
+        // A zero-length file is not yet a SQLite database (SQLite initializes it
+        // on first write), so treat it like a missing one.
+        let db_exists = match fs::metadata(&path).await {
+            Ok(meta) => meta.len() > 0,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+            Err(e) => return Err(ErrorKind::Init.context(e).into()),
+        };
+
+        // Keep the wallet database private to the owner. This must happen before
+        // SQLite opens it, as SQLite creates its journal files (which contain
+        // database content) with the database file's permissions. A missing
+        // database is created up front so it never exists with wider permissions.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let restrict = match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await
+                }
+                Err(e) => Err(e),
+            };
+            restrict.map_err(|e| {
+                ErrorKind::Init.context(fl!(
+                    "err-init-failed-to-restrict-permissions",
+                    path = path.display().to_string(),
+                    error = e.to_string(),
+                ))
+            })?;
+        }
 
         let db_data_pool = connection::pool(&path, config.consensus.network())?;
 

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -577,18 +577,17 @@ fn step_privacy_requirement<NoteRef>(
             PrivacyPolicy::AllowRevealedRecipients,
             IncompatiblePrivacyPolicy::TransparentChange,
         ))
-    } else if let Some(pool) = shielded_pool_crossed_into(step) {
-        // TODO: This should only trigger when there is a non-fee valueBalance.
-        // TODO: Determine whether this is due to the presence of an explicit
-        // recipient address in that pool, or having insufficient funds to pay a
-        // UA within a single pool.
-        Some((
-            PrivacyPolicy::AllowRevealedAmounts,
-            IncompatiblePrivacyPolicy::RevealingShieldedAmount(pool),
-        ))
     } else {
-        // Nothing is revealed by this step.
-        None
+        shielded_pool_crossed_into(step).map(|pool| {
+            // TODO: This should only trigger when there is a non-fee valueBalance.
+            // TODO: Determine whether this is due to the presence of an explicit
+            // recipient address in that pool, or having insufficient funds to pay a
+            // UA within a single pool.
+            (
+                PrivacyPolicy::AllowRevealedAmounts,
+                IncompatiblePrivacyPolicy::RevealingShieldedAmount(pool),
+            )
+        })
     }
 }
 

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -678,6 +678,64 @@ pub(super) fn required_privacy_policy<FeeRuleT, NoteRef>(
         })
 }
 
+/// A shielded pool in which a proposal step exceeds the per-pool action limit.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ShieldedActionLimitExceeded {
+    pub(super) pool: ShieldedPool,
+    pub(super) count: usize,
+    /// Which side of the pool's bundle exceeds the limit: `"inputs"`, `"outputs"`, or
+    /// `"actions"` when both do.
+    pub(super) kind: &'static str,
+}
+
+/// Checks every step of the proposal against the per-pool action limit.
+///
+/// The limit applies per shielded pool: each pool's spends and outputs bound the memory
+/// needed to prove and construct that pool's part of the transaction.
+pub(super) fn check_shielded_action_limits<FeeRuleT, NoteRef>(
+    proposal: &Proposal<FeeRuleT, NoteRef>,
+    limit: usize,
+) -> Result<(), ShieldedActionLimitExceeded> {
+    for step in proposal.steps() {
+        for pool in all_shielded_pools() {
+            let spends = step
+                .shielded_inputs()
+                .iter()
+                .flat_map(|inputs| inputs.notes())
+                .filter(|note| note.note().pool() == pool)
+                .count();
+
+            let outputs = step
+                .payment_pools()
+                .values()
+                .filter(|payment_pool| **payment_pool == PoolType::Shielded(pool))
+                .count()
+                + step
+                    .balance()
+                    .proposed_change()
+                    .iter()
+                    .filter(|change| change.output_pool() == PoolType::Shielded(pool))
+                    .count();
+
+            let actions = spends.max(outputs);
+
+            if actions > limit {
+                let (count, kind) = if outputs <= limit {
+                    (spends, "inputs")
+                } else if spends <= limit {
+                    (outputs, "outputs")
+                } else {
+                    (actions, "actions")
+                };
+
+                return Err(ShieldedActionLimitExceeded { pool, count, kind });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Parses the optional `privacy_policy` JSON-RPC argument into a [`PrivacyPolicy`],
 /// defaulting to [`PrivacyPolicy::FullPrivacy`] when absent and rejecting the unsupported
 /// `"LegacyCompat"` policy.
@@ -693,6 +751,7 @@ pub(super) fn parse_privacy_policy(privacy_policy: Option<&str>) -> RpcResult<Pr
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub(super) enum IncompatiblePrivacyPolicy {
     /// Requested [`PrivacyPolicy`] doesn’t include `NoPrivacy`.
     NoPrivacy,
@@ -1948,5 +2007,310 @@ mod privacy_policy_tests {
             let expected = format!("Unknown privacy policy {s}");
             prop_assert_eq!(err.message(), expected);
         }
+    }
+}
+
+#[cfg(test)]
+mod proposal_policy_tests {
+    //! Tests for the pure proposal checks — [`enforce_privacy_policy`],
+    //! [`required_privacy_policy`], and [`check_shielded_action_limits`] — over
+    //! in-memory proposals built from dummy notes. Note contents beyond pool and value
+    //! are irrelevant to the code under test, so fixed keys and randomness suffice.
+
+    use std::collections::BTreeMap;
+
+    use incrementalmerkletree::Position;
+    use nonempty::NonEmpty;
+    use zcash_client_backend::{
+        data_api::wallet::{ConfirmationsPolicy, TargetHeight},
+        fees::{ChangeValue, TransactionBalance},
+        proposal::ShieldedInputs,
+        wallet::{Note, ReceivedNote},
+    };
+    use zcash_protocol::consensus::BlockHeight;
+
+    use super::*;
+
+    /// The value of every dummy input note.
+    const NOTE_VALUE: u64 = 20_000;
+
+    /// Constructs a dummy note in the given shielded pool.
+    fn note_in_pool(pool: ShieldedPool, value: u64) -> Note {
+        match pool {
+            ShieldedPool::Sapling => {
+                let (_, recipient) =
+                    sapling::zip32::ExtendedSpendingKey::master(&[0x2a; 32]).default_address();
+                Note::Sapling(sapling::Note::from_parts(
+                    recipient,
+                    sapling::value::NoteValue::from_raw(value),
+                    sapling::Rseed::AfterZip212([0x1b; 32]),
+                ))
+            }
+            ShieldedPool::Orchard | ShieldedPool::Ironwood => {
+                let sk: orchard::keys::SpendingKey =
+                    Option::from(orchard::keys::SpendingKey::from_bytes([0x2a; 32]))
+                        .expect("valid spending key");
+                let recipient = orchard::keys::FullViewingKey::from(&sk)
+                    .address_at(0u32, zip32::Scope::External);
+                let rho =
+                    Option::from(orchard::note::Rho::from_bytes(&[0; 32])).expect("valid rho");
+                let rseed = Option::from(orchard::note::RandomSeed::from_bytes([0x1b; 32], &rho))
+                    .expect("valid rseed");
+                let (version, value_pool) = if pool == ShieldedPool::Ironwood {
+                    (orchard::note::NoteVersion::V3, orchard::ValuePool::Ironwood)
+                } else {
+                    (orchard::note::NoteVersion::V2, orchard::ValuePool::Orchard)
+                };
+                Note::Orchard {
+                    note: Option::from(orchard::note::Note::from_parts(
+                        recipient,
+                        orchard::value::NoteValue::from_raw(value),
+                        rho,
+                        rseed,
+                        version,
+                    ))
+                    .expect("valid note"),
+                    pool: value_pool,
+                }
+            }
+        }
+    }
+
+    /// Wraps one dummy note of [`NOTE_VALUE`] per entry of `pools` as a step's shielded
+    /// inputs.
+    fn shielded_inputs_spending(pools: &[ShieldedPool]) -> ShieldedInputs<u32> {
+        let notes = pools
+            .iter()
+            .enumerate()
+            .map(|(i, pool)| {
+                ReceivedNote::from_parts(
+                    i as u32,
+                    TxId::from_bytes([0; 32]),
+                    i as u16,
+                    note_in_pool(*pool, NOTE_VALUE),
+                    zip32::Scope::External,
+                    Position::from(i as u64),
+                    Some(BlockHeight::from_u32(100)),
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        ShieldedInputs::from_parts(NonEmpty::from_vec(notes).expect("at least one input pool"))
+    }
+
+    /// A single-step proposal spending one dummy note per entry of `input_pools`, paying
+    /// `request` (whose payments are placed in `payment_pools`) and returning `change`;
+    /// the input value not consumed by payments or change becomes the fee, keeping the
+    /// step balanced.
+    fn build_proposal(
+        input_pools: &[ShieldedPool],
+        request: TransactionRequest,
+        payment_pools: BTreeMap<usize, PoolType>,
+        change: Vec<ChangeValue>,
+    ) -> Proposal<(), u32> {
+        let input_total = NOTE_VALUE * input_pools.len() as u64;
+        let payments_total = u64::from(
+            request
+                .total()
+                .expect("no overflow")
+                .expect("all payments carry amounts"),
+        );
+        let change_total = change.iter().map(|c| u64::from(c.value())).sum::<u64>();
+        let fee = input_total
+            .checked_sub(payments_total + change_total)
+            .expect("inputs cover outputs");
+
+        Proposal::single_step(
+            request,
+            payment_pools,
+            vec![],
+            Some(shielded_inputs_spending(input_pools)),
+            BlockHeight::from_u32(100),
+            TransactionBalance::new(change, Zatoshis::const_from_u64(fee)).expect("valid balance"),
+            (),
+            TargetHeight::from(BlockHeight::from_u32(101)),
+            ConfirmationsPolicy::default(),
+            false,
+            false,
+        )
+        .expect("valid proposal")
+    }
+
+    /// A proposal with no payments: spends one dummy note per entry of `input_pools` and
+    /// returns `change`.
+    fn change_only_proposal(
+        input_pools: &[ShieldedPool],
+        change: Vec<ChangeValue>,
+    ) -> Proposal<(), u32> {
+        build_proposal(
+            input_pools,
+            TransactionRequest::empty(),
+            BTreeMap::new(),
+            change,
+        )
+    }
+
+    fn change(pool: ShieldedPool, value: u64) -> ChangeValue {
+        ChangeValue::shielded(pool, Zatoshis::const_from_u64(value), None)
+    }
+
+    /// A step that keeps value within a single shielded pool reveals nothing, whichever
+    /// pool it is.
+    #[test]
+    fn same_pool_spend_satisfies_full_privacy() {
+        for pool in all_shielded_pools() {
+            let proposal = change_only_proposal(&[pool], vec![change(pool, 10_000)]);
+            assert_eq!(
+                enforce_privacy_policy(&proposal, PrivacyPolicy::FullPrivacy),
+                Ok(()),
+                "within {pool:?}",
+            );
+            assert_eq!(
+                required_privacy_policy(&proposal),
+                PrivacyPolicy::FullPrivacy,
+                "within {pool:?}",
+            );
+        }
+    }
+
+    /// Moving value between two distinct shielded pools reveals the crossing amount in
+    /// the transaction's public value balances, so `FullPrivacy` must reject it for
+    /// every ordered pool pair — including the pairs involving Ironwood that a pairwise
+    /// Sapling↔Orchard check would miss.
+    #[test]
+    fn crossing_into_any_other_pool_requires_revealed_amounts() {
+        for from in all_shielded_pools() {
+            for to in all_shielded_pools() {
+                if from == to {
+                    continue;
+                }
+                let proposal = change_only_proposal(&[from], vec![change(to, 10_000)]);
+                assert_eq!(
+                    enforce_privacy_policy(&proposal, PrivacyPolicy::FullPrivacy),
+                    Err(IncompatiblePrivacyPolicy::RevealingShieldedAmount(to)),
+                    "crossing {from:?} -> {to:?}",
+                );
+                assert_eq!(
+                    enforce_privacy_policy(&proposal, PrivacyPolicy::AllowRevealedAmounts),
+                    Ok(()),
+                    "crossing {from:?} -> {to:?}",
+                );
+                assert_eq!(
+                    required_privacy_policy(&proposal),
+                    PrivacyPolicy::AllowRevealedAmounts,
+                    "crossing {from:?} -> {to:?}",
+                );
+            }
+        }
+    }
+
+    /// A payment (not just change) into a pool the inputs don't come from is likewise a
+    /// crossing.
+    #[test]
+    fn payment_into_another_pool_requires_revealed_amounts() {
+        let request = TransactionRequest::new(vec![
+            Payment::new(
+                arb::SAPLING_ADDR.parse::<ZcashAddress>().expect("valid"),
+                Some(Zatoshis::const_from_u64(10_000)),
+                None,
+                None,
+                None,
+                vec![],
+            )
+            .expect("valid payment"),
+        ])
+        .expect("valid request");
+
+        let proposal = build_proposal(
+            &[ShieldedPool::Orchard],
+            request,
+            [(0, PoolType::SAPLING)].into_iter().collect(),
+            vec![],
+        );
+
+        assert_eq!(
+            enforce_privacy_policy(&proposal, PrivacyPolicy::FullPrivacy),
+            Err(IncompatiblePrivacyPolicy::RevealingShieldedAmount(
+                ShieldedPool::Sapling
+            )),
+        );
+        assert_eq!(
+            required_privacy_policy(&proposal),
+            PrivacyPolicy::AllowRevealedAmounts,
+        );
+    }
+
+    /// The transaction-size cap applies to every shielded pool's spends, not only
+    /// Orchard's.
+    #[test]
+    fn action_limit_applies_to_spends_in_every_pool() {
+        for pool in all_shielded_pools() {
+            let proposal = change_only_proposal(&[pool; 3], vec![change(pool, 10_000)]);
+            assert_eq!(
+                check_shielded_action_limits(&proposal, 2),
+                Err(ShieldedActionLimitExceeded {
+                    pool,
+                    count: 3,
+                    kind: "inputs",
+                }),
+                "spends in {pool:?}",
+            );
+            assert_eq!(
+                check_shielded_action_limits(&proposal, 3),
+                Ok(()),
+                "spends in {pool:?}",
+            );
+        }
+    }
+
+    /// Change outputs count against the same per-pool limit as spends.
+    #[test]
+    fn action_limit_applies_to_outputs_in_every_pool() {
+        for pool in all_shielded_pools() {
+            let proposal = change_only_proposal(&[pool; 2], vec![change(pool, 10_000); 3]);
+            assert_eq!(
+                check_shielded_action_limits(&proposal, 2),
+                Err(ShieldedActionLimitExceeded {
+                    pool,
+                    count: 3,
+                    kind: "outputs",
+                }),
+                "outputs in {pool:?}",
+            );
+        }
+    }
+
+    /// When both sides of a pool's bundle exceed the limit, the combined action count is
+    /// reported.
+    #[test]
+    fn action_limit_reports_actions_when_both_sides_exceed() {
+        for pool in all_shielded_pools() {
+            let proposal = change_only_proposal(&[pool; 3], vec![change(pool, 10_000); 3]);
+            assert_eq!(
+                check_shielded_action_limits(&proposal, 2),
+                Err(ShieldedActionLimitExceeded {
+                    pool,
+                    count: 3,
+                    kind: "actions",
+                }),
+                "actions in {pool:?}",
+            );
+        }
+    }
+
+    /// The limit is per pool: spends spread across pools may exceed it in aggregate as
+    /// long as no single pool does.
+    #[test]
+    fn action_limit_is_per_pool() {
+        let proposal = change_only_proposal(
+            &[
+                ShieldedPool::Sapling,
+                ShieldedPool::Sapling,
+                ShieldedPool::Orchard,
+                ShieldedPool::Orchard,
+            ],
+            vec![],
+        );
+        assert_eq!(check_shielded_action_limits(&proposal, 2), Ok(()));
     }
 }

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -227,7 +227,10 @@ pub(super) fn propose_and_check(
                     max_sapling_available - value,
                 ) {
                     (false, None) => {
-                        return Err(IncompatiblePrivacyPolicy::RevealingSaplingAmount.into());
+                        return Err(IncompatiblePrivacyPolicy::RevealingShieldedAmount(
+                            ShieldedPool::Sapling,
+                        )
+                        .into());
                     }
                     (false, Some(rest)) => max_sapling_available = rest,
                     (true, _) => (),
@@ -561,10 +564,6 @@ fn step_privacy_requirement<NoteRef>(
 ) -> Option<(PrivacyPolicy, IncompatiblePrivacyPolicy)> {
     let has_transparent_recipient = step.output_in_pool(PoolType::Transparent);
     let has_transparent_change = step.change_in_pool(PoolType::Transparent);
-    let has_sapling_recipient =
-        step.output_in_pool(PoolType::SAPLING) || step.change_in_pool(PoolType::SAPLING);
-    let has_orchard_recipient =
-        step.output_in_pool(PoolType::ORCHARD) || step.change_in_pool(PoolType::ORCHARD);
 
     if step.input_in_pool(PoolType::Transparent) {
         let received_addrs = step
@@ -608,24 +607,52 @@ fn step_privacy_requirement<NoteRef>(
             PrivacyPolicy::AllowRevealedRecipients,
             IncompatiblePrivacyPolicy::TransparentChange,
         ))
-    } else if step.input_in_pool(PoolType::ORCHARD) && has_sapling_recipient {
+    } else if let Some(pool) = shielded_pool_crossed_into(step) {
         // TODO: This should only trigger when there is a non-fee valueBalance.
-        // TODO: Determine whether this is due to the presence of an explicit Sapling
-        // recipient address, or having insufficient funds to pay a UA within a single pool.
+        // TODO: Determine whether this is due to the presence of an explicit
+        // recipient address in that pool, or having insufficient funds to pay a
+        // UA within a single pool.
         Some((
             PrivacyPolicy::AllowRevealedAmounts,
-            IncompatiblePrivacyPolicy::RevealingSaplingAmount,
-        ))
-    } else if step.input_in_pool(PoolType::SAPLING) && has_orchard_recipient {
-        // TODO: This should only trigger when there is a non-fee valueBalance.
-        Some((
-            PrivacyPolicy::AllowRevealedAmounts,
-            IncompatiblePrivacyPolicy::RevealingOrchardAmount,
+            IncompatiblePrivacyPolicy::RevealingShieldedAmount(pool),
         ))
     } else {
         // Nothing is revealed by this step.
         None
     }
+}
+
+/// Every shielded pool, for the privacy checks below, which must consider all cross-pool
+/// value flows.
+///
+/// Written as a match so that adding a `ShieldedPool` variant fails compilation here,
+/// forcing the new pool to be modeled by the privacy policy rather than bypassing it.
+fn all_shielded_pools() -> [ShieldedPool; 3] {
+    match ShieldedPool::Sapling {
+        ShieldedPool::Sapling | ShieldedPool::Orchard | ShieldedPool::Ironwood => [
+            ShieldedPool::Sapling,
+            ShieldedPool::Orchard,
+            ShieldedPool::Ironwood,
+        ],
+    }
+}
+
+/// Returns a shielded pool that the given step moves value into from a different
+/// shielded pool, if any.
+///
+/// Crossing between shielded pools reveals the crossing amount in the transaction's
+/// public value balances, so it requires [`PrivacyPolicy::AllowRevealedAmounts`].
+fn shielded_pool_crossed_into<NoteRef>(step: &Step<NoteRef>) -> Option<ShieldedPool> {
+    let input_pools = all_shielded_pools()
+        .into_iter()
+        .filter(|pool| step.input_in_pool(PoolType::Shielded(*pool)))
+        .collect::<Vec<_>>();
+
+    all_shielded_pools().into_iter().find(|pool| {
+        (step.output_in_pool(PoolType::Shielded(*pool))
+            || step.change_in_pool(PoolType::Shielded(*pool)))
+            && input_pools.iter().any(|input_pool| input_pool != pool)
+    })
 }
 
 pub(super) fn enforce_privacy_policy<FeeRuleT, NoteRef>(
@@ -720,12 +747,9 @@ pub(super) enum IncompatiblePrivacyPolicy {
     TransparentReceiver,
 
     /// Requested [`PrivacyPolicy`] doesn’t include `AllowRevealedAmounts`, but we don’t
-    /// have enough Sapling funds to avoid revealing amounts.
-    RevealingSaplingAmount,
-
-    /// Requested [`PrivacyPolicy`] doesn’t include `AllowRevealedAmounts`, but we don’t
-    /// have enough Orchard funds to avoid revealing amounts.
-    RevealingOrchardAmount,
+    /// have enough funds in the given shielded pool to avoid revealing amounts by
+    /// crossing into it from another pool.
+    RevealingShieldedAmount(ShieldedPool),
 
     /// Requested [`PrivacyPolicy`] doesn’t include `AllowRevealedAmounts`, but we are
     /// trying to pay a UA where we don’t have enough funds in any single pool that it has
@@ -795,18 +819,12 @@ impl From<IncompatiblePrivacyPolicy> for ErrorObjectOwned {
                     policy = "AllowRevealedRecipients"
                 )
             ),
-            IncompatiblePrivacyPolicy::RevealingSaplingAmount => format!(
+            IncompatiblePrivacyPolicy::RevealingShieldedAmount(pool) => format!(
                 "{} {}",
-                fl!("err-privpol-revealing-amount-not-allowed", pool = "Sapling"),
                 fl!(
-                    "rec-privpol-privacy-weakening",
-                    parameter = "privacyPolicy",
-                    policy = "AllowRevealedAmounts"
-                )
-            ),
-            IncompatiblePrivacyPolicy::RevealingOrchardAmount => format!(
-                "{} {}",
-                fl!("err-privpol-revealing-amount-not-allowed", pool = "Orchard"),
+                    "err-privpol-revealing-amount-not-allowed",
+                    pool = PoolType::Shielded(pool).to_string()
+                ),
                 fl!(
                     "rec-privpol-privacy-weakening",
                     parameter = "privacyPolicy",

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -339,48 +339,18 @@ pub(super) fn propose_and_check(
 
     enforce_privacy_policy(&proposal, privacy_policy)?;
 
-    let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
-    for step in proposal.steps() {
-        let orchard_spends = step
-            .shielded_inputs()
-            .iter()
-            .flat_map(|inputs| inputs.notes())
-            .filter(|note| note.note().pool() == ShieldedPool::Orchard)
-            .count();
-
-        let orchard_outputs = step
-            .payment_pools()
-            .values()
-            .filter(|pool| pool == &&PoolType::ORCHARD)
-            .count()
-            + step
-                .balance()
-                .proposed_change()
-                .iter()
-                .filter(|change| change.output_pool() == PoolType::ORCHARD)
-                .count();
-
-        let orchard_actions = orchard_spends.max(orchard_outputs);
-
-        if orchard_actions > orchard_actions_limit {
-            let (count, kind) = if orchard_outputs <= orchard_actions_limit {
-                (orchard_spends, "inputs")
-            } else if orchard_spends <= orchard_actions_limit {
-                (orchard_outputs, "outputs")
-            } else {
-                (orchard_actions, "actions")
-            };
-
-            return Err(LegacyCode::Misc.with_message(fl!(
-                "err-excess-orchard-actions",
-                count = count,
-                kind = kind,
-                limit = orchard_actions_limit,
-                config = "-orchardactionlimit=N",
-                bound = format!("N >= %u"),
-            )));
-        }
-    }
+    let actions_limit = APP.config().builder.limits.orchard_actions().into();
+    check_shielded_action_limits(&proposal, actions_limit).map_err(|e| {
+        LegacyCode::Misc.with_message(fl!(
+            "err-excess-shielded-actions",
+            pool = PoolType::Shielded(e.pool).to_string(),
+            count = e.count,
+            kind = e.kind,
+            limit = actions_limit,
+            config = "-orchardactionlimit=N",
+            bound = format!("N >= %u"),
+        ))
+    })?;
 
     Ok(proposal)
 }
@@ -627,7 +597,7 @@ fn step_privacy_requirement<NoteRef>(
 ///
 /// Written as a match so that adding a `ShieldedPool` variant fails compilation here,
 /// forcing the new pool to be modeled by the privacy policy rather than bypassing it.
-fn all_shielded_pools() -> [ShieldedPool; 3] {
+pub(super) fn all_shielded_pools() -> [ShieldedPool; 3] {
     match ShieldedPool::Sapling {
         ShieldedPool::Sapling | ShieldedPool::Orchard | ShieldedPool::Ironwood => [
             ShieldedPool::Sapling,

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -28,6 +28,7 @@ pub(crate) use error::LegacyCode;
 pub(crate) mod authorization;
 pub(crate) mod cookie;
 mod http_request_compatibility;
+mod method_logger;
 mod rpc_call_compatibility;
 
 type ServerTask = JoinHandle<Result<(), Error>>;
@@ -79,8 +80,10 @@ pub(crate) async fn spawn<C: Chain>(
         .layer(http_request_compatibility::HttpRequestMiddlewareLayer::new())
         .timeout(timeout);
 
+    // Note: `RpcServiceBuilder::rpc_logger` must not be used here; it logs full
+    // call parameters and responses, which can contain secrets.
     let rpc_middleware = RpcServiceBuilder::new()
-        .rpc_logger(1024)
+        .layer_fn(method_logger::MethodLoggerMiddleware::new)
         .layer_fn(rpc_call_compatibility::FixRpcResponseMiddleware::new);
 
     let server_instance = Server::builder()

--- a/zallet-core/src/components/json_rpc/server/authorization.rs
+++ b/zallet-core/src/components/json_rpc/server/authorization.rs
@@ -162,7 +162,9 @@ impl AuthorizationLayer {
         let mut users: HashMap<String, PasswordHash> = auth
             .into_iter()
             .map(|a| match (a.password, a.pwhash) {
-                (Some(password), None) => {
+                // An empty password provides no authentication; treat it as an
+                // invalid config rather than an open RPC interface.
+                (Some(password), None) if !password.expose_secret().is_empty() => {
                     using_bare_password = true;
                     Ok((a.user, PasswordHash::from_bare(password.expose_secret())))
                 }
@@ -258,6 +260,18 @@ mod tests {
         use base64ct::{Base64, Encoding};
         let encoded = Base64::encode_string(format!("{user}:{password}").as_bytes());
         HeaderValue::from_str(&format!("Basic {encoded}")).unwrap()
+    }
+
+    #[test]
+    fn empty_bare_password_is_rejected() {
+        use crate::config::RpcAuthSection;
+
+        let auth = vec![RpcAuthSection {
+            user: "user1".to_string(),
+            password: Some(secrecy::SecretString::new(String::new())),
+            pwhash: None,
+        }];
+        assert!(AuthorizationLayer::new(auth, None).is_err());
     }
 
     #[test]

--- a/zallet-core/src/components/json_rpc/server/method_logger.rs
+++ b/zallet-core/src/components/json_rpc/server/method_logger.rs
@@ -1,0 +1,40 @@
+//! Call logging for the JSON-RPC server.
+
+use futures::future::BoxFuture;
+use jsonrpsee::{
+    MethodResponse, server::middleware::rpc::RpcServiceT, tracing::debug, types::Request,
+};
+
+/// JSON-RPC middleware that logs each call by method name only.
+///
+/// This deliberately never logs call parameters or responses: they can carry
+/// secrets (wallet passphrases, exported or imported keys) and private
+/// transaction data, which must not end up in log output at any verbosity.
+#[derive(Clone)]
+pub struct MethodLoggerMiddleware<S> {
+    service: S,
+}
+
+impl<S> MethodLoggerMiddleware<S> {
+    /// Create a new `MethodLoggerMiddleware` with the given `service`.
+    pub fn new(service: S) -> Self {
+        Self { service }
+    }
+}
+
+impl<'a, S> RpcServiceT<'a> for MethodLoggerMiddleware<S>
+where
+    S: RpcServiceT<'a> + Send + Sync + Clone + 'static,
+{
+    type Future = BoxFuture<'a, MethodResponse>;
+
+    fn call(&self, request: Request<'a>) -> Self::Future {
+        let service = self.service.clone();
+        Box::pin(async move {
+            let method = request.method_name().to_owned();
+            let response = service.call(request).await;
+            debug!(method, is_error = response.is_error(), "rpc call");
+            response
+        })
+    }
+}

--- a/zallet-core/src/components/json_rpc/server/rpc_call_compatibility.rs
+++ b/zallet-core/src/components/json_rpc/server/rpc_call_compatibility.rs
@@ -24,6 +24,7 @@ use crate::components::json_rpc::server::error::LegacyCode;
 ///
 /// But these codes are different from `zcashd`, and some RPC clients rely on the exact
 /// code.
+#[derive(Clone)]
 pub struct FixRpcResponseMiddleware {
     service: RpcService,
 }
@@ -48,7 +49,8 @@ impl<'a> RpcServiceT<'a> for FixRpcResponseMiddleware {
                         .expect("response string should be valid json");
 
                 let replace_code = |old, new: ErrorObject<'_>| {
-                    debug!("Replacing RPC error: {old} with {new}");
+                    // Log only the codes; error messages can echo call parameters.
+                    debug!("Replacing RPC error code {old} with {}", new.code());
                     MethodResponse::error(result.id, new)
                 };
 

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -888,6 +888,15 @@ impl KeyStore {
                 && dfvk.decrypt_diversifier(address).is_some()
             {
                 let extsk = decrypt_standalone_sapling_extsk(&identities, &encrypted_extsk)?;
+
+                // The ciphertext is not bound to the DFVK the row is keyed by, so verify
+                // that the decrypted key reproduces the DFVK used for the lookup.
+                if extsk.to_diversifiable_full_viewing_key().to_bytes() != dfvk_array {
+                    return Err(ErrorKind::Generic
+                        .context(fl!("err-keystore-key-material-mismatch"))
+                        .into());
+                }
+
                 return Ok(Some(extsk));
             }
         }
@@ -1104,7 +1113,9 @@ fn encrypt_string(
 ///
 /// [ZIP 32]: https://zips.z.cash/zip-0032#seed-fingerprints
 fn seed_matches_fingerprint(seed: &[u8], seed_fp: &SeedFingerprint) -> bool {
-    SeedFingerprint::from_seed(seed).is_some_and(|fp| fp.to_bytes() == seed_fp.to_bytes())
+    use subtle::ConstantTimeEq;
+    SeedFingerprint::from_seed(seed)
+        .is_some_and(|fp| bool::from(fp.to_bytes().ct_eq(&seed_fp.to_bytes())))
 }
 
 /// Returns whether the seed derived from the given mnemonic phrase has the given [ZIP 32]


### PR DESCRIPTION
## Summary

Closes security findings surfaced by a third-party audit. Each commit maps
to one finding; see the finding-to-commit map below. Rebased onto current
`main` (post-0.1.0-beta.2, post-MSRV-1.95).

## Changes

### Privacy policy enforcement across all shielded pools
`e966780` — Replaces the pairwise Sapling↔Orchard checks in
`enforce_privacy_policy` and `required_privacy_policy` with a single
`shielded_pool_crossed_into(step)` helper that iterates
`all_shielded_pools()`. The pool list is an exhaustive match, so adding a
`ShieldedPool` variant fails to compile instead of silently bypassing the
gate. Ironwood and any future pool are covered by construction.

**Wire-compat note:** `RevealingSaplingAmount` / `RevealingOrchardAmount`
collapse into `RevealingShieldedAmount(ShieldedPool)`. The error *code* is
unchanged, but the error *message text* is now templated by
`PoolType::Shielded(pool).to_string()` rather than a fixed "…Sapling…" /
"…Orchard…" string. Clients that string-match on the message will see
different wording.

### Per-pool action limit
`c951703` — The `builder.limits.orchard_actions` transaction-size cap now
applies to each shielded pool's spends and outputs, not only Orchard's.

**Note:** The config key is intentionally retained as
`orchard_actions` for compatibility, but its semantics now cover Sapling
and Ironwood as well. The error message still references
`-orchardactionlimit=N`, which is the correct key but reads as a misnomer
for non-Orchard pools.

### Constant-time seed fingerprint comparison
`765da78` — `seed_matches_fingerprint` now uses `subtle::ConstantTimeEq`
instead of a short-circuiting `==`. Also adds a DFVK binding check for
decrypted standalone Sapling `extsk`: after decrypting, verifies
`extsk.to_diversifiable_full_viewing_key().to_bytes() == dfvk_array`
before returning, matching the checks already done for mnemonics, legacy
seeds, and transparent keys.

### Reject empty identity passphrases
`f7998db` — `generate-encryption-identity` now rejects empty passphrases
on both the `--passphrase-file` and interactive paths. An empty passphrase
previously produced an identity file that parsed as encrypted while being
trivially decryptable.

### Filesystem permissions
`92ca36c` — Datadir set to `0700` on lock; `wallet.db` created with
`create_new(true).mode(0o600)` or chmod'd to `0600` before SQLite opens it,
so journal/WAL/sidecar files inherit the database file's mode. Zero-length
file treated as missing to avoid a permissions window.

### Method-name-only RPC logging
`b0f79a4` — Replaces jsonrpsee's `rpc_logger(1024)` (which logged full call
parameters and responses) with `MethodLoggerMiddleware` that logs only the
method name and `is_error`. Compatibility middleware no longer logs full
replaced error objects — only error codes.

### Drop env-var passphrase, add `--passphrase-file`
`1477704` — `ZALLET_IDENTITY_PASSPHRASE` environment variable removed
(visible to sibling processes). `--passphrase-file PATH` reads the first
line from `-` (stdin) or a file. Buffer is `Zeroizing`.

### Reject empty RPC passwords
`fa29ee2` — `add-rpc-user` refuses an empty typed password; bare-password
`rpc.auth` config entries with an empty `password` fall through to the
existing error arm, so `AuthorizationLayer::new` returns
`err-init-rpc-auth-invalid`.

### Unit tests for privacy policy and action limit (review feedback)
`470fd2e` — Extracts the per-pool action limit check from `z_sendmany`
into `check_shielded_action_limits`, a pure function of the proposal, and
adds a `proposal_policy_tests` module that builds proposals in-memory from
dummy notes (the pattern used by `zcash_client_backend`'s own proposal
tests). Covers: every ordered pair of distinct shielded pools triggers
`RevealingShieldedAmount(pool)` under `FullPrivacy` (including the
Ironwood pairs the old pairwise checks missed) and passes under
`AllowRevealedAmounts`; same-pool steps satisfy `FullPrivacy`;
`required_privacy_policy` agreement; and the action limit for spends,
outputs, and combined actions in each pool, per-pool independence, and
the at-the-limit boundary.

## Finding → Commit Map

| Finding | Commit |
|---|---|
| Privacy policy misses Ironwood / future pools | `e966780` |
| Action limit only counts Orchard | `c951703` |
| Non-constant-time seed fingerprint compare; missing DFVK binding check | `765da78` |
| Empty passphrase produces trivially-decryptable "encrypted" identity | `f7998db` |
| Overly permissive datadir / wallet.db permissions | `92ca36c` |
| JSON-RPC logging leaks full parameters and responses | `b0f79a4` |
| `ZALLET_IDENTITY_PASSPHRASE` env var visible to sibling processes | `1477704` |
| Empty RPC password opens unauthenticated interface | `fa29ee2` |
| CHANGELOG documentation | `5807980` |
| CI: format imports + sync zaino lockfile | `d7d47ba` |
| Review feedback: unit tests for privacy policy + action limit | `470fd2e` |

## Known Follow-ups

- **Empty-RPC-password config-load path downgrades to a generic config
  parse error** (`err-init-rpc-auth-invalid`) rather than a targeted
  "empty password" message, unlike the `add-rpc-user` path which has a
  dedicated message.
- **`all_shielded_pools()` is `pub(super)` and duplicated in concept** —
  parallel pool enumeration exists in `view_transaction.rs`,
  `list_unspent.rs`, `get_notes_count.rs`. A single source of truth in
  `zcash_protocol` would prevent the next pool-addition bug.
