### PR TITLE
fix(rpc): bound the async operation queue without discarding results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ be considered breaking changes.
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
 
+### Fixed
+
+- The queue of asynchronous RPC operations (`z_sendmany`, `z_shieldcoinbase`)
+  is now bounded (GHSA-3wr9-v982-59fj). Finished operations are still retained
+  until collected with `z_getoperationresult`, but once the queue reaches its
+  limit (configurable via `rpc.async_operation_limit`, default 1000), the
+  oldest finished operations are evicted to make room, and new operations are
+  rejected while the queue is full of unfinished operations. Previously the
+  queue was unbounded, allowing an authenticated caller to exhaust wallet
+  memory by starting operations without collecting their results.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Added

--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -337,6 +337,17 @@ as_of_version = "0.1.0-beta.2"
 #
 [rpc]
 
+# The maximum number of asynchronous RPC operations (e.g. `z_sendmany`) that can
+# be queued at once.
+#
+# Finished operations are retained in the queue until their results are collected
+# with `z_getoperationresult`, or until they are evicted (oldest first) to make
+# room for a new operation. New operations are rejected while the queue is full
+# of unfinished operations.
+#
+# Setting this to 0 disables the affected RPC methods entirely.
+#async_operation_limit = 1000
+
 # Addresses to listen for JSON-RPC connections.
 #
 # Note: The RPC server is disabled by default. To enable the RPC server, set a

--- a/zallet-core/src/components/json_rpc/asyncop.rs
+++ b/zallet-core/src/components/json_rpc/asyncop.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
@@ -12,7 +13,7 @@ use jsonrpsee::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, RwLockReadGuard};
 use uuid::Uuid;
 
 use super::server::LegacyCode;
@@ -73,6 +74,11 @@ impl OperationState {
             "success" => Some(Self::Success),
             _ => None,
         }
+    }
+
+    /// Returns whether an operation in this state has finished executing.
+    pub(super) fn is_finished(self) -> bool {
+        matches!(self, Self::Cancelled | Self::Failed | Self::Success)
     }
 }
 
@@ -243,6 +249,158 @@ impl AsyncOperation {
     }
 }
 
+/// A bounded queue of async operations.
+///
+/// Operations are retained in the queue after they finish so that their results can be
+/// collected with `z_getoperationresult` (matching `zcashd` behaviour). To bound the
+/// memory used by the queue, inserting an operation into a full queue evicts the oldest
+/// finished operations; if the queue is full of unfinished operations, the insertion is
+/// rejected instead.
+pub(super) struct OperationQueue {
+    ops: RwLock<Vec<AsyncOperation>>,
+    limit: usize,
+}
+
+impl OperationQueue {
+    pub(super) fn new(limit: usize) -> Self {
+        Self {
+            ops: RwLock::new(Vec::new()),
+            limit,
+        }
+    }
+
+    /// Launches a new async operation and inserts it into the queue.
+    ///
+    /// Returns an error (and does not launch the operation) if the queue is full of
+    /// unfinished operations.
+    pub(super) async fn insert<T: Serialize + Send + 'static>(
+        &self,
+        context: Option<ContextInfo>,
+        f: impl Future<Output = RpcResult<T>> + Send + 'static,
+    ) -> RpcResult<OperationId> {
+        // Determine which operations are evictable before taking the write lock, so
+        // that the queue remains readable while per-operation states are inspected.
+        let finished = self.finished_ids().await;
+
+        let mut ops = self.ops.write().await;
+        if ops.len() >= self.limit {
+            // Evict the oldest finished operations to make room. An operation that
+            // finished after the snapshot above remains evictable by later insertions.
+            let mut excess = (ops.len() + 1).saturating_sub(self.limit);
+            ops.retain(|op| {
+                if excess > 0 && finished.contains(op.operation_id()) {
+                    excess -= 1;
+                    false
+                } else {
+                    true
+                }
+            });
+            if ops.len() >= self.limit {
+                return Err(Self::full_error());
+            }
+        }
+
+        // `AsyncOperation::new` spawns the operation's task, so it must only be called
+        // once the operation is guaranteed a slot in the queue.
+        let op = AsyncOperation::new(context, f).await;
+        let operation_id = op.operation_id().clone();
+        ops.push(op);
+        Ok(operation_id)
+    }
+
+    /// Errors if a subsequent [`Self::insert`] would be rejected.
+    ///
+    /// Callers that do expensive work to construct an operation should check this first,
+    /// so that a request rejected by the queue is rejected cheaply. The answer is
+    /// necessarily advisory: the queue may fill up or drain between this check and the
+    /// insertion.
+    pub(super) async fn check_capacity(&self) -> RpcResult<()> {
+        if self.ops.read().await.len() < self.limit || self.any_finished().await {
+            Ok(())
+        } else {
+            Err(Self::full_error())
+        }
+    }
+
+    /// Returns a read guard over the operations in the queue.
+    pub(super) async fn read(&self) -> RwLockReadGuard<'_, Vec<AsyncOperation>> {
+        self.ops.read().await
+    }
+
+    /// Removes the finished operations matching `filter` from the queue, returning
+    /// their statuses.
+    ///
+    /// The queue's write lock is held for the duration, so concurrent calls cannot
+    /// collect the same result twice. Insertions must go through [`Self::insert`] to
+    /// maintain the queue bound.
+    pub(super) async fn collect_finished(
+        &self,
+        filter: impl Fn(&AsyncOperation) -> bool,
+    ) -> Vec<OperationStatus> {
+        let mut ops = self.ops.write().await;
+
+        let mut ret = vec![];
+        let mut remove = HashSet::new();
+        for op in ops.iter().filter(|op| filter(op)) {
+            if op.state().await.is_finished() {
+                ret.push(op.to_status().await);
+                remove.insert(op.operation_id().clone());
+            }
+        }
+        ops.retain(|op| !remove.contains(op.operation_id()));
+
+        ret
+    }
+
+    /// Returns whether any operation in the queue has finished executing.
+    ///
+    /// The queue lock is not held while individual operation states are read.
+    async fn any_finished(&self) -> bool {
+        let snapshot = self
+            .ops
+            .read()
+            .await
+            .iter()
+            .map(|op| op.data.clone())
+            .collect::<Vec<_>>();
+
+        for data in snapshot {
+            if data.read().await.state.is_finished() {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns the IDs of the operations that have finished executing.
+    ///
+    /// The queue lock is not held while individual operation states are read.
+    async fn finished_ids(&self) -> HashSet<OperationId> {
+        let snapshot = self
+            .ops
+            .read()
+            .await
+            .iter()
+            .map(|op| (op.operation_id().clone(), op.data.clone()))
+            .collect::<Vec<_>>();
+
+        let mut finished = HashSet::new();
+        for (operation_id, data) in snapshot {
+            if data.read().await.state.is_finished() {
+                finished.insert(operation_id);
+            }
+        }
+        finished
+    }
+
+    fn full_error() -> ErrorObjectOwned {
+        LegacyCode::OutOfMemory.with_static(
+            "Too many pending asynchronous operations; \
+             collect finished operations with z_getoperationresult",
+        )
+    }
+}
+
 /// The status of an async operation.
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub(crate) struct OperationStatus {
@@ -349,5 +507,122 @@ mod tests {
         let status = op.to_status().await;
         assert!(status.error.is_none());
         assert_eq!(status.result, Some(Value::from(42_u32)));
+    }
+
+    use tokio::sync::oneshot;
+
+    /// Inserts an operation that finishes once the returned sender is dropped.
+    async fn insert_op(queue: &OperationQueue) -> (OperationId, oneshot::Sender<()>) {
+        let (tx, rx) = oneshot::channel::<()>();
+        let operation_id = queue
+            .insert(None, async move {
+                let _ = rx.await;
+                Ok(())
+            })
+            .await
+            .expect("queue has capacity");
+        (operation_id, tx)
+    }
+
+    /// Finishes the given operation and waits for its state to reflect that.
+    async fn finish_op(
+        queue: &OperationQueue,
+        operation_id: &OperationId,
+        tx: oneshot::Sender<()>,
+    ) {
+        drop(tx);
+        for _ in 0..100 {
+            let ops = queue.read().await;
+            let op = ops
+                .iter()
+                .find(|op| op.operation_id() == operation_id)
+                .expect("operation is in the queue");
+            if op.state().await.is_finished() {
+                return;
+            }
+            drop(ops);
+            tokio::task::yield_now().await;
+        }
+        panic!("operation did not finish");
+    }
+
+    async fn queued_ids(queue: &OperationQueue) -> Vec<OperationId> {
+        queue
+            .read()
+            .await
+            .iter()
+            .map(|op| op.operation_id().clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn finished_operations_are_retained_below_the_limit() {
+        let queue = OperationQueue::new(4);
+
+        let (op_a, tx_a) = insert_op(&queue).await;
+        finish_op(&queue, &op_a, tx_a).await;
+
+        let (op_b, _tx_b) = insert_op(&queue).await;
+
+        // Inserting a new operation must not discard an uncollected result.
+        assert_eq!(queued_ids(&queue).await, vec![op_a, op_b]);
+    }
+
+    #[tokio::test]
+    async fn oldest_finished_operations_are_evicted_at_the_limit() {
+        let queue = OperationQueue::new(2);
+
+        let (op_a, tx_a) = insert_op(&queue).await;
+        finish_op(&queue, &op_a, tx_a).await;
+        let (op_b, tx_b) = insert_op(&queue).await;
+        finish_op(&queue, &op_b, tx_b).await;
+
+        let (op_c, _tx_c) = insert_op(&queue).await;
+
+        // Only the oldest finished operation is evicted to make room.
+        assert_eq!(queued_ids(&queue).await, vec![op_b, op_c]);
+    }
+
+    #[tokio::test]
+    async fn eviction_skips_unfinished_operations() {
+        let queue = OperationQueue::new(3);
+
+        let (op_a, _tx_a) = insert_op(&queue).await;
+        let (op_b, tx_b) = insert_op(&queue).await;
+        finish_op(&queue, &op_b, tx_b).await;
+        let (op_c, _tx_c) = insert_op(&queue).await;
+
+        let (op_d, _tx_d) = insert_op(&queue).await;
+
+        // The unfinished head of the queue is skipped; the oldest finished operation
+        // is evicted.
+        assert_eq!(queued_ids(&queue).await, vec![op_a, op_c, op_d]);
+    }
+
+    #[tokio::test]
+    async fn a_zero_limit_rejects_all_insertions() {
+        let queue = OperationQueue::new(0);
+
+        assert!(queue.check_capacity().await.is_err());
+        assert!(queue.insert(None, async { Ok(()) }).await.is_err());
+        assert!(queued_ids(&queue).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn insertions_are_rejected_while_full_of_unfinished_operations() {
+        let queue = OperationQueue::new(2);
+
+        let (op_a, tx_a) = insert_op(&queue).await;
+        let (op_b, _tx_b) = insert_op(&queue).await;
+
+        assert!(queue.check_capacity().await.is_err());
+        assert!(queue.insert(None, async { Ok(()) }).await.is_err());
+        assert_eq!(queued_ids(&queue).await, vec![op_a.clone(), op_b.clone()]);
+
+        // Capacity is reclaimed once an operation finishes.
+        finish_op(&queue, &op_a, tx_a).await;
+        assert!(queue.check_capacity().await.is_ok());
+        let (op_c, _tx_c) = insert_op(&queue).await;
+        assert_eq!(queued_ids(&queue).await, vec![op_b, op_c]);
     }
 }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -12,12 +12,10 @@ use crate::components::{
 
 #[cfg(zallet_build = "wallet")]
 use {
-    super::asyncop::{AsyncOperation, ContextInfo, OperationId},
+    super::asyncop::{OperationId, OperationQueue},
     crate::components::{
         json_rpc::payments::AmountParameter, keystore::KeyStore, sync::WalletDecryptorHandle,
     },
-    serde::Serialize,
-    tokio::sync::RwLock,
 };
 
 mod convert_tex;
@@ -1014,7 +1012,7 @@ pub(crate) struct WalletRpcImpl<C: Chain> {
     general: RpcImpl<C>,
     keystore: KeyStore,
     decryptor: WalletDecryptorHandle,
-    async_ops: RwLock<Vec<AsyncOperation>>,
+    async_ops: OperationQueue,
 }
 
 #[cfg(zallet_build = "wallet")]
@@ -1026,12 +1024,13 @@ impl<C: Chain> WalletRpcImpl<C> {
         chain_view: C,
         decryptor: WalletDecryptorHandle,
         sync_status: SyncStatusReader,
+        async_operation_limit: usize,
     ) -> Self {
         Self {
             general: RpcImpl::new(wallet, keystore.clone(), chain_view, sync_status),
             keystore,
             decryptor,
-            async_ops: RwLock::new(Vec::new()),
+            async_ops: OperationQueue::new(async_operation_limit),
         }
     }
 
@@ -1041,18 +1040,6 @@ impl<C: Chain> WalletRpcImpl<C> {
 
     async fn chain(&self) -> RpcResult<C> {
         self.general.chain().await
-    }
-
-    async fn start_async<F, T>(&self, (context, f): (Option<ContextInfo>, F)) -> OperationId
-    where
-        F: Future<Output = RpcResult<T>> + Send + 'static,
-        T: Serialize + Send + 'static,
-    {
-        let mut async_ops = self.async_ops.write().await;
-        let op = AsyncOperation::new(context, f).await;
-        let op_id = op.operation_id().clone();
-        async_ops.push(op);
-        op_id
     }
 }
 
@@ -1216,7 +1203,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
     }
 
     async fn get_operation_result(&self, operationid: Vec<OperationId>) -> get_operation::Response {
-        get_operation::result(self.async_ops.write().await.as_mut(), operationid).await
+        get_operation::result(&self.async_ops, operationid).await
     }
 
     async fn get_wallet_info(&self) -> get_wallet_info::Response {
@@ -1385,21 +1372,21 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         privacy_policy: Option<String>,
     ) -> z_send_many::Response {
         self.general.ensure_synced()?;
-        Ok(self
-            .start_async(
-                z_send_many::call(
-                    self.wallet().await?,
-                    self.keystore.clone(),
-                    self.chain().await?,
-                    fromaddress,
-                    amounts,
-                    minconf,
-                    fee,
-                    privacy_policy,
-                )
-                .await?,
-            )
-            .await)
+        // Cheaply reject the request if the operation could not be queued, before
+        // doing the expensive work of constructing a proposal.
+        self.async_ops.check_capacity().await?;
+        let (context, fut) = z_send_many::call(
+            self.wallet().await?,
+            self.keystore.clone(),
+            self.chain().await?,
+            fromaddress,
+            amounts,
+            minconf,
+            fee,
+            privacy_policy,
+        )
+        .await?;
+        self.async_ops.insert(context, fut).await
     }
 
     async fn z_send_from_account(
@@ -1433,6 +1420,9 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         privacy_policy: Option<String>,
     ) -> z_shieldcoinbase::Response {
         self.general.ensure_synced()?;
+        // Cheaply reject the request if the operation could not be queued, before
+        // doing the expensive work of constructing a proposal.
+        self.async_ops.check_capacity().await?;
         let (preflight, context, fut) = z_shieldcoinbase::call(
             self.wallet().await?,
             self.keystore.clone(),
@@ -1445,7 +1435,7 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             privacy_policy,
         )
         .await?;
-        let opid = self.start_async((context, fut)).await;
+        let opid = self.async_ops.insert(context, fut).await?;
         Ok(z_shieldcoinbase::ShieldCoinbaseResult::new(preflight, opid))
     }
 

--- a/zallet-core/src/components/json_rpc/methods/get_operation.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_operation.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::Serialize;
 
 use crate::components::json_rpc::asyncop::{
-    AsyncOperation, OperationId, OperationState, OperationStatus,
+    AsyncOperation, OperationId, OperationQueue, OperationStatus,
 };
 
 /// Response to a `z_getoperationstatus` or `z_getoperationresult` RPC request.
@@ -35,26 +35,12 @@ pub(crate) async fn status(
     Ok(ResultType(ret))
 }
 
-pub(crate) async fn result(
-    async_ops: &mut Vec<AsyncOperation>,
-    operationid: Vec<OperationId>,
-) -> Response {
+pub(crate) async fn result(async_ops: &OperationQueue, operationid: Vec<OperationId>) -> Response {
     let filter = operationid.into_iter().collect::<HashSet<_>>();
 
-    let mut ret = vec![];
-    let mut remove = HashSet::new();
-
-    for op in filtered(async_ops, filter) {
-        if matches!(
-            op.state().await,
-            OperationState::Success | OperationState::Failed | OperationState::Cancelled
-        ) {
-            ret.push(op.to_status().await);
-            remove.insert(op.operation_id().clone());
-        }
-    }
-
-    async_ops.retain(|op| !remove.contains(op.operation_id()));
+    let ret = async_ops
+        .collect_finished(|op| filter.is_empty() || filter.contains(op.operation_id()))
+        .await;
 
     Ok(ResultType(ret))
 }

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -59,6 +59,7 @@ pub(crate) async fn spawn<C: Chain>(
         chain.clone(),
         decryptor,
         sync_status.clone(),
+        config.async_operation_limit(),
     );
     let rpc_impl = RpcImpl::new(
         wallet,

--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -750,6 +750,17 @@ impl NoteManagementSection {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Documented, DocumentedFields)]
 #[serde(deny_unknown_fields)]
 pub struct RpcSection {
+    /// The maximum number of asynchronous RPC operations (e.g. `z_sendmany`) that can
+    /// be queued at once.
+    ///
+    /// Finished operations are retained in the queue until their results are collected
+    /// with `z_getoperationresult`, or until they are evicted (oldest first) to make
+    /// room for a new operation. New operations are rejected while the queue is full
+    /// of unfinished operations.
+    ///
+    /// Setting this to 0 disables the affected RPC methods entirely.
+    pub async_operation_limit: Option<usize>,
+
     /// Addresses to listen for JSON-RPC connections.
     ///
     /// Note: The RPC server is disabled by default. To enable the RPC server, set a
@@ -775,6 +786,13 @@ pub struct RpcSection {
 }
 
 impl RpcSection {
+    /// The maximum number of asynchronous RPC operations that can be queued at once.
+    ///
+    /// Default is 1000.
+    pub fn async_operation_limit(&self) -> usize {
+        self.async_operation_limit.unwrap_or(1000)
+    }
+
     /// Timeout during HTTP requests.
     ///
     /// Default is 30 seconds.
@@ -911,6 +929,7 @@ impl ZalletConfig {
                 "target_note_count",
                 conf.note_management.target_note_count(),
             ),
+            rpc("async_operation_limit", conf.rpc.async_operation_limit()),
             rpc("bind", &conf.rpc.bind),
             rpc("timeout", conf.rpc.timeout().as_secs()),
             sync("recover_batch_size", conf.sync.recover_batch_size()),


### PR DESCRIPTION
https://github.com/zcash/zallet/pull/725

Fixes GHSA-3wr9-v982-59fj: the queue of async operations backing z_sendmany and z_shieldcoinbase was unbounded, so an authenticated caller could exhaust wallet memory by starting operations without ever collecting their results.

Queue maintenance is now owned by a dedicated OperationQueue type. Finished operations are retained until collected via z_getoperationresult (matching zcashd), but inserting into a full queue evicts the oldest finished operations, and fails if the queue is full of unfinished operations. The bound is configurable via rpc.async_operation_limit (default 1000). Async RPC methods check capacity before constructing a proposal, so rejected requests are rejected cheaply, and eviction candidates are computed without holding the queue lock across per-operation state reads.