### PR TITLE
Implement z_sendfromaccount on the PCZT pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@ be considered breaking changes.
   - `pczt_extract` — verify the PCZT and extract the final, network-ready
     transaction, additionally recording it in the wallet (marking its inputs
     pending-spent) when the PCZT was created by this wallet.
+- `z_sendfromaccount` RPC method: send funds from an account UUID in one shot,
+  drawing only on the funds named by an isolating `fund_source` (`"orchard"`,
+  `"sapling"`, `"any_transparent"`, or an array of transparent addresses). The
+  transaction is assembled through the same PCZT pipeline as the `pczt_*`
+  methods, and the required `privacy_policy` argument acknowledges its
+  information leakage up front. For a review-first flow, use `pczt_create`
+  (which reports the policy a transaction would require) and the other
+  `pczt_*` methods instead.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,14 @@ be considered breaking changes.
   `minconf`, and `maxconf` was never applied to transparent outputs at all. An
   output of an unmined transaction is now reported only for `minconf = 0`, and
   both bounds remain inclusive.
+- The amounts/recipients objects of `z_sendmany`, `z_sendfromaccount`, and
+  `pczt_create` now reject unknown keys, as `zcashd` does. Previously a stray
+  key was silently ignored, so a misspelled `memo` field sent the payment
+  without its memo.
+- Async RPC operations whose task panics are now marked as failed, with the
+  panic message reported via `z_getoperationstatus` and `z_getoperationresult`.
+  Previously such operations remained in the `executing` state forever and
+  could not be pruned.
 - `z_getbalances` now reports the documented transparent balance split:
   `regular` contains only non-coinbase funds and `coinbase` is populated with
   coinbase funds (immature coinbase is reported as `pending` rather than

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -624,6 +624,39 @@ Use the `z_getaddressforaccount` RPC method to obtain addresses for an account.
   - `zip32_account_index` (numeric, required)
   - `birthday_height` (numeric, required)
 
+## `z_sendfromaccount`
+
+*Only available in wallet builds of Zallet.*
+
+Sends funds from an account in one shot, signing and broadcasting the
+transaction.
+
+Unlike `z_sendmany`, the source of funds is an account UUID together
+with an explicit fund source, rather than an address. The transaction is
+assembled through the same pipeline as the `pczt_*` methods (create,
+prove, sign, extract); use those methods directly to inspect a
+transaction before executing it. Unlike `z_sendmany`, the call completes
+synchronously, returning the txid rather than an operation id.
+
+#### Arguments
+- `account` (string, required) The UUID of the account to send the funds
+  from.
+- `fund_source` (string or array, required) Where funds may be drawn
+  from. One of the strings `"orchard"`, `"sapling"`,
+  `"any_transparent"`, or an array of transparent address strings. Each
+  source is isolating: a source that cannot cover the payment reports
+  insufficient funds rather than drawing on the account's other funds.
+  `"orchard"` includes the Ironwood pool, where an account's
+  Orchard-receiver funds are held once NU6.3 activates.
+- `recipients` (array, required) An array of JSON objects representing
+  the amounts to send, with the same shape as `z_sendmany`'s `amounts`.
+- `minconf` (numeric, optional) Only use funds confirmed at least this
+  many times.
+- `privacy_policy` (string, required) Policy for what information
+  leakage is acceptable, using the same values as `z_sendmany`.
+  Required: the send is not proposed for review first, so the caller
+  must acknowledge its privacy implications up front.
+
 ## `z_sendmany`
 
 *Only available in wallet builds of Zallet.*

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -87,6 +87,8 @@ mod z_get_total_balance;
 #[cfg(zallet_build = "wallet")]
 mod z_import_address;
 #[cfg(zallet_build = "wallet")]
+mod z_send_from_account;
+#[cfg(zallet_build = "wallet")]
 mod z_send_many;
 #[cfg(zallet_build = "wallet")]
 mod z_shieldcoinbase;
@@ -729,6 +731,44 @@ pub(crate) trait WalletRpc {
         privacy_policy: Option<String>,
     ) -> z_send_many::Response;
 
+    /// Sends funds from an account in one shot, signing and broadcasting the
+    /// transaction.
+    ///
+    /// Unlike `z_sendmany`, the source of funds is an account UUID together
+    /// with an explicit fund source, rather than an address. The transaction is
+    /// assembled through the same pipeline as the `pczt_*` methods (create,
+    /// prove, sign, extract); use those methods directly to inspect a
+    /// transaction before executing it. Unlike `z_sendmany`, the call completes
+    /// synchronously, returning the txid rather than an operation id.
+    ///
+    /// # Arguments
+    /// - `account` (string, required) The UUID of the account to send the funds
+    ///   from.
+    /// - `fund_source` (string or array, required) Where funds may be drawn
+    ///   from. One of the strings `"orchard"`, `"sapling"`,
+    ///   `"any_transparent"`, or an array of transparent address strings. Each
+    ///   source is isolating: a source that cannot cover the payment reports
+    ///   insufficient funds rather than drawing on the account's other funds.
+    ///   `"orchard"` includes the Ironwood pool, where an account's
+    ///   Orchard-receiver funds are held once NU6.3 activates.
+    /// - `recipients` (array, required) An array of JSON objects representing
+    ///   the amounts to send, with the same shape as `z_sendmany`'s `amounts`.
+    /// - `minconf` (numeric, optional) Only use funds confirmed at least this
+    ///   many times.
+    /// - `privacy_policy` (string, required) Policy for what information
+    ///   leakage is acceptable, using the same values as `z_sendmany`.
+    ///   Required: the send is not proposed for review first, so the caller
+    ///   must acknowledge its privacy implications up front.
+    #[method(name = "z_sendfromaccount")]
+    async fn z_send_from_account(
+        &self,
+        account: JsonValue,
+        fund_source: JsonValue,
+        recipients: Vec<AmountParameter>,
+        minconf: Option<u32>,
+        privacy_policy: String,
+    ) -> z_send_from_account::Response;
+
     /// Shields coinbase UTXOs from a single wallet-owned source into a
     /// shielded address.
     ///
@@ -1337,6 +1377,27 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
                 .await?,
             )
             .await)
+    }
+
+    async fn z_send_from_account(
+        &self,
+        account: JsonValue,
+        fund_source: JsonValue,
+        recipients: Vec<AmountParameter>,
+        minconf: Option<u32>,
+        privacy_policy: String,
+    ) -> z_send_from_account::Response {
+        z_send_from_account::call(
+            self.general.wallet.clone(),
+            self.keystore.clone(),
+            self.chain().await?,
+            account,
+            fund_source,
+            recipients,
+            minconf,
+            privacy_policy,
+        )
+        .await
     }
 
     async fn z_shieldcoinbase(

--- a/zallet-core/src/components/json_rpc/methods/pczt_create.rs
+++ b/zallet-core/src/components/json_rpc/methods/pczt_create.rs
@@ -17,10 +17,12 @@ use zcash_client_backend::{
         Account, WalletRead,
         wallet::{ConfirmationsPolicy, create_pczt_from_proposal, input_selection::SpendPolicy},
     },
+    fees::StandardFeeRule,
+    proposal::Proposal,
     wallet::OvkPolicy,
     zip321::TransactionRequest,
 };
-use zcash_client_sqlite::AccountUuid;
+use zcash_client_sqlite::{AccountUuid, ReceivedNoteId};
 use zcash_keys::address::Address;
 use zcash_primitives::transaction::builder::BundlePadding;
 
@@ -147,7 +149,7 @@ pub(crate) async fn call(
     let privacy_policy = parse_privacy_policy(privacy_policy.as_deref())?;
     let confirmations_policy = confirmations_policy_for_minconf(minconf)?;
 
-    let (pczt, required_policy) = build_pczt(
+    let (pczt, required_policy, _proposal) = build_pczt(
         &mut wallet,
         &account,
         &spend_policy,
@@ -166,8 +168,9 @@ pub(crate) async fn call(
 ///
 /// Enforces `privacy_policy` and the configured Orchard action limit on the
 /// proposal, then records Zallet's signing hints and the proposal's minimum
-/// required privacy policy as proprietary fields. The required policy is
-/// returned alongside the PCZT so the caller can report it.
+/// required privacy policy as proprietary fields. The required policy and the
+/// proposal itself are returned alongside the PCZT, so the caller can report
+/// the one and verify the eventual transaction against the other.
 ///
 /// Only single-step proposals can become a PCZT, so a request that would need
 /// more than one step (a ZIP 320 TEX recipient) is rejected rather than built.
@@ -178,7 +181,11 @@ pub(super) fn build_pczt(
     request: TransactionRequest,
     privacy_policy: PrivacyPolicy,
     confirmations_policy: ConfirmationsPolicy,
-) -> RpcResult<(Pczt, PrivacyPolicy)> {
+) -> RpcResult<(
+    Pczt,
+    PrivacyPolicy,
+    Proposal<StandardFeeRule, ReceivedNoteId>,
+)> {
     let params = *wallet.params();
     let proposal = propose_and_check(
         wallet.as_mut(),
@@ -302,5 +309,5 @@ pub(super) fn build_pczt(
         .map_err(PcztError::RecordSigningHints)?
         .finish();
 
-    Ok((pczt, required_policy))
+    Ok((pczt, required_policy, proposal))
 }

--- a/zallet-core/src/components/json_rpc/methods/z_send_from_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_from_account.rs
@@ -1,0 +1,170 @@
+//! `z_sendfromaccount` — send funds from an account in one shot.
+//!
+//! Unlike `z_sendmany`, the source of funds is an account UUID together with an
+//! explicit, isolating `fund_source`, rather than an address. The transaction
+//! is assembled by driving a PCZT through the same pipeline the `pczt_*`
+//! methods expose — create, prove, sign, extract — so this method differs from
+//! that flow only in doing it in one call and broadcasting the result.
+
+use jsonrpsee::core::{JsonValue, RpcResult};
+use secrecy::ExposeSecret;
+use zcash_client_backend::data_api::{Account, WalletRead};
+use zcash_encoding::ReverseHex;
+use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_protocol::TxId;
+
+use super::pczt_common::encode_pczt_base64;
+use super::{pczt_create, pczt_extract, pczt_prove, pczt_sign};
+use crate::{
+    components::{
+        chain::Chain,
+        database::{Database, DbHandle},
+        json_rpc::{
+            fund_source::FundSource,
+            payments::{
+                AmountParameter, SendResult, build_request, confirmations_policy_for_minconf,
+                parse_privacy_policy, verify_and_broadcast_transactions,
+            },
+            server::LegacyCode,
+            utils::parse_account_parameter,
+        },
+        keystore::KeyStore,
+    },
+    fl,
+};
+
+/// Response to a `z_sendfromaccount` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// The result of a `z_sendfromaccount` request: the resulting transaction ID(s).
+pub(crate) type ResultType = SendResult;
+
+pub(super) const PARAM_ACCOUNT_DESC: &str = "The UUID of the account to send the funds from.";
+pub(super) const PARAM_FUND_SOURCE_DESC: &str = "Where funds may be drawn from: \"orchard\", \"sapling\", \"any_transparent\", or an array \
+     of transparent addresses.";
+pub(super) const PARAM_RECIPIENTS_DESC: &str =
+    "An array of JSON objects representing the amounts to send.";
+pub(super) const PARAM_RECIPIENTS_REQUIRED: bool = true;
+pub(super) const PARAM_MINCONF_DESC: &str = "Only use funds confirmed at least this many times.";
+pub(super) const PARAM_PRIVACY_POLICY_DESC: &str =
+    "Policy for what information leakage is acceptable.";
+
+async fn wallet_handle(wallet: &Database) -> RpcResult<DbHandle> {
+    wallet
+        .handle()
+        .await
+        .map_err(|_| jsonrpsee::types::ErrorCode::InternalError.into())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn call<C: Chain>(
+    wallet: Database,
+    keystore: KeyStore,
+    chain: C,
+    account: JsonValue,
+    fund_source: JsonValue,
+    recipients: Vec<AmountParameter>,
+    minconf: Option<u32>,
+    privacy_policy: String,
+) -> Response {
+    let mut handle = wallet_handle(&wallet).await?;
+
+    let request = build_request(&recipients)?;
+
+    let account_id = parse_account_parameter(handle.as_ref(), &keystore, &account).await?;
+
+    // Fetch the account up front: it both validates that the account exists and
+    // provides the key derivation needed to sign the transaction.
+    let account = handle
+        .as_ref()
+        .get_account(account_id)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| LegacyCode::InvalidParameter.with_message(fl!("err-account-not-found")))?;
+
+    let fund_source = FundSource::parse(&fund_source, handle.params())?;
+
+    // This method sends in one shot, so the caller must acknowledge the privacy
+    // implications up front: the policy is required, not optional. It is
+    // enforced at proposal time here, and acknowledged again at the signing
+    // step below.
+    let privacy_policy = parse_privacy_policy(Some(&privacy_policy))?;
+
+    let confirmations_policy = confirmations_policy_for_minconf(minconf)?;
+
+    let (pczt, _required_policy, proposal) = pczt_create::build_pczt(
+        &mut handle,
+        &account,
+        &fund_source.spend_policy(),
+        request,
+        privacy_policy,
+        confirmations_policy,
+    )?;
+
+    // Derive the full viewing key from the wallet seed while we still hold the
+    // account. The built transaction's transparent outputs are verified against
+    // it before broadcast, because their addresses come from wallet database
+    // records that are not integrity-protected.
+    let derivation = account.source().key_derivation().ok_or_else(|| {
+        LegacyCode::InvalidAddressOrKey.with_message(fl!("err-account-no-payment-source"))
+    })?;
+
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            // TODO: Improve internal error types.
+            //       https://github.com/zcash/zallet/issues/256
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+    let ufvk = UnifiedSpendingKey::from_seed(
+        handle.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?
+    .to_unified_full_viewing_key();
+
+    // The remaining steps acquire their own wallet handles; do not hold this
+    // one across them.
+    drop(handle);
+
+    // Drive the PCZT through the same pipeline the `pczt_*` methods expose.
+    let proved = pczt_prove::call(&encode_pczt_base64(pczt)?).await?;
+
+    // `strict` guarantees that every input was signed: this wallet created the
+    // PCZT from its own account, so an unsigned input is a failure, not a
+    // multi-party hand-off. The caller's policy doubles as the acknowledgement
+    // that signing requires.
+    let signed = pczt_sign::call(
+        wallet_handle(&wallet).await?,
+        keystore.clone(),
+        &proved.pczt,
+        Some(privacy_policy.to_string()),
+        Some(true),
+    )
+    .await?;
+
+    // Extraction verifies the proofs and signatures, and records the
+    // transaction in the wallet so its inputs are marked pending-spent before
+    // broadcast.
+    let extracted = pczt_extract::call(wallet_handle(&wallet).await?, &signed.pczt).await?;
+
+    // The user-facing txid string is byte-reversed hex, per Bitcoin convention.
+    let txid = ReverseHex::decode(&extracted.txid)
+        .map(TxId::from_bytes)
+        .ok_or_else(|| LegacyCode::Misc.with_static("Failed to decode txid"))?;
+
+    let handle = wallet_handle(&wallet).await?;
+    verify_and_broadcast_transactions(
+        handle.as_ref(),
+        chain,
+        account_id,
+        &ufvk,
+        &proposal,
+        vec![txid],
+    )
+    .await
+}

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -45,7 +45,11 @@ use super::{
     utils::{ZCASH_LEGACY_ACCOUNT, zatoshis_from_value},
 };
 
+// `deny_unknown_fields` matches `zcashd`, which rejects unknown keys in the
+// amounts objects. Silently ignoring them is dangerous for a payment API: a
+// misspelled `memo` key would send the payment without its memo.
 #[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AmountParameter {
     /// A taddr, zaddr, or Unified Address.
     address: String,
@@ -844,6 +848,34 @@ pub(super) fn parse_memo(memo_hex: &str) -> RpcResult<MemoBytes> {
         LegacyCode::InvalidParameter
             .with_static("Invalid parameter, memo is longer than the maximum allowed 512 bytes.")
     })
+}
+
+#[cfg(test)]
+mod amount_parameter_tests {
+    use super::AmountParameter;
+
+    #[test]
+    fn accepts_the_known_keys() {
+        for json in [
+            r#"{"address": "taddr", "amount": 1}"#,
+            r#"{"address": "zaddr", "amount": "0.5", "memo": "00"}"#,
+        ] {
+            serde_json::from_str::<AmountParameter>(json).expect("known keys parse");
+        }
+    }
+
+    /// An unknown key must be rejected, as in `zcashd`: silently ignoring one
+    /// means a misspelled `memo` sends the payment without its memo.
+    #[test]
+    fn rejects_an_unknown_key() {
+        let err = match serde_json::from_str::<AmountParameter>(
+            r#"{"address": "zaddr", "amount": 1, "memmo": "00"}"#,
+        ) {
+            Ok(_) => panic!("unknown key should be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("memmo"), "{err}");
+    }
 }
 
 #[cfg(test)]

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -1302,7 +1302,7 @@ pub(super) async fn verify_and_broadcast_transactions<C: Chain, FeeRuleT, NoteRe
 }
 
 /// The result of sending a payment.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, documented::Documented, JsonSchema)]
 pub(crate) struct SendResult {
     /// The ID of the resulting transaction, if the payment only produced one.
     ///


### PR DESCRIPTION
Implements z_sendfromaccount. This one-shot method is a composition of: build_pczt (shared with pczt_create, now also returning the proposal) → pczt_prove → pczt_sign (strict, acknowledging the caller's policy) → pczt_extract (which records the transaction in the wallet) → the shared verify-and-broadcast path used by z_sendmany.

The fund_source parameter is the isolating source selector ported with the fixups: a source that cannot cover the payment reports insufficient funds rather than drawing on the account's other pools, and "orchard" includes Ironwood, where an account's Orchard-receiver funds live once NU6.3 activates.

Closes https://github.com/zcash/zallet/issues/217
Subsumes https://github.com/zcash/zallet/pull/531
[COR-300](https://linear.app/zodl/issue/COR-300/rpc-design-and-implement-z-sendfromaccount)