### PR TITLE
build: raise MSRV to Rust 1.95

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 Zallet is a Zcash full node wallet, designed to replace the legacy wallet that was included within zcashd.
 
 - **Rust edition**: 2024
-- **MSRV**: 1.88 (pinned in `rust-toolchain.toml`)
+- **MSRV**: 1.95 (pinned in `rust-toolchain.toml`)
 - **License**: MIT OR Apache-2.0
 - **Repository**: https://github.com/zcash/zallet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ be considered breaking changes.
 
 ### Changed
 
+- MSRV updated to 1.95.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Kris Nuttycombe <kris@electriccoin.co>",
 ]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 repository = "https://github.com/zcash/zallet"
 license = "MIT OR Apache-2.0"
 categories = ["cryptography::cryptocurrencies"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@
 
 # --- Stage 1: build ---------------------------------------------------------
 # Digest-pin the base so the build is a function of its inputs only (bump the
-# tag AND the digest together, deliberately). rust 1.91.1 on bookworm matches
+# tag AND the digest together, deliberately). rust 1.95.0 on bookworm matches
 # the runtime base below so the dynamically-linked glibc binary just works.
-FROM rust:1.91.1-slim-bookworm@sha256:8514999d4786ef12efe89239e86b3d0a021b94b9d35108c8efe6c79ca7dc1a65 AS builder
+FROM rust:1.95.0-slim-bookworm@sha256:d7482085ff5b415f84dba5647ae71606650bdef00db7aeb69f4b3d170c3e4082 AS builder
 
 # Build deps: protobuf (tonic/PROTOC), clang+llvm (bindgen / *-sys C/C++ deps),
 # pkg-config, and git (zaino-state's build.rs embeds the commit).
@@ -38,7 +38,7 @@ FROM rust:1.91.1-slim-bookworm@sha256:8514999d4786ef12efe89239e86b3d0a021b94b9d3
 # even though nothing in this repo changed. When that happens, re-read the
 # candidate versions from the pinned base and bump the offending pin:
 #
-#   docker run --rm rust:1.91.1-slim-bookworm@sha256:8514999d... \
+#   docker run --rm rust:1.95.0-slim-bookworm@sha256:d7482085... \
 #     bash -c 'apt-get update -qq && apt-cache policy protobuf-compiler'
 #
 # (Pinning apt to a snapshot.debian.org timestamp would make this immune, at the

--- a/Dockerfile.stagex
+++ b/Dockerfile.stagex
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM stagex/pallet-rust:1.91.1@sha256:4062550919db682ebaeea07661551b5b89b3921e3f3a2b0bc665ddea7f6af1ca AS pallet-rust
+FROM stagex/pallet-rust:1.95.0@sha256:2d90b9552412ee2c4fa2a13b489c2f28c044be7fb5d6a942bfd5a480a5c288fd AS pallet-rust
 FROM stagex/user-protobuf:26.1@sha256:b399bb058216a55130d83abcba4e5271d8630fff55abbb02ed40818b0d96ced1 AS protobuf
 FROM stagex/user-abseil-cpp:20240116.2@sha256:183e8aff7b3e8b37ab8e89a20a364a21d99ce506ae624028b92d3bed747d2c06 AS abseil-cpp
 
@@ -13,6 +13,7 @@ ENV SOURCE_DATE_EPOCH=1
 ENV TARGET_ARCH=x86_64-unknown-linux-musl
 ENV CFLAGS=-target\ x86_64-unknown-linux-musl
 ENV CXXFLAGS=-stdlib=libc++
+ENV CXXSTDLIB=c++
 ENV CARGO_HOME=/usr/local/cargo
 ENV CARGO_TARGET_DIR="/usr/src/zallet/target"
 ENV CARGO_INCREMENTAL=0

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -3047,8 +3047,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb.git?rev=0442de85de82234643b5ba0a8f66a13ecf31b17d#0442de85de82234643b5ba0a8f66a13ecf31b17d"
 dependencies = [
  "bindgen",
  "bzip2-sys",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Kris Nuttycombe <kris@electriccoin.co>",
 ]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 description = "A prototype wallet, using the Zaino chain indexer. Don't rely on this for privacy or with significant funds yet!"
 repository = "https://github.com/zcash/zallet"
 license = "MIT OR Apache-2.0"
@@ -72,6 +72,10 @@ once_cell = "1.2"
 tempfile = "3"
 
 [patch.crates-io]
+# Use libc++ when requested by the StageX musl builder. This upstream fix landed
+# after rocksdb 0.24.0 and can return to crates.io with the next release.
+librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
+
 # TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
 # `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash
 # 0.30/0.10 cohort matching this workspace and surfaces the Ironwood (NU6.3)

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -2908,8 +2908,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb.git?rev=0442de85de82234643b5ba0a8f66a13ecf31b17d#0442de85de82234643b5ba0a8f66a13ecf31b17d"
 dependencies = [
  "bindgen",
  "bzip2-sys",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Kris Nuttycombe <kris@electriccoin.co>",
 ]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 description = "A prototype wallet. Don't rely on this for privacy or with significant funds yet!"
 repository = "https://github.com/zcash/zallet"
 license = "MIT OR Apache-2.0"
@@ -74,6 +74,10 @@ rpc-cli = ["zallet-core/rpc-cli"]
 ## `tokio-console` support.
 tokio-console = ["zallet-core/tokio-console"]
 
+[patch.crates-io]
+# Use libc++ when requested by the StageX musl builder. This upstream fix landed
+# after rocksdb 0.24.0 and can return to crates.io with the next release.
+librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',

--- a/book/src/guide/installation/README.md
+++ b/book/src/guide/installation/README.md
@@ -90,7 +90,7 @@ Executable binaries are available for download on the [GitHub Releases page].
 
 To build Zallet from source, you will first need to install Rust and Cargo. Follow the
 instructions on the [Rust installation page]. Zallet currently requires at least Rust
-version 1.88.
+version 1.95.
 
 > WARNING: The following does not yet work because Zallet cannot be published to
 > [crates.io] while it has unpublished dependencies. This will be fixed before the 1.0.0

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         # crates.
         targetEnvSuffix =
           builtins.replaceStrings [ "-" "." ] [ "_" "_" ] muslTarget;
-        rustToolchain = pkgs.rust-bin.stable."1.88.0".default.override {
+        rustToolchain = pkgs.rust-bin.stable."1.95.0".default.override {
           targets = [ muslTarget ];
         };
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.95"
 components = [ "clippy", "rustfmt" ]

--- a/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
@@ -100,10 +100,10 @@ pub(crate) async fn call<C: Chain>(
         .chain_height()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
-    if let (Some(height), Some(tip)) = (start_height, chain_tip) {
-        if height > tip {
-            return Err(LegacyCode::InvalidParameter.with_static("Block height out of range."));
-        }
+    if let (Some(height), Some(tip)) = (start_height, chain_tip)
+        && height > tip
+    {
+        return Err(LegacyCode::InvalidParameter.with_static("Block height out of range."));
     }
 
     let hrp_fvk = wallet.params().hrp_sapling_extended_full_viewing_key();


### PR DESCRIPTION
## Summary

- Raise the root and backend workspace MSRV to a coordinated Rust 1.95 compiler floor.
- Update the pinned rustup, Docker, StageX, and Nix toolchains together, plus the developer documentation and release note.
- Use the upstream post-0.24 `librocksdb-sys` standard-library selection fix so the StageX builder can select libc++ while the Nix builder retains its native libstdc++ toolchain.

## Compatibility

Zallet now requires Rust 1.95 for source builds. The previous Rust 1.88 floor was introduced during the NU6.3 update because `zewif-zcashd` adopted let-chain syntax stabilized in Rust 1.88; it was a real minimum at the time, not an upper-bound compatibility constraint. The current dependency graph does not require a higher compiler, and Rust 1.96 adds no capability needed by this change.

Builders using the repository's pinned Docker, StageX, or Nix inputs receive the matching compiler automatically. The RocksDB source override can return to crates.io after a release containing the upstream C++ standard-library selection fix.
