### PR TITLE
fix(rpc): avoid wallet database pool deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,8 @@ be considered breaking changes.
 - Full Sapling `z_exportviewingkey` requests release their wallet database handle
   before reading encrypted seed material, avoiding a deadlock while wallet sync
   retains its long-lived database connections.
+- `z_getnewaccount` no longer deadlocks while wallet sync retains its long-lived
+  database connections.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,9 @@ be considered breaking changes.
 
 - Hot key imports, account creation, account recovery, and rescans now interrupt
   mempool following to scan newly scheduled work through the unchanged chain tip.
+- Full Sapling `z_exportviewingkey` requests release their wallet database handle
+  before reading encrypted seed material, avoiding a deadlock while wallet sync
+  retains its long-lived database connections.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,8 @@ be considered breaking changes.
   before decrypting spending keys, avoiding the same connection-pool deadlock.
 - `z_viewtransaction` releases its wallet database handle before reading legacy
   shielding keys, avoiding the same connection-pool deadlock.
+- `z_recoveraccounts` releases its wallet database handle before decrypting
+  seed material, avoiding the same connection-pool deadlock.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,8 @@ be considered breaking changes.
   database connections.
 - `z_sendmany` and `z_shieldcoinbase` release their wallet database handle
   before decrypting spending keys, avoiding the same connection-pool deadlock.
+- `z_viewtransaction` releases its wallet database handle before reading legacy
+  shielding keys, avoiding the same connection-pool deadlock.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,8 @@ be considered breaking changes.
   retains its long-lived database connections.
 - `z_getnewaccount` no longer deadlocks while wallet sync retains its long-lived
   database connections.
+- `z_sendmany` and `z_shieldcoinbase` release their wallet database handle
+  before decrypting spending keys, avoiding the same connection-pool deadlock.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -873,6 +873,7 @@ mod tests {
     #[derive(Clone)]
     pub(crate) struct MockChainView {
         tip: ChainBlock,
+        serves_empty_tree_states: bool,
     }
 
     impl ChainView for MockChainView {
@@ -894,9 +895,11 @@ mod tests {
 
         async fn tree_state_as_of(
             &self,
-            _height: BlockHeight,
+            height: BlockHeight,
         ) -> Result<Option<ChainState>, ChainError> {
-            Ok(None)
+            Ok(self
+                .serves_empty_tree_states
+                .then(|| ChainState::empty(height, BlockHash([0u8; 32]))))
         }
 
         async fn get_block_header(
@@ -978,7 +981,10 @@ mod tests {
             height: BlockHeight::from_u32(42),
             hash: BlockHash([7u8; 32]),
         };
-        let view = MockChainView { tip };
+        let view = MockChainView {
+            tip,
+            serves_empty_tree_states: false,
+        };
         assert_eq!(view.tip().await.unwrap(), tip);
         // The fork point resolves when the locator includes the view's own tip, and
         // not for a locator that excludes it.
@@ -1273,6 +1279,7 @@ mod tests {
         params: super::Network,
         upgrades: Vec<ReportedUpgrade>,
         tip: BlockHeight,
+        serves_empty_tree_states: bool,
     }
 
     impl MockChain {
@@ -1281,7 +1288,13 @@ mod tests {
                 params: super::Network::Consensus(Network::MainNetwork),
                 upgrades,
                 tip: BlockHeight::from_u32(tip),
+                serves_empty_tree_states: false,
             }
+        }
+
+        pub(crate) fn with_empty_tree_states(mut self) -> Self {
+            self.serves_empty_tree_states = true;
+            self
         }
     }
 
@@ -1332,6 +1345,7 @@ mod tests {
                     height: self.tip,
                     hash: BlockHash([0u8; 32]),
                 },
+                serves_empty_tree_states: self.serves_empty_tree_states,
             })
         }
     }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -1243,7 +1243,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         accounts: Vec<recover_accounts::AccountParameter<'_>>,
     ) -> recover_accounts::Response {
         recover_accounts::call(
-            self.wallet().await?,
+            &self.general.wallet,
             &self.keystore,
             self.chain().await?,
             &self.reconfiguration,

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -1131,7 +1131,7 @@ impl<C: Chain> RpcServer for RpcImpl<C> {
 
     async fn view_transaction(&self, txid: &str) -> view_transaction::Response {
         view_transaction::call(
-            self.wallet().await?.as_ref(),
+            &self.wallet,
             #[cfg(zallet_build = "wallet")]
             &self.keystore,
             self.chain().await?,

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -1228,7 +1228,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         seedfp: Option<&str>,
     ) -> get_new_account::Response {
         get_new_account::call(
-            self.wallet().await?,
+            &self.general.wallet,
             &self.keystore,
             self.chain().await?,
             &self.reconfiguration,

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -1445,7 +1445,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         zaddr: &str,
         ivk: Option<bool>,
     ) -> z_export_viewing_key::Response {
-        z_export_viewing_key::call(self.wallet().await?.as_ref(), &self.keystore, zaddr, ivk).await
+        z_export_viewing_key::call(self.wallet().await?, &self.keystore, zaddr, ivk).await
     }
 
     async fn pczt_create(

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -1377,7 +1377,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         // doing the expensive work of constructing a proposal.
         self.async_ops.check_capacity().await?;
         let (context, fut) = z_send_many::call(
-            self.wallet().await?,
+            self.general.wallet.clone(),
             self.keystore.clone(),
             self.chain().await?,
             fromaddress,
@@ -1425,7 +1425,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         // doing the expensive work of constructing a proposal.
         self.async_ops.check_capacity().await?;
         let (preflight, context, fut) = z_shieldcoinbase::call(
-            self.wallet().await?,
+            self.general.wallet.clone(),
             self.keystore.clone(),
             self.chain().await?,
             fromaddress,

--- a/zallet-core/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_new_account.rs
@@ -1,12 +1,13 @@
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use jsonrpsee::types::ErrorCode as RpcErrorCode;
 use schemars::JsonSchema;
 use serde::Serialize;
 use zcash_client_backend::data_api::{AccountBirthday, WalletRead, WalletWrite};
 
 use crate::components::{
     chain::{Chain, ChainView},
-    database::DbHandle,
+    database::Database,
     json_rpc::{
         server::LegacyCode,
         utils::{ensure_wallet_is_unlocked, parse_seedfp_parameter},
@@ -35,7 +36,7 @@ pub(super) const PARAM_SEEDFP_DESC: &str =
     "ZIP 32 seed fingerprint for the BIP 39 mnemonic phrase from which to derive the account.";
 
 pub(crate) async fn call<C: Chain>(
-    mut wallet: DbHandle,
+    wallet: &Database,
     keystore: &KeyStore,
     chain: C,
     reconfiguration: &WalletSyncReconfiguration,
@@ -53,18 +54,23 @@ pub(crate) async fn call<C: Chain>(
         .await
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
-    let chain_height = wallet
+    let chain_tip = chain_view
+        .tip()
+        .await
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+    let wallet_handle = wallet
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
+    let chain_height = wallet_handle
         .chain_height()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
         .ok_or(LegacyCode::InWarmup.with_static("Wallet sync required"))?
         // Tolerate race conditions between this RPC and the sync engine.
-        .min(
-            chain_view
-                .tip()
-                .await
-                .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-                .height(),
-        );
+        .min(chain_tip.height());
+    // Keystore reads acquire their own pooled connection. Release this read handle before
+    // entering the keystore while sync retains its four long-lived connections.
+    drop(wallet_handle);
     let treestate_height = chain_height.saturating_sub(1);
 
     let chain_state = chain_view
@@ -100,11 +106,17 @@ pub(crate) async fn call<C: Chain>(
         .await
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
+    let mut wallet_handle = wallet
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
+    // Reserve the mutation connection before waiting for exclusive sync admission so two
+    // concurrent key mutations cannot acquire those resources in opposite orders.
     let admitted = reconfiguration.admit_reconfiguration().await;
-    let (account_id, _usk) = wallet
+    let (account_id, _usk) = wallet_handle
         .create_account(account_name, &seed, &birthday, None)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
-    drop(wallet);
+    drop(wallet_handle);
 
     // Reload viewing keys so the new account is scanned without a restart (see z_importkey).
     if !admitted.reload_keys_and_wake_wallet_recovery().await {
@@ -116,4 +128,116 @@ pub(crate) async fn call<C: Chain>(
         // TODO: Should we ever set this in Zallet?
         account: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use age::secrecy::ExposeSecret;
+    use bip0039::{English, Mnemonic};
+    use secrecy::SecretVec;
+    use zcash_client_backend::data_api::{
+        AccountBirthday, WalletRead as _, WalletWrite as _, chain::ChainState,
+    };
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::consensus::BlockHeight;
+
+    use super::super::{WalletRpcImpl, WalletRpcServer};
+    use crate::{
+        components::{
+            chain::MockChain,
+            database::Database,
+            keystore::KeyStore,
+            sync::{WalletSync, WalletSyncReconfiguration, status},
+        },
+        config::ZalletConfig,
+    };
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const SYNC_CONNECTION_COUNT: usize = 4;
+    const TIP_HEIGHT: u32 = 500_100;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rpc_creates_account_while_sync_retains_database_connections() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let identity = age::x25519::Identity::generate();
+        std::fs::write(
+            config.encryption_identity(),
+            identity.to_string().expose_secret(),
+        )
+        .expect("writes unencrypted identity");
+
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let keystore = KeyStore::new(&config, database.clone()).expect("creates keystore");
+        keystore
+            .initialize_recipients(vec![identity.to_public().to_string()])
+            .await
+            .expect("initializes unencrypted keystore");
+        let mnemonic =
+            Mnemonic::<English>::from_phrase(TEST_MNEMONIC).expect("parses test mnemonic");
+        let seed = SecretVec::new(mnemonic.to_seed("").to_vec());
+        keystore
+            .encrypt_and_store_mnemonic(mnemonic)
+            .await
+            .expect("stores test mnemonic");
+
+        let mut setup_wallet = database.handle().await.expect("reserves setup database");
+        setup_wallet
+            .create_account(
+                "existing account",
+                &seed,
+                &AccountBirthday::from_parts(
+                    ChainState::empty(BlockHeight::from_u32(TIP_HEIGHT - 1), BlockHash([0u8; 32])),
+                    None,
+                ),
+                None,
+            )
+            .expect("creates existing account");
+        setup_wallet
+            .update_chain_tip(BlockHeight::from_u32(TIP_HEIGHT))
+            .expect("records chain tip");
+        drop(setup_wallet);
+
+        let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
+        drop(decryptor_engine);
+        let (_sync_status_writer, sync_status) = status::channel(config.sync.lock_threshold());
+        let rpc = WalletRpcImpl::new(
+            database.clone(),
+            keystore,
+            MockChain::reporting(Vec::new(), TIP_HEIGHT).with_empty_tree_states(),
+            WalletSyncReconfiguration::new(decryptor),
+            sync_status,
+            config.rpc.async_operation_limit(),
+        );
+        let mut sync_wallets = Vec::with_capacity(SYNC_CONNECTION_COUNT);
+        for _ in 0..SYNC_CONNECTION_COUNT {
+            sync_wallets.push(database.handle().await.expect("reserves sync database"));
+        }
+
+        let account = tokio::time::timeout(
+            Duration::from_secs(10),
+            WalletRpcServer::get_new_account(&rpc, "saturation test", None),
+        )
+        .await
+        .expect("account creation completes while sync retains database connections")
+        .expect("creates account");
+
+        let wallet = database.handle().await.expect("reopens wallet database");
+        assert!(account.account_uuid.parse::<uuid::Uuid>().is_ok());
+        assert_eq!(
+            wallet
+                .get_account_ids()
+                .expect("lists created wallet accounts")
+                .len(),
+            2
+        );
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use documented::Documented;
-use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
+use jsonrpsee::{
+    core::RpcResult,
+    types::{ErrorCode as RpcErrorCode, ErrorObjectOwned},
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use zcash_client_backend::data_api::{Account as _, AccountBirthday, WalletRead, WalletWrite};
@@ -9,7 +12,7 @@ use zcash_protocol::consensus::BlockHeight;
 
 use crate::components::{
     chain::{Chain, ChainView},
-    database::DbHandle,
+    database::Database,
     json_rpc::{
         server::LegacyCode,
         utils::{ensure_wallet_is_unlocked, parse_seedfp_parameter},
@@ -52,7 +55,7 @@ pub(super) const PARAM_ACCOUNTS_DESC: &str =
 pub(super) const PARAM_ACCOUNTS_REQUIRED: bool = true;
 
 pub(crate) async fn call<C: Chain>(
-    mut wallet: DbHandle,
+    wallet: &Database,
     keystore: &KeyStore,
     chain: C,
     reconfiguration: &WalletSyncReconfiguration,
@@ -67,10 +70,17 @@ pub(crate) async fn call<C: Chain>(
         .await
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
-    let recover_until = wallet
+    let wallet_handle = wallet
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
+    let recover_until = wallet_handle
         .chain_height()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
         .ok_or(LegacyCode::InWarmup.with_static("Wallet sync required"))?;
+    // Keystore reads acquire their own pooled connection. Release this read handle before
+    // decrypting seeds while sync retains its four long-lived connections.
+    drop(wallet_handle);
 
     // Prepare arguments for the wallet.
     let mut account_args = vec![];
@@ -119,13 +129,19 @@ pub(crate) async fn call<C: Chain>(
     }
 
     // Import the accounts.
+    let mut wallet_handle = wallet
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
+    // Reserve the mutation connection before waiting for exclusive sync admission so two
+    // concurrent key mutations cannot acquire those resources in opposite orders.
     let admitted = reconfiguration.admit_reconfiguration().await;
     let accounts = account_args
         .into_iter()
         .map(|(account_name, seed_fp, account_index, birthday)| {
             let seed = seeds.get(&seed_fp).expect("present");
 
-            let (account, _usk) = wallet
+            let (account, _usk) = wallet_handle
                 .import_account_hd(account_name, seed, account_index, &birthday, None)
                 .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
@@ -136,7 +152,7 @@ pub(crate) async fn call<C: Chain>(
             })
         })
         .collect::<Result<_, _>>()?;
-    drop(wallet);
+    drop(wallet_handle);
 
     // Reload viewing keys so recovered accounts are scanned without a restart (see z_importkey).
     if !admitted.reload_keys_and_wake_wallet_recovery().await {
@@ -146,4 +162,117 @@ pub(crate) async fn call<C: Chain>(
     }
 
     Ok(Accounts { accounts })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use age::secrecy::ExposeSecret as _;
+    use bip0039::{English, Mnemonic};
+    use secrecy::{ExposeSecret as _, SecretVec};
+    use zcash_client_backend::data_api::{WalletRead as _, WalletWrite as _};
+    use zcash_protocol::consensus::BlockHeight;
+    use zip32::fingerprint::SeedFingerprint;
+
+    use super::{
+        super::{WalletRpcImpl, WalletRpcServer},
+        AccountParameter,
+    };
+    use crate::{
+        components::{
+            chain::MockChain,
+            database::Database,
+            keystore::KeyStore,
+            sync::{WalletSync, WalletSyncReconfiguration, status},
+        },
+        config::ZalletConfig,
+    };
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const SYNC_CONNECTION_COUNT: usize = 4;
+    const TIP_HEIGHT: u32 = 500_100;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rpc_recovers_account_while_sync_retains_database_connections() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let identity = age::x25519::Identity::generate();
+        std::fs::write(
+            config.encryption_identity(),
+            identity.to_string().expose_secret(),
+        )
+        .expect("writes unencrypted identity");
+
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let keystore = KeyStore::new(&config, database.clone()).expect("creates keystore");
+        keystore
+            .initialize_recipients(vec![identity.to_public().to_string()])
+            .await
+            .expect("initializes unencrypted keystore");
+        let mnemonic =
+            Mnemonic::<English>::from_phrase(TEST_MNEMONIC).expect("parses test mnemonic");
+        let seed = SecretVec::new(mnemonic.to_seed("").to_vec());
+        let seedfp = SeedFingerprint::from_seed(seed.expose_secret())
+            .expect("derives seed fingerprint")
+            .to_string();
+        keystore
+            .encrypt_and_store_mnemonic(mnemonic)
+            .await
+            .expect("stores test mnemonic");
+
+        let mut setup_wallet = database.handle().await.expect("reserves setup database");
+        setup_wallet
+            .update_chain_tip(BlockHeight::from_u32(TIP_HEIGHT))
+            .expect("records chain tip");
+        drop(setup_wallet);
+
+        let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
+        drop(decryptor_engine);
+        let (_sync_status_writer, sync_status) = status::channel(config.sync.lock_threshold());
+        let rpc = WalletRpcImpl::new(
+            database.clone(),
+            keystore,
+            MockChain::reporting(Vec::new(), TIP_HEIGHT).with_empty_tree_states(),
+            WalletSyncReconfiguration::new(decryptor),
+            sync_status,
+            config.rpc.async_operation_limit(),
+        );
+        let mut sync_wallets = Vec::with_capacity(SYNC_CONNECTION_COUNT);
+        for _ in 0..SYNC_CONNECTION_COUNT {
+            sync_wallets.push(database.handle().await.expect("reserves sync database"));
+        }
+
+        let recovered = tokio::time::timeout(
+            Duration::from_secs(10),
+            WalletRpcServer::recover_accounts(
+                &rpc,
+                vec![AccountParameter {
+                    name: "saturation test",
+                    seedfp: &seedfp,
+                    zip32_account_index: 0,
+                    birthday_height: TIP_HEIGHT,
+                }],
+            ),
+        )
+        .await
+        .expect("account recovery completes while sync retains database connections")
+        .expect("recovers account");
+
+        let wallet = database.handle().await.expect("reopens wallet database");
+        assert_eq!(recovered.accounts.len(), 1);
+        assert_eq!(
+            wallet
+                .get_account_ids()
+                .expect("lists recovered wallet accounts")
+                .len(),
+            1
+        );
+    }
 }

--- a/zallet-core/src/components/json_rpc/methods/view_transaction.rs
+++ b/zallet-core/src/components/json_rpc/methods/view_transaction.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
+use jsonrpsee::types::ErrorCode as RpcErrorCode;
 use orchard::note_encryption::{
     DomainVersion, IronwoodVersion, NoteEncryptionDomain, OrchardVersion,
 };
@@ -26,7 +27,7 @@ use zcash_protocol::{
 
 use crate::components::{
     chain::{Chain, ChainView},
-    database::DbConnection,
+    database::{Database, DbConnection},
     json_rpc::{
         server::LegacyCode,
         utils::{JsonZec, parse_txid, value_from_zatoshis},
@@ -36,6 +37,7 @@ use crate::components::{
 #[cfg(zallet_build = "wallet")]
 use {
     crate::components::{
+        database::DbHandle,
         json_rpc::utils::{JsonZecBalance, value_from_zat_balance},
         keystore::KeyStore,
     },
@@ -310,8 +312,52 @@ fn ovk_for_shielding_from_taddr(raw_seed: &[u8]) -> [u8; 32] {
     ovk
 }
 
+#[cfg(zallet_build = "wallet")]
+async fn collect_legacy_transparent_shielding_ovks(
+    wallet: DbHandle,
+    keystore: &KeyStore,
+) -> RpcResult<Vec<([u8; 32], zip32::Scope)>> {
+    // Keystore operations acquire their own database connections. Release the RPC's
+    // connection first so these lookups cannot deadlock when wallet sync retains the
+    // other connections in the pool.
+    drop(wallet);
+
+    let mut ovks = vec![];
+
+    // Mnemonic seeds use the BIP 39 seed bytes; legacy non-mnemonic seeds use their
+    // raw imported bytes. Either could have been the active `zcashd` HD seed, so try
+    // both. Decryption fails when the wallet is locked, so skip on error rather than
+    // failing the whole request.
+    for seed_fp in keystore
+        .list_seed_fingerprints()
+        .await
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+    {
+        if let Ok(seed) = keystore.decrypt_seed(&seed_fp).await {
+            ovks.push((
+                ovk_for_shielding_from_taddr(seed.expose_secret()),
+                zip32::Scope::External,
+            ));
+        }
+    }
+    for seed_fp in keystore
+        .list_legacy_seed_fingerprints()
+        .await
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+    {
+        if let Ok(seed) = keystore.decrypt_legacy_seed(&seed_fp).await {
+            ovks.push((
+                ovk_for_shielding_from_taddr(seed.expose_secret()),
+                zip32::Scope::External,
+            ));
+        }
+    }
+
+    Ok(ovks)
+}
+
 pub(crate) async fn call<C: Chain>(
-    wallet: &DbConnection,
+    database: &Database,
     #[cfg(zallet_build = "wallet")] keystore: &KeyStore,
     chain: C,
     txid_str: &str,
@@ -322,6 +368,11 @@ pub(crate) async fn call<C: Chain>(
         .snapshot()
         .await
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    let wallet = database
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
 
     let tx = wallet
         .get_transaction(txid)
@@ -386,36 +437,14 @@ pub(crate) async fn call<C: Chain>(
     // to external shielded" outputs. This requires the seed, so it is best-effort: if the
     // wallet is locked we simply skip it (the modern OVKs above still apply).
     #[cfg(zallet_build = "wallet")]
-    {
-        // Mnemonic seeds use the BIP 39 seed bytes; legacy non-mnemonic seeds use their
-        // raw imported bytes. Either could have been the active `zcashd` HD seed, so try
-        // both. Decryption fails when the wallet is locked, so skip on error rather than
-        // failing the whole request.
-        for seed_fp in keystore
-            .list_seed_fingerprints()
+    let wallet = {
+        ovks.extend(collect_legacy_transparent_shielding_ovks(wallet, keystore).await?);
+        database
+            .handle()
             .await
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-        {
-            if let Ok(seed) = keystore.decrypt_seed(&seed_fp).await {
-                ovks.push((
-                    ovk_for_shielding_from_taddr(seed.expose_secret()),
-                    zip32::Scope::External,
-                ));
-            }
-        }
-        for seed_fp in keystore
-            .list_legacy_seed_fingerprints()
-            .await
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-        {
-            if let Ok(seed) = keystore.decrypt_legacy_seed(&seed_fp).await {
-                ovks.push((
-                    ovk_for_shielding_from_taddr(seed.expose_secret()),
-                    zip32::Scope::External,
-                ));
-            }
-        }
-    }
+            .map_err(|_| RpcErrorCode::InternalError)?
+    };
+    let wallet = wallet.as_ref();
 
     // TODO: Add `WalletRead::get_note_with_nullifier`
     type OutputInfo = (TxId, u16, AccountUuid, Option<String>, Zatoshis);
@@ -1146,7 +1175,70 @@ fn is_expiring_soon_tx(
 
 #[cfg(all(test, zallet_build = "wallet"))]
 mod tests {
+    use std::time::Duration;
+
+    use age::secrecy::ExposeSecret as _;
+    use bip0039::{English, Mnemonic};
+
     use super::*;
+    use crate::config::ZalletConfig;
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const SYNC_CONNECTION_COUNT: usize = 4;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn legacy_shielding_ovk_lookup_releases_wallet_connection() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let identity = age::x25519::Identity::generate();
+        std::fs::write(
+            config.encryption_identity(),
+            identity.to_string().expose_secret(),
+        )
+        .expect("writes unencrypted identity");
+
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let keystore = KeyStore::new(&config, database.clone()).expect("creates keystore");
+        keystore
+            .initialize_recipients(vec![identity.to_public().to_string()])
+            .await
+            .expect("initializes unencrypted keystore");
+        let mnemonic =
+            Mnemonic::<English>::from_phrase(TEST_MNEMONIC).expect("parses test mnemonic");
+        let expected_seed = mnemonic.to_seed("");
+        keystore
+            .encrypt_and_store_mnemonic(mnemonic)
+            .await
+            .expect("stores test mnemonic");
+
+        let mut sync_wallets = Vec::with_capacity(SYNC_CONNECTION_COUNT);
+        for _ in 0..SYNC_CONNECTION_COUNT {
+            sync_wallets.push(database.handle().await.expect("reserves sync database"));
+        }
+        let wallet = database.handle().await.expect("reserves RPC database");
+
+        let ovks = tokio::time::timeout(
+            Duration::from_secs(1),
+            collect_legacy_transparent_shielding_ovks(wallet, &keystore),
+        )
+        .await
+        .expect("OVK lookup completes while sync retains database connections")
+        .expect("derives legacy shielding OVKs");
+
+        assert_eq!(
+            ovks,
+            vec![(
+                ovk_for_shielding_from_taddr(&expected_seed),
+                zip32::Scope::External,
+            )]
+        );
+    }
 
     #[test]
     fn ovk_for_shielding_from_taddr_matches_zcashd() {

--- a/zallet-core/src/components/json_rpc/methods/z_export_viewing_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_export_viewing_key.rs
@@ -10,7 +10,7 @@ use zcash_keys::{
 use zcash_protocol::consensus::NetworkConstants;
 
 use crate::components::{
-    database::DbConnection,
+    database::DbHandle,
     json_rpc::{
         payments::get_account_for_address, server::LegacyCode, utils::ensure_wallet_is_unlocked,
     },
@@ -29,7 +29,7 @@ pub(super) const PARAM_ZADDR_DESC: &str = "The Sapling payment address or unifie
 pub(super) const PARAM_IVK_DESC: &str = "Whether to export the unified incoming viewing key (UIVK) instead of the full viewing key. Default is false.";
 
 pub(crate) async fn call(
-    wallet: &DbConnection,
+    wallet: DbHandle,
     keystore: &KeyStore,
     zaddr: &str,
     ivk: Option<bool>,
@@ -43,7 +43,7 @@ pub(crate) async fn call(
 
     match &address {
         Address::Unified(_) => {
-            let account = get_account_for_address(wallet, &address).map_err(|e| {
+            let account = get_account_for_address(wallet.as_ref(), &address).map_err(|e| {
                 // Align the "address not held" error with the Sapling path below;
                 // `get_account_for_address` reports it with a payment-oriented message.
                 if e.code() == LegacyCode::InvalidAddressOrKey as i32 {
@@ -102,10 +102,13 @@ pub(crate) async fn call(
                     "Wallet does not hold private key or viewing key for this zaddr",
                 ))?;
 
-            let derivation = account.source().key_derivation().ok_or_else(|| {
+            let derivation = account.source().key_derivation().cloned().ok_or_else(|| {
                 LegacyCode::Wallet
                     .with_static("Cannot export viewing key for an imported view-only account")
             })?;
+            let params = *wallet.params();
+            let ufvk = ufvk.clone();
+            drop(wallet);
 
             let seed = keystore
                 .decrypt_seed(derivation.seed_fingerprint())
@@ -120,7 +123,7 @@ pub(crate) async fn call(
                 })?;
 
             let usk = UnifiedSpendingKey::from_seed(
-                wallet.params(),
+                &params,
                 seed.expose_secret(),
                 derivation.account_index(),
             )
@@ -143,7 +146,7 @@ pub(crate) async fn call(
             #[allow(deprecated)]
             let extfvk = usk.sapling().to_extended_full_viewing_key();
 
-            let hrp = wallet.params().hrp_sapling_extended_full_viewing_key();
+            let hrp = params.hrp_sapling_extended_full_viewing_key();
             Ok(ResultType(encode_extended_full_viewing_key(hrp, &extfvk)))
         }
         _ => Err(LegacyCode::InvalidAddressOrKey
@@ -153,6 +156,12 @@ pub(crate) async fn call(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use age::secrecy::ExposeSecret as _;
+    use bip0039::{English, Mnemonic};
+    use secrecy::SecretVec;
+    use zcash_client_backend::data_api::{AccountBirthday, WalletWrite};
     use zcash_keys::{
         encoding::{
             decode_extended_full_viewing_key, encode_extended_full_viewing_key,
@@ -160,10 +169,22 @@ mod tests {
         },
         keys::UnifiedFullViewingKey,
     };
+    use zcash_primitives::block::BlockHash;
     use zcash_protocol::{
-        consensus::{MAIN_NETWORK, TEST_NETWORK},
+        consensus::{BlockHeight, MAIN_NETWORK, NetworkConstants, TEST_NETWORK},
         constants,
     };
+
+    use super::call;
+    use crate::{
+        components::{database::Database, keystore::KeyStore},
+        config::ZalletConfig,
+    };
+
+    const ACCOUNT_BIRTHDAY_HEIGHT: u32 = 1;
+    const EXPORT_COMPLETION_TIMEOUT: Duration = Duration::from_secs(1);
+    const LIFELONG_SYNC_CONNECTIONS: usize = 4;
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     /// Constructs a UFVK (with only a Sapling component) from seed `[0; 32]`.
     fn test_ufvk() -> UnifiedFullViewingKey {
@@ -301,5 +322,72 @@ mod tests {
         let reimported_addr = encode_payment_address(hrp_addr, &reimported_payment_addr);
 
         assert_eq!(original_addr, reimported_addr);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn full_sapling_export_releases_rpc_connection_before_keystore_lookup() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let identity = age::x25519::Identity::generate();
+        std::fs::write(
+            config.encryption_identity(),
+            identity.to_string().expose_secret(),
+        )
+        .expect("writes unencrypted identity");
+
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let keystore = KeyStore::new(&config, database.clone()).expect("creates keystore");
+        keystore
+            .initialize_recipients(vec![identity.to_public().to_string()])
+            .await
+            .expect("initializes unencrypted keystore");
+        let mnemonic =
+            Mnemonic::<English>::from_phrase(TEST_MNEMONIC).expect("parses test mnemonic");
+        let seed = SecretVec::new(mnemonic.to_seed("").to_vec());
+        keystore
+            .encrypt_and_store_mnemonic(mnemonic)
+            .await
+            .expect("stores test mnemonic");
+
+        let mut setup_wallet = database.handle().await.expect("reserves setup database");
+        let birthday = AccountBirthday::from_parts(
+            zcash_client_backend::data_api::chain::ChainState::empty(
+                BlockHeight::from_u32(ACCOUNT_BIRTHDAY_HEIGHT),
+                BlockHash([0; 32]),
+            ),
+            None,
+        );
+        let (_, usk) = setup_wallet
+            .create_account("export test account", &seed, &birthday, None)
+            .expect("creates HD account");
+        #[allow(deprecated)]
+        let extfvk = usk.sapling().to_extended_full_viewing_key();
+        let (_, sapling_address) = extfvk.default_address();
+        let zaddr = encode_payment_address(
+            setup_wallet.params().hrp_sapling_payment_address(),
+            &sapling_address,
+        );
+        drop(setup_wallet);
+
+        let mut sync_wallets = Vec::with_capacity(LIFELONG_SYNC_CONNECTIONS);
+        for _ in 0..LIFELONG_SYNC_CONNECTIONS {
+            sync_wallets.push(database.handle().await.expect("reserves sync database"));
+        }
+        let rpc_wallet = database.handle().await.expect("reserves RPC database");
+
+        let result = tokio::time::timeout(
+            EXPORT_COMPLETION_TIMEOUT,
+            call(rpc_wallet, &keystore, &zaddr, None),
+        )
+        .await
+        .expect("full Sapling export completes while sync retains database connections")
+        .expect("exports full Sapling viewing key");
+        assert!(result.0.starts_with("zxviews"));
     }
 }

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -3,6 +3,7 @@ use std::convert::Infallible;
 use abscissa_core::Application;
 
 use jsonrpsee::core::{JsonValue, RpcResult};
+use jsonrpsee::types::ErrorCode as RpcErrorCode;
 use secrecy::ExposeSecret;
 use serde_json::json;
 use zcash_client_backend::data_api::wallet::SpendingKeys;
@@ -28,13 +29,14 @@ use zcash_proofs::prover::LocalTxProver;
 use crate::{
     components::{
         chain::Chain,
-        database::DbHandle,
+        database::{Database, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
             payments::{
                 AmountParameter, SendResult, build_request, confirmations_policy_for_minconf,
-                get_account_for_address, get_legacy_pool_account, parse_privacy_policy,
-                propose_and_check, spend_policy_for, verify_and_broadcast_transactions,
+                decrypt_spending_seed, get_account_for_address, get_legacy_pool_account,
+                parse_privacy_policy, propose_and_check, spend_policy_for,
+                verify_and_broadcast_transactions,
             },
             server::LegacyCode,
         },
@@ -45,7 +47,9 @@ use crate::{
 };
 
 #[cfg(feature = "zcashd-import")]
-use crate::components::json_rpc::utils::collect_standalone_transparent_keys;
+use crate::components::json_rpc::utils::{
+    decrypt_standalone_transparent_keys, standalone_transparent_input_addresses,
+};
 
 /// Response to a `z_sendmany` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -84,7 +88,7 @@ fn legacy_pool_spend_policy() -> SpendPolicy {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn call<C: Chain>(
-    mut wallet: DbHandle,
+    database: Database,
     keystore: KeyStore,
     chain: C,
     fromaddress: String,
@@ -104,6 +108,10 @@ pub(crate) async fn call<C: Chain>(
             .with_static("Zallet always calculates fees internally; the fee field must be null."));
     }
 
+    let mut wallet = database
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
     let request = build_request(&amounts)?;
 
     let (account, spend_policy) = match fromaddress.as_str() {
@@ -159,33 +167,29 @@ pub(crate) async fn call<C: Chain>(
         &spend_policy,
     )?;
 
-    let derivation = account.source().key_derivation().ok_or_else(|| {
+    let account_id = account.id();
+    let derivation = account.source().key_derivation().cloned().ok_or_else(|| {
         LegacyCode::InvalidAddressOrKey.with_message(fl!("err-from-address-no-payment-source"))
     })?;
 
+    #[cfg(feature = "zcashd-import")]
+    let standalone_input_addresses =
+        standalone_transparent_input_addresses(wallet.as_ref(), account_id, &proposal)?;
+
     // Fetch spending key last, to avoid a keystore decryption if unnecessary.
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            // TODO: Improve internal error types.
-            //       https://github.com/zcash/zallet/issues/256
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
-        })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+    let seed = decrypt_spending_seed(wallet, &keystore, derivation.seed_fingerprint()).await?;
+    let usk =
+        UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), derivation.account_index())
+            .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
     #[cfg(feature = "zcashd-import")]
     let standalone_keys =
-        collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account.id(), &proposal)
-            .await?;
+        decrypt_standalone_transparent_keys(&keystore, standalone_input_addresses).await?;
+
+    let wallet = database
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
 
     // TODO: verify that the proposal satisfies the requested privacy policy
 
@@ -201,7 +205,7 @@ pub(crate) async fn call<C: Chain>(
         run(
             wallet,
             chain,
-            account.id(),
+            account_id,
             usk.to_unified_full_viewing_key(),
             proposal,
             #[cfg(feature = "zcashd-import")]

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
+use jsonrpsee::types::ErrorCode as RpcErrorCode;
 use schemars::JsonSchema;
 use secrecy::ExposeSecret;
 use serde::Serialize;
@@ -36,10 +37,13 @@ use crate::components::json_rpc::payments::{check_shielded_action_limits, enforc
 use crate::{
     components::{
         chain::Chain,
-        database::{DbConnection, DbHandle},
+        database::{Database, DbConnection, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
-            payments::{PrivacyPolicy, SendResult, parse_memo, verify_and_broadcast_transactions},
+            payments::{
+                PrivacyPolicy, SendResult, decrypt_spending_seed, parse_memo,
+                verify_and_broadcast_transactions,
+            },
             server::LegacyCode,
             utils::{JsonZec, value_from_zatoshis},
         },
@@ -50,7 +54,9 @@ use crate::{
 };
 
 #[cfg(feature = "zcashd-import")]
-use crate::components::json_rpc::utils::collect_standalone_transparent_keys;
+use crate::components::json_rpc::utils::{
+    decrypt_standalone_transparent_keys, standalone_transparent_input_addresses,
+};
 
 /// The result of a `z_shieldcoinbase` pre-flight call.
 ///
@@ -147,7 +153,7 @@ pub(super) const COINBASE_INPUTS_WARN_THRESHOLD: u64 = 400;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn call<C: Chain>(
-    mut wallet: DbHandle,
+    database: Database,
     keystore: KeyStore,
     chain: C,
     fromaddress: String,
@@ -180,6 +186,11 @@ pub(crate) async fn call<C: Chain>(
     // Parse the memo parameter (hex-encoded).
     let memo = memo.as_deref().map(parse_memo).transpose()?;
     let limit_usize = limit.map(|n| n as usize);
+
+    let mut wallet = database
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
 
     // Classify `fromaddress` before touching the DB, so we can use its shape
     // (single t-addr vs account UUID) to pick the default privacy policy.
@@ -305,32 +316,30 @@ pub(crate) async fn call<C: Chain>(
     };
 
     // Derive the spending key for the source account.
-    let derivation = account.source().key_derivation().ok_or_else(|| {
+    let derivation = account.source().key_derivation().cloned().ok_or_else(|| {
         LegacyCode::InvalidAddressOrKey.with_message(format!(
             "No payment source found for account {}.",
             account_id.expose_uuid(),
         ))
     })?;
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
-        })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+
+    #[cfg(feature = "zcashd-import")]
+    let standalone_input_addresses =
+        standalone_transparent_input_addresses(wallet.as_ref(), account_id, &proposal)?;
+
+    let seed = decrypt_spending_seed(wallet, &keystore, derivation.seed_fingerprint()).await?;
+    let usk =
+        UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), derivation.account_index())
+            .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
     #[cfg(feature = "zcashd-import")]
     let standalone_keys =
-        collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account_id, &proposal)
-            .await?;
+        decrypt_standalone_transparent_keys(&keystore, standalone_input_addresses).await?;
+
+    let wallet = database
+        .handle()
+        .await
+        .map_err(|_| RpcErrorCode::InternalError)?;
 
     Ok((
         preflight,

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -33,6 +33,15 @@ use zcash_protocol::{
 };
 use zip32::{AccountId, fingerprint::SeedFingerprint};
 
+#[cfg(zallet_build = "wallet")]
+use {
+    crate::{
+        components::{database::DbHandle, keystore::KeyStore},
+        error::ErrorKind,
+    },
+    secrecy::SecretVec,
+};
+
 use crate::{
     components::{chain::Chain, database::DbConnection},
     fl,
@@ -357,6 +366,97 @@ pub(super) fn propose_and_check(
     })?;
 
     Ok(proposal)
+}
+
+/// Decrypts an account seed without retaining the wallet connection used to select it.
+///
+/// Wallet sync retains all but one pooled connection. Consuming and releasing the foreground
+/// handle before the keystore lookup prevents spending RPCs from waiting for a sixth connection.
+#[cfg(zallet_build = "wallet")]
+pub(super) async fn decrypt_spending_seed(
+    wallet: DbHandle,
+    keystore: &KeyStore,
+    seed_fingerprint: &SeedFingerprint,
+) -> RpcResult<SecretVec<u8>> {
+    drop(wallet);
+    keystore
+        .decrypt_seed(seed_fingerprint)
+        .await
+        .map_err(|e| match e.kind() {
+            ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })
+}
+
+#[cfg(all(test, zallet_build = "wallet"))]
+mod spending_seed_tests {
+    use std::time::Duration;
+
+    use age::secrecy::ExposeSecret as _;
+    use bip0039::{English, Mnemonic};
+    use secrecy::ExposeSecret as _;
+    use zip32::fingerprint::SeedFingerprint;
+
+    use super::decrypt_spending_seed;
+    use crate::{
+        components::{database::Database, keystore::KeyStore},
+        config::ZalletConfig,
+    };
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const SYNC_CONNECTION_COUNT: usize = 4;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn spending_seed_decryption_releases_wallet_connection() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let identity = age::x25519::Identity::generate();
+        std::fs::write(
+            config.encryption_identity(),
+            identity.to_string().expose_secret(),
+        )
+        .expect("writes unencrypted identity");
+
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let keystore = KeyStore::new(&config, database.clone()).expect("creates keystore");
+        keystore
+            .initialize_recipients(vec![identity.to_public().to_string()])
+            .await
+            .expect("initializes unencrypted keystore");
+        let mnemonic =
+            Mnemonic::<English>::from_phrase(TEST_MNEMONIC).expect("parses test mnemonic");
+        let expected_seed = mnemonic.to_seed("");
+        let seed_fingerprint =
+            SeedFingerprint::from_seed(&expected_seed).expect("derives seed fingerprint");
+        keystore
+            .encrypt_and_store_mnemonic(mnemonic)
+            .await
+            .expect("stores test mnemonic");
+
+        let mut sync_wallets = Vec::with_capacity(SYNC_CONNECTION_COUNT);
+        for _ in 0..SYNC_CONNECTION_COUNT {
+            sync_wallets.push(database.handle().await.expect("reserves sync database"));
+        }
+        let wallet = database.handle().await.expect("reserves RPC database");
+
+        let decrypted_seed = tokio::time::timeout(
+            Duration::from_secs(1),
+            decrypt_spending_seed(wallet, &keystore, &seed_fingerprint),
+        )
+        .await
+        .expect("seed decryption completes while sync retains database connections")
+        .expect("decrypts spending seed");
+
+        assert_eq!(decrypted_seed.expose_secret(), &expected_seed);
+    }
 }
 
 /// A strategy to use for managing privacy when constructing a transaction.

--- a/zallet-core/src/components/json_rpc/utils.rs
+++ b/zallet-core/src/components/json_rpc/utils.rs
@@ -60,27 +60,20 @@ pub(super) async fn ensure_wallet_is_unlocked(keystore: &KeyStore) -> RpcResult<
     }
 }
 
-/// Collects the standalone (non-HD) transparent spending keys required to sign the
-/// transparent inputs of `proposal`.
+/// Identifies standalone transparent inputs whose keys are needed to sign `proposal`.
 ///
 /// Determines which transparent receivers in this account were imported standalone
-/// (vs. HD-derived). Only those have an associated entry in the keystore's
-/// standalone-key table; HD-derived receivers are signed for using `usk` and must not
-/// be looked up via `decrypt_standalone_transparent_key` (which would error with
-/// `QueryReturnedNoRows`).
+/// rather than HD-derived. This database-only phase must finish before callers release
+/// their wallet handle and enter the keystore.
 ///
-/// Gated on `zcashd-import` because the keystore's standalone-key table (and the
-/// `decrypt_standalone_transparent_key` accessor) only exists under that feature.
-/// Also gated on the `wallet` build because its only callers (`z_send_many` and
-/// `z_shieldcoinbase`) are wallet-only, and the `DbConnection`/`KeyStore` types it
-/// uses are only imported in that build.
+/// Gated on `zcashd-import` because the keystore's standalone-key table and its
+/// corresponding signing path exist only under that feature.
 #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
-pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
+pub(super) fn standalone_transparent_input_addresses<NoteRef>(
     wallet: &DbConnection,
-    keystore: &KeyStore,
     account_id: AccountUuid,
     proposal: &Proposal<StandardFeeRule, NoteRef>,
-) -> RpcResult<HashMap<TransparentAddress, Vec<secp256k1::SecretKey>>> {
+) -> RpcResult<Vec<TransparentAddress>> {
     let standalone_addrs: HashSet<TransparentAddress> = wallet
         .get_transparent_receivers(account_id, true, true)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
@@ -95,7 +88,7 @@ pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
         })
         .collect();
 
-    let mut keys: HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> = HashMap::new();
+    let mut input_addresses = Vec::new();
     for step in proposal.steps() {
         for input in step.transparent_inputs() {
             if let Some(address) = script::FromChain::parse(&input.txout().script_pubkey().0)
@@ -106,19 +99,32 @@ pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
                 if !standalone_addrs.contains(&address) {
                     continue;
                 }
-                let secret_key = keystore
-                    .decrypt_standalone_transparent_key(&address)
-                    .await
-                    .map_err(|e| match e.kind() {
-                        // TODO: Improve internal error types.
-                        ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                            LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-                        }
-                        _ => LegacyCode::Database.with_message(e.to_string()),
-                    })?;
-                keys.entry(address).or_default().push(secret_key);
+                input_addresses.push(address);
             }
         }
+    }
+    Ok(input_addresses)
+}
+
+/// Decrypts the staged standalone transparent keys without retaining a wallet handle.
+#[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+pub(super) async fn decrypt_standalone_transparent_keys(
+    keystore: &KeyStore,
+    input_addresses: Vec<TransparentAddress>,
+) -> RpcResult<HashMap<TransparentAddress, Vec<secp256k1::SecretKey>>> {
+    let mut keys: HashMap<TransparentAddress, Vec<secp256k1::SecretKey>> = HashMap::new();
+    for address in input_addresses {
+        let secret_key = keystore
+            .decrypt_standalone_transparent_key(&address)
+            .await
+            .map_err(|e| match e.kind() {
+                // TODO: Improve internal error types.
+                ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                    LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+                }
+                _ => LegacyCode::Database.with_message(e.to_string()),
+            })?;
+        keys.entry(address).or_default().push(secret_key);
     }
     Ok(keys)
 }


### PR DESCRIPTION
Closes #708.

Depends on #714 because account creation and recovery must reserve their database connection before waiting for exclusive wallet-reconfiguration admission. The remaining RPC handle-ordering fixes share the same connection-pool failure mode.

Several wallet RPCs held the last foreground database connection while keystore or signing work attempted to acquire another. Under normal sync ownership, those nested acquisitions could wait indefinitely.

## What changes

- Stages database-backed inputs before nested keystore or signing work.
- Releases foreground handles before acquiring key material, then reacquires one connection for the final wallet operation.
- Applies one resource-ordering rule to account creation, recovery, key export, account listing, transaction inspection, and spending.