### PR TITLE
docs: explain why `add-rpc-user` prints its config snippet to stdout

### DIFF
--- a/zallet-core/src/commands/add_rpc_user.rs
+++ b/zallet-core/src/commands/add_rpc_user.rs
@@ -18,6 +18,13 @@ impl AsyncRunnable for AddRpcUserCmd {
 
         let pwhash = PasswordHash::from_bare(password.expose_secret());
 
+        // Emitting this snippet on stdout is the entire point of the command: the
+        // user pastes it into their `zallet.toml`. It is a deliverable, not a log —
+        // Zallet's only tracing subscriber writes to stderr, and there is no log
+        // file. `username` is the positional argument the user just supplied, so it
+        // is already in argv, and the password itself never leaves `SecretString`:
+        // only its salted hash is printed. CodeQL's `rust/cleartext-logging` still
+        // flags the `user` line, because it treats `println!` as a logging sink.
         eprintln!("{}", fl!("cmd-add-rpc-user-instructions"));
         eprintln!();
         println!("[[rpc.auth]]");


### PR DESCRIPTION
Addresses code scanning alert [#147](https://github.com/zcash/zallet/security/code-scanning/147) (`rust/cleartext-logging`, CodeQL, security severity **high**).

**Assessment: false positive. No behaviour change in this PR — comment only.**

## The finding

`zallet-core/src/commands/add_rpc_user.rs:24` — *"This operation writes `self.username` to a log file."*

```rust
println!("user = \"{}\"", self.username);
```

## Why it is not a vulnerability

- **It is not a log file.** Zallet's only tracing subscriber writes to `io::stderr` (`components/tracing.rs:27`) and no file writer is configured anywhere. `println!` goes straight to stdout via `std` and is never routed through `tracing` regardless. CodeQL flags it because the query models `println!` as a logging sink.
- **stdout is the deliverable.** The command exists to emit a config snippet for the user to paste into `zallet.toml` — the preceding line literally prints *"Add this to your zallet.toml file:"*. Redacting the username would break the command.
- **The username is not a secret.** It is the positional CLI argument the user supplied seconds earlier (`cli.rs:267`), so it is already in argv, the process table, and shell history.
- **The real secret is handled correctly.** The password is held in `SecretString`; `expose_secret()` is called only to feed `PasswordHash::from_bare`, which applies a random 16-byte salt and a KDF. What line 25 prints is `salt$hex(hash)` — never the password.

I also swept the crate for genuine leaks as a cross-check: no `expose_secret()` value reaches any print or log sink. The `expose_secret()` call sites feed seed fingerprints and an auth header, and `export_mnemonic` prints only the *encrypted* mnemonic behind an explicit warning.

## What this PR does

Records the above next to the code, so the next reader — or the next person triaging this alert — does not have to re-derive it. The alert itself is being dismissed as a false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYacoAQ2BB2uM7z8oDHxhG