### PR TITLE
ci: pass `toJSON(needs)` via env var instead of inline expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,4 +226,6 @@ jobs:
     steps:
       - name: Determine whether all required-pass steps succeeded
         run: |
-          echo '${{ toJSON(needs) }}' | jq -e '[ .[] | .result == "success" ] | all'
+          echo "${NEEDS}" | jq -e '[ .[] | .result == "success" ] | all'
+        env:
+          NEEDS: ${{ toJSON(needs) }}


### PR DESCRIPTION
Resolves code scanning alert [#45](https://github.com/zcash/zallet/security/code-scanning/45) (`zizmor/template-injection`, severity: note).

## The finding

`.github/workflows/ci.yml:229`, in the `required-checks` gate:

```yaml
- name: Determine whether all required-pass steps succeeded
  run: |
    echo '${{ toJSON(needs) }}' | jq -e '[ .[] | .result == "success" ] | all'
```

GitHub interpolates `${{ ... }}` into the `run:` block as **text, before the shell parses it**. A single quote anywhere in the expanded JSON would terminate the surrounding `'...'` and the remainder would be parsed as shell source.

## Exploitability

Low in practice, which matches zizmor's own `audit confidence → Low`. Neither needed job (`test-msrv-required`, `build-latest`) declares `outputs:`, so `toJSON(needs)` currently expands to nothing but job names and the fixed `result` enum — no attacker-controllable text. The hazard is latent: it becomes real the moment someone adds a job output derived from a PR title, branch name, or any other untrusted input, and that change would land in a *different* file than this one.

## The fix

Route the value through the environment so the shell receives it as **data**, never as source text. This is not a new pattern for this repo — `lints.yml` and `audits.yml` already use exactly this form for the identical gate; `ci.yml` was the last holdout, so this also removes the inconsistency.

## Verification

- Reproduced the alert locally with `zizmor --offline --persona regular` on the pre-fix file: flagged at `229:28`, the same line and column as alert #45.
- Re-ran on the fixed file: `No findings to report.`
- Full `.github/` scan post-fix is clean, so this closes out the last open zizmor finding in the repo.
- Confirmed the gate semantics are byte-identical: `echo "${NEEDS}"` preserves the multi-line pretty JSON that `toJSON` emits, and `jq -e` still exits `0` when every `result` is `success` and `1` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYacoAQ2BB2uM7z8oDHxhG