### PR TITLE
Close remaining gaps in the hardening changes from #677

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,12 +92,23 @@ be considered breaking changes.
 - The `builder.limits.orchard_actions` transaction-size limit now applies to
   each shielded pool's spends and outputs, not only Orchard's.
 - Empty JSON-RPC passwords are now rejected, both by `add-rpc-user` and when
-  loading a bare `rpc.auth` password from the config.
-- `zallet rpc help` is now answered locally instead of being sent to the
-  wallet's JSON-RPC server, so it no longer requires a config file, an
-  initialized wallet, or a running `zallet start`. The command argument may
-  now be passed bare (`zallet rpc help getwalletinfo`) in addition to the
-  JSON-quoted form.
+  loading a bare `rpc.auth` password from the config. This includes a
+  configured `pwhash` that was generated from an empty password, which
+  authenticates the secretless credential `<username>:`.
+- `zallet rpc` accepts a parameter written `@PATH`, read from the first line of
+  `PATH` and sent as a JSON string. Use it for secrets such as the spending key
+  given to `z_importkey`: command-line arguments are visible to other local
+  users and are recorded in shell history. `@-` reads standard input, prompting
+  without echo when it is a terminal.
+- `generate-encryption-identity` now creates missing parent directories with
+  mode 0700 on Unix, rather than at the process umask.
+- `z_sendmany` now rejects a recipient count that exceeds the
+  `builder.limits.orchard_actions` limit before selecting inputs, rather than
+  after building a proposal.
+- `z_shieldcoinbase` now applies the `builder.limits.orchard_actions` limit to
+  its proposal; previously it had no action limit, so shielding a large
+  coinbase UTXO set without the `limit` parameter was bounded only at
+  broadcast time.
 - The standalone release binaries are now published as one signed archive per
   platform, `zallet-<version>-<arch>.tar.gz`, containing all three binaries
   (`zallet`, `zallet-zebra`, `zallet-zaino`). Previously each binary was a

--- a/backends/zebra/tests/acceptance.rs
+++ b/backends/zebra/tests/acceptance.rs
@@ -356,6 +356,20 @@ fn generate_encryption_identity_creates_missing_parent_dir() {
         nested.exists(),
         "nested output path should have been created"
     );
+
+    // The created directories hold the encryption identity, so they must not be
+    // readable by other local users regardless of the umask this test runs under.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for dir in [
+            nested.parent().unwrap(),
+            datadir.path().join("sub").as_path(),
+        ] {
+            let mode = std::fs::metadata(dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "{} should be owner-only", dir.display());
+        }
+    }
 }
 
 /// With `-p` and `--passphrase-file -`, the passphrase is read from standard

--- a/book/src/cli/rpc.md
+++ b/book/src/cli/rpc.md
@@ -10,6 +10,31 @@ command-line shell.
 - `zallet rpc <method>` will call that JSON-RPC method. Parameters can be provided via
   additional CLI arguments (`zallet rpc <method> <param>`).
 
+## Secret parameters
+
+Command-line arguments are visible to other users through process listings, and your
+shell records them in its history. Some JSON-RPC methods take secrets as parameters —
+the spending key given to `z_importkey`, the passphrase given to `walletpassphrase` —
+which should not be passed that way.
+
+Write such a parameter as `@PATH` instead. Zallet reads the first line of `PATH` and
+sends it as a JSON string, so no quoting is needed:
+
+```
+# Read the key from a pipe.
+$ get-key-from-vault | zallet rpc z_importkey @- '"whenkeyisnew"'
+
+# Read the key from a file descriptor, without it ever touching disk.
+$ zallet rpc z_importkey @/dev/fd/3 3<<<"$KEY"
+
+# Prompt for the key without echoing it.
+$ zallet rpc z_importkey @-
+Enter parameter value:
+```
+
+`@-` reads from standard input, prompting without echo when standard input is a
+terminal. Prefer a pipe or file descriptor over a regular file on disk.
+
 ## Authentication
 
 When Zallet starts its JSON-RPC server, it generates a random cookie credential and
@@ -30,7 +55,7 @@ below:
 |-----------------------------------|------------------------------------|
 | `zcash-cli -conf=<file>`          | `zallet --config <file> rpc`       |
 | `zcash-cli -datadir=<dir>`        | `zallet --datadir <dir> rpc`       |
-| `zcash-cli -stdin`                | Not implemented                    |
+| `zcash-cli -stdin`                | `@-` parameter (see above)         |
 | `zcash-cli -rpcconnect=<ip>`      | `rpc.bind` setting in config file  |
 | `zcash-cli -rpcport=<port>`       | `rpc.bind` setting in config file  |
 | `zcash-cli -rpcwait`              | Not implemented                    |

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -43,6 +43,7 @@ flags-header = Options
 ## Command prompts & output
 
 cmd-add-rpc-user-prompt = Enter password:
+rpc-cli-param-prompt = Enter parameter value:
 cmd-add-rpc-user-password-empty = Password must not be empty.
 cmd-add-rpc-user-instructions = Add this to your {-zallet_toml} file:
 cmd-seed-fingerprint = Seed fingerprint: {$seedfp}
@@ -477,6 +478,7 @@ err-rpc-convert-tex-not-p2pkh = Address is not a transparent p2pkh address
 
 err-rpc-cli-conn-failed = Failed to connect to the Zallet wallet's JSON-RPC port.
 err-rpc-cli-invalid-param = Invalid parameter '{$parameter}'
+err-rpc-cli-param-read-failed = Failed to read parameter from {$path}: {$error}
 err-rpc-cli-no-server = No JSON-RPC port is available.
 err-rpc-cli-request-failed = JSON-RPC request failed: {$error}
 

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -425,6 +425,11 @@ err-ux-C = {"                    "}
 
 ## Limit errors
 
+err-excess-recipients =
+    Sending to {$count} recipients would exceed the current limit of {$limit}
+    actions, which exists to prevent memory exhaustion, because every recipient
+    needs at least one output. Restart with '{$config}' where {$bound} to allow
+    the wallet to attempt to construct this transaction.
 err-excess-shielded-actions =
     Including {$count} {$pool} {$kind} would exceed the current limit of
     {$limit} actions, which exists to prevent memory exhaustion. Restart with

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -295,7 +295,15 @@ pub(crate) struct RpcCliCmd {
     /// Use `zallet rpc help` to get a list of RPC endpoints.
     pub(crate) command: String,
 
-    /// Any parameters for the command.
+    /// Any parameters for the command, as JSON values.
+    ///
+    /// A parameter of the form `@PATH` is read from the first line of `PATH`
+    /// instead, and passed as a JSON string. Use this for secrets such as the
+    /// spending key given to `z_importkey`: command-line arguments are visible
+    /// to other processes and are recorded in shell history.
+    ///
+    /// `@-` reads from standard input, prompting without echo if it is a
+    /// terminal. `@/dev/fd/3` reads from a caller-supplied file descriptor.
     pub(crate) params: Vec<String>,
 }
 

--- a/zallet-core/src/commands/generate_encryption_identity.rs
+++ b/zallet-core/src/commands/generate_encryption_identity.rs
@@ -47,8 +47,18 @@ impl AsyncRunnable for GenerateEncryptionIdentityCmd {
         if let Some(path) = output_path {
             // Ensure the parent directory exists; `generate-encryption-identity`
             // is typically the first command run against a fresh data directory.
+            //
+            // Directories created here hold the encryption identity, and for the default
+            // layout later the wallet database too, so create them owner-only rather than
+            // at the process umask (commonly 022, which would leave them world-readable).
+            // This command does not take the data directory lock, so it cannot rely on
+            // `lock_datadir` to restrict the datadir on a later run.
             if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
-                tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                let mut builder = tokio::fs::DirBuilder::new();
+                builder.recursive(true);
+                #[cfg(unix)]
+                builder.mode(0o700);
+                builder.create(parent).await.map_err(|e| {
                     ErrorKind::Init.context(fl!(
                         "cmd-generate-encryption-identity-write-failed",
                         path = path.display().to_string(),

--- a/zallet-core/src/commands/rpc_cli.rs
+++ b/zallet-core/src/commands/rpc_cli.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::time::Duration;
 
 use abscissa_core::Runnable;
+use age::secrecy::zeroize::Zeroizing;
 use base64ct::{Base64, Encoding};
 use hyper::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use jsonrpsee::core::{client::ClientT, params::ArrayParams};
@@ -122,8 +123,11 @@ impl AsyncRunnable for RpcCliCmd {
         // Construct the request.
         let mut params = ArrayParams::new();
         for param in &self.params {
-            let value: serde_json::Value = serde_json::from_str(param)
-                .map_err(|_| RpcCliError::InvalidParameter(param.clone()))?;
+            let value = match param.strip_prefix('@') {
+                Some(source) => serde_json::Value::String(read_indirect_param(source)?),
+                None => serde_json::from_str(param)
+                    .map_err(|_| RpcCliError::InvalidParameter(param.clone()))?,
+            };
             params
                 .insert(value)
                 .map_err(|_| RpcCliError::InvalidParameter(param.clone()))?;
@@ -146,6 +150,51 @@ impl AsyncRunnable for RpcCliCmd {
     }
 }
 
+/// Reads the value of an `@PATH` parameter: the first line of `PATH`, without its line
+/// terminator.
+///
+/// `-` means standard input, prompting without echo when it is a terminal. This exists so
+/// that secret parameters (a `z_importkey` spending key, a `walletpassphrase` passphrase)
+/// never have to appear in the process argument vector, where other local users can read
+/// them from process listings and where the shell records them in its history.
+fn read_indirect_param(source: &str) -> Result<String, RpcCliError> {
+    use std::io::{BufRead, IsTerminal};
+
+    let read_failed = |e: std::io::Error| RpcCliError::ParamReadFailed {
+        source: source.to_string(),
+        error: e.to_string(),
+    };
+
+    if source == "-" && std::io::stdin().is_terminal() {
+        return rpassword::prompt_password(fl!("rpc-cli-param-prompt")).map_err(read_failed);
+    }
+
+    // The buffer holds the parameter in the clear, so zeroize it on drop.
+    let mut buf = Zeroizing::new(Vec::new());
+    if source == "-" {
+        std::io::stdin()
+            .lock()
+            .read_until(b'\n', &mut buf)
+            .map_err(read_failed)?;
+    } else {
+        let file = std::fs::File::open(source).map_err(read_failed)?;
+        std::io::BufReader::new(file)
+            .read_until(b'\n', &mut buf)
+            .map_err(read_failed)?;
+    }
+
+    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+        buf.pop();
+    }
+
+    std::str::from_utf8(&buf)
+        .map(|s| s.to_owned())
+        .map_err(|e| RpcCliError::ParamReadFailed {
+            source: source.to_string(),
+            error: e.to_string(),
+        })
+}
+
 impl Runnable for RpcCliCmd {
     fn run(&self) {
         self.run_on_runtime();
@@ -159,6 +208,13 @@ pub enum RpcCliError {
     FailedToConnect,
     /// A request parameter was not valid JSON.
     InvalidParameter(String),
+    /// An `@PATH` request parameter could not be read.
+    ParamReadFailed {
+        /// The `PATH` the parameter was to be read from.
+        source: String,
+        /// Why reading it failed.
+        error: String,
+    },
     /// The JSON-RPC request failed.
     RequestFailed(String),
     /// The wallet is not running a JSON-RPC server.
@@ -172,6 +228,14 @@ impl fmt::Display for RpcCliError {
             Self::InvalidParameter(param) => {
                 wfl!(f, "err-rpc-cli-invalid-param", parameter = param)
             }
+            Self::ParamReadFailed { source, error } => {
+                wfl!(
+                    f,
+                    "err-rpc-cli-param-read-failed",
+                    path = source,
+                    error = error
+                )
+            }
             Self::RequestFailed(e) => {
                 wfl!(f, "err-rpc-cli-request-failed", error = e)
             }
@@ -181,3 +245,42 @@ impl fmt::Display for RpcCliError {
 }
 
 impl std::error::Error for RpcCliError {}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use super::read_indirect_param;
+
+    /// Writes `contents` to a temporary file and returns its path.
+    fn temp_file(contents: &[u8]) -> tempfile::TempPath {
+        let mut f = tempfile::NamedTempFile::new().expect("creates temp file");
+        f.write_all(contents).expect("writes temp file");
+        f.into_temp_path()
+    }
+
+    /// Only the first line is taken, and the line terminator is not part of the value:
+    /// a here-doc or `echo` adds a trailing newline that is not part of the secret.
+    #[test]
+    fn reads_first_line_without_terminator() {
+        for (contents, expected) in [
+            (&b"secret-key"[..], "secret-key"),
+            (&b"secret-key\n"[..], "secret-key"),
+            (&b"secret-key\r\n"[..], "secret-key"),
+            (&b"secret-key\nnot this\n"[..], "secret-key"),
+            (&b""[..], ""),
+        ] {
+            let path = temp_file(contents);
+            assert_eq!(
+                read_indirect_param(path.to_str().expect("valid path")).expect("reads param"),
+                expected,
+                "contents {contents:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        assert!(read_indirect_param("/nonexistent/zallet-rpc-param").is_err());
+    }
+}

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -1,5 +1,7 @@
 use std::convert::Infallible;
 
+use abscissa_core::Application;
+
 use jsonrpsee::core::{JsonValue, RpcResult};
 use secrecy::ExposeSecret;
 use serde_json::json;
@@ -39,6 +41,7 @@ use crate::{
         keystore::KeyStore,
     },
     fl,
+    prelude::APP,
 };
 
 #[cfg(feature = "zcashd-import")]
@@ -126,8 +129,22 @@ pub(crate) async fn call<C: Chain>(
 
     let privacy_policy = parse_privacy_policy(privacy_policy.as_deref())?;
 
-    // Sanity check for transaction size
-    // TODO: https://github.com/zcash/zallet/issues/255
+    // Reject an oversized recipient set before input selection and proving, which both
+    // scale with it. Every recipient needs at least one output in its pool, so this only
+    // rejects requests the post-proposal per-pool check would reject anyway.
+    //
+    // TODO: also bound the serialized transaction size.
+    // https://github.com/zcash/zallet/issues/255
+    let actions_limit: usize = APP.config().builder.limits.orchard_actions().into();
+    if amounts.len() > actions_limit {
+        return Err(LegacyCode::Misc.with_message(fl!(
+            "err-excess-recipients",
+            count = amounts.len(),
+            limit = actions_limit,
+            config = "-orchardactionlimit=N",
+            bound = format!("N >= %u"),
+        )));
+    }
 
     let confirmations_policy = confirmations_policy_for_minconf(minconf)?;
 

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -30,9 +30,9 @@ use zcash_keys::{
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
 };
 use zcash_proofs::prover::LocalTxProver;
-use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{PoolType, value::Zatoshis};
 
-use crate::components::json_rpc::payments::enforce_privacy_policy;
+use crate::components::json_rpc::payments::{check_shielded_action_limits, enforce_privacy_policy};
 use crate::{
     components::{
         chain::Chain,
@@ -45,6 +45,7 @@ use crate::{
         },
         keystore::KeyStore,
     },
+    fl,
     prelude::*,
 };
 
@@ -237,6 +238,24 @@ pub(crate) async fn call<C: Chain>(
     // parsed above bounds which of these leakages the caller is willing to accept;
     // `enforce_privacy_policy` rejects the proposal if it requires more than the caller permitted.
     enforce_privacy_policy(&proposal, privacy_policy)?;
+
+    // Bound the transaction the same way `z_sendmany` does. Shielding a large coinbase
+    // UTXO set is exactly the case that produces an oversized transaction: without
+    // `limit`, the proposal takes every eligible UTXO, and this method's own
+    // documentation warns that the result can exceed transaction-size limits. Rejecting
+    // it here costs one proposal, versus proving a transaction that cannot be built.
+    let actions_limit = APP.config().builder.limits.orchard_actions().into();
+    check_shielded_action_limits(&proposal, actions_limit).map_err(|e| {
+        LegacyCode::Misc.with_message(fl!(
+            "err-excess-shielded-actions",
+            pool = PoolType::Shielded(e.pool).to_string(),
+            count = e.count,
+            kind = e.kind,
+            limit = actions_limit,
+            config = "-orchardactionlimit=N",
+            bound = format!("N >= %u"),
+        ))
+    })?;
 
     // Pre-flight numerics. We compute `remaining_*` by enumerating all eligible coinbase UTXOs
     // (`total_*`) and subtracting the ones the proposal selected (`shielding_*`). The

--- a/zallet-core/src/components/json_rpc/server/authorization.rs
+++ b/zallet-core/src/components/json_rpc/server/authorization.rs
@@ -170,7 +170,12 @@ impl AuthorizationLayer {
                 }
                 (None, Some(pwhash)) => {
                     using_pwhash = true;
-                    Ok((a.user, pwhash.parse()?))
+                    let hash: PasswordHash = pwhash.parse()?;
+                    // Reject empty passwords.
+                    if hash.check("") {
+                        return Err(());
+                    }
+                    Ok((a.user, hash))
                 }
                 _ => Err(()),
             })
@@ -272,6 +277,27 @@ mod tests {
             pwhash: None,
         }];
         assert!(AuthorizationLayer::new(auth, None).is_err());
+    }
+
+    /// An empty password pre-hashed into a `pwhash` entry is just as unauthenticated as a
+    /// bare empty password, and must be rejected on the same grounds.
+    #[test]
+    fn pwhash_of_empty_password_is_rejected() {
+        use crate::config::RpcAuthSection;
+
+        let auth = vec![RpcAuthSection {
+            user: "__cookie__".to_string(),
+            password: None,
+            pwhash: Some(PasswordHash::from_bare("").to_string()),
+        }];
+        assert!(AuthorizationLayer::new(auth, None).is_err());
+
+        let auth = vec![RpcAuthSection {
+            user: "user1".to_string(),
+            password: None,
+            pwhash: Some(PasswordHash::from_bare("abadpassword").to_string()),
+        }];
+        assert!(AuthorizationLayer::new(auth, None).is_ok());
     }
 
     #[test]

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -118,6 +118,7 @@ use std::time::{Duration, SystemTime};
 use bip0039::{English, Mnemonic};
 use rusqlite::named_params;
 use secrecy::{ExposeSecret, SecretString, SecretVec, Zeroize};
+use subtle::ConstantTimeEq;
 use tokio::{
     sync::{Mutex, RwLock},
     task::JoinHandle,
@@ -890,8 +891,13 @@ impl KeyStore {
                 let extsk = decrypt_standalone_sapling_extsk(&identities, &encrypted_extsk)?;
 
                 // The ciphertext is not bound to the DFVK the row is keyed by, so verify
-                // that the decrypted key reproduces the DFVK used for the lookup.
-                if extsk.to_diversifiable_full_viewing_key().to_bytes() != dfvk_array {
+                // that the decrypted key reproduces it.
+                if !bool::from(
+                    extsk
+                        .to_diversifiable_full_viewing_key()
+                        .to_bytes()
+                        .ct_eq(&dfvk_array),
+                ) {
                     return Err(ErrorKind::Generic
                         .context(fl!("err-keystore-key-material-mismatch"))
                         .into());
@@ -1113,7 +1119,6 @@ fn encrypt_string(
 ///
 /// [ZIP 32]: https://zips.z.cash/zip-0032#seed-fingerprints
 fn seed_matches_fingerprint(seed: &[u8], seed_fp: &SeedFingerprint) -> bool {
-    use subtle::ConstantTimeEq;
     SeedFingerprint::from_seed(seed)
         .is_some_and(|fp| bool::from(fp.to_bytes().ct_eq(&seed_fp.to_bytes())))
 }


### PR DESCRIPTION
## Summary

Follow-ups to #677, targeting that PR's branch so they land together.

Each commit closes a gap in a hardening change #677 already makes: either the
change covers one location of a problem but not another, or it stops one step
short of the property it is meant to guarantee. One commit per fix, as in #677.

## Commits

### `c06bb54` — constant-time DFVK comparison

The binding check for the decrypted standalone Sapling `extsk` used a
short-circuiting `!=`, while `seed_matches_fingerprint` in the same commit moved
to `subtle::ConstantTimeEq`. Both operands here derive from a secret spending
key, so use the same comparison.

### `9f55387` — reject a pwhash that authenticates the empty password

#677 rejects an empty **bare** `password`, but the `pwhash` arm still accepts
any parseable hash — including one generated from the empty string.
`PasswordHash::from_bare("")` looks like any other hash, so `add-rpc-user`
output generated before that check, or a hand-written entry, still authenticates
the secretless credential `<username>:`.

This matters most for `__cookie__`: the username is defined in the source, and a
configured entry using it suppresses generated-cookie creation, so the resulting
credential is both publicly derivable and the only one in play. Each configured
pwhash is now checked against the empty string at load time.

### `d94dde5` — owner-only identity parent directory

`generate-encryption-identity` created missing parent directories at the process
umask (commonly 0755). It does not take the data directory lock, so it cannot
rely on #677's `lock_datadir` chmod: a datadir first initialized by this command
stays world-readable until some later command runs, and a custom `-o` path
outside the datadir is never restricted at all.

The acceptance test asserts mode 0700 so it holds regardless of the umask CI
runs under.

### `d1abb2a` — protected parameter input for `zallet rpc`

`zallet rpc` required every JSON-RPC parameter to be a command-line argument, so
`z_importkey` put a Sapling spending key in the process argument vector —
readable through process listings, and recorded in shell history. #677 removed
the `ZALLET_IDENTITY_PASSPHRASE` env-var channel; this is the argv side.

A parameter written `@PATH` is now read from the first line of `PATH` and sent
as a JSON string:

```
$ get-key-from-vault | zallet rpc z_importkey @- '"whenkeyisnew"'
$ zallet rpc z_importkey @/dev/fd/3 3<<<"$KEY"
$ zallet rpc z_importkey @-      # prompts without echo on a terminal
```

`@` cannot collide with an ordinary parameter, as no JSON value begins with it.
The read buffer is `Zeroizing`. This also fills in the `zcash-cli -stdin` row of
the comparison table in the book, previously "Not implemented".

### `dc4d23a` — bound the transaction before the expensive work

Two gaps remained after #677 made the action limit per-pool:

1. `z_sendmany` only bounded the transaction *after* proposing it, so an
   unreasonable `amounts` array still drove input selection first. Every
   recipient needs at least one output in its pool, so a request with more
   recipients than the limit cannot produce a passing proposal — reject it up
   front. The serialized-size bound (which also depends on memo lengths and
   selected inputs) remains #255.
2. `z_shieldcoinbase` had **no** action limit at all, though it is the method
   most likely to produce an oversized transaction: without `limit` it selects
   every eligible coinbase UTXO, as its own docstring warns. #677's extracted
   `check_shielded_action_limits` made this a few lines.

### `928c756` — CHANGELOG

Also drops a duplicated `zallet rpc help` entry introduced earlier on this
branch.

## Not included: exact `cargo-deb` pin

One more commit is ready but **not pushed**: the deb job installs
`cargo-deb --version "^2.10"` while the GPG signing key is already on the
runner, so a semver-compatible release from a compromised upstream would execute
next to the key without review. `--locked` pins cargo-deb's dependencies, not
cargo-deb itself. The fix pins `=2.12.1`.

My token lacks the `workflow` scope needed to push `.github/workflows/`. Happy
to add it here once that is sorted, or someone with the scope can apply the
one-line change directly.

## Testing

- `cargo test -p zallet-core --lib --all-features` — 295 passed, 0 failed.
- `cargo fmt` clean on all three manifests (workspace, zebra backend, zaino
  backend), and `cargo clippy` clean.
- Compiles under both `zallet_build = "wallet"` and
  `zallet_build = "merchant_terminal"`.
- New tests: `pwhash_of_empty_password_is_rejected`,
  `reads_first_line_without_terminator`, `missing_file_is_an_error`, plus a mode
  assertion in the existing `generate_encryption_identity_creates_missing_parent_dir`
  acceptance test.

Note: the `Latest build` CI job is failing on `main` as well — it deletes the
lockfiles and builds against newest dependencies, so it is unrelated to this
branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2qGvpzxEM1Vk1XNEz7Xg1

Closes https://github.com/zcash/zallet/issues/662
