### PR TITLE
init-wallet-encryption: canonicalize and validate age recipients before storing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ be considered breaking changes.
 
 ### Fixed
 
+- `init-wallet-encryption` now canonicalizes the age recipients derived from
+  the identity file before storing them, and validates that the resulting set
+  is non-empty and parseable. Previously every line of the internally generated
+  recipients file was stored verbatim as a recipient; the format permits
+  comments and blank lines, and a stray entry would only surface as an error
+  the first time the wallet tried to encrypt key material (e.g. during
+  `generate-mnemonic`) rather than failing initialization. `@`-prefixed
+  recipient entries are rejected, as indirection through external sources
+  cannot be part of the wallet's stored recipient set.
 - The queue of asynchronous RPC operations (`z_sendmany`, `z_shieldcoinbase`)
   is now bounded (GHSA-3wr9-v982-59fj). Finished operations are still retained
   until collected with `z_getoperationresult`, but once the queue reaches its

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -192,6 +192,10 @@ err-config-backend-mismatch = The config file selects the '{$configured}' chain 
 err-keystore-missing-recipients = The wallet has not been set up to store key material securely.
 rec-keystore-missing-recipients = Have you run '{$init_cmd}'?
 err-keystore-already-initialized = Keystore age recipients already initialized
+err-keystore-empty-recipients = No age recipients were derived from the encryption identity file.
+err-keystore-recipient-indirection =
+    Refusing to store the age recipient entry '{$entry}': '@'-prefixed indirection is not
+    supported in the wallet's recipient set.
 err-keystore-key-material-mismatch =
     Decrypted key material does not match the fingerprint it is stored under. The wallet
     database is corrupted or has been tampered with.

--- a/zallet-core/src/commands/init_wallet_encryption.rs
+++ b/zallet-core/src/commands/init_wallet_encryption.rs
@@ -3,7 +3,10 @@ use abscissa_core::Runnable;
 use crate::{
     cli::InitWalletEncryptionCmd,
     commands::AsyncRunnable,
-    components::{database::Database, keystore::KeyStore},
+    components::{
+        database::Database,
+        keystore::{KeyStore, canonicalize_recipients_file},
+    },
     error::{Error, ErrorKind},
     fl,
     prelude::*,
@@ -46,16 +49,17 @@ impl AsyncRunnable for InitWalletEncryptionCmd {
         }
         .map_err(|e| ErrorKind::Generic.context(e))?;
 
-        // Write out a recipients file, then parse it back into recipient strings.
+        // Write out a recipients file, then canonicalize it back into bare recipient
+        // strings. The file format permits comments and blank lines, which must not be
+        // stored as recipients.
         let mut recipients = vec![];
         identity_file
             .write_recipients_file(&mut recipients)
             .map_err(|e| ErrorKind::Generic.context(e))?;
-        let recipient_strings = String::from_utf8(recipients)
-            .map_err(|e| ErrorKind::Generic.context(e))?
-            .lines()
-            .map(String::from)
-            .collect();
+        let recipient_strings = canonicalize_recipients_file(
+            &String::from_utf8(recipients).map_err(|e| ErrorKind::Generic.context(e))?,
+        )
+        .map_err(|e| ErrorKind::Generic.context(e))?;
 
         // Store the recipients in the keystore.
         keystore.initialize_recipients(recipient_strings).await

--- a/zallet-core/src/components/json_rpc/methods/unlock_wallet.rs
+++ b/zallet-core/src/components/json_rpc/methods/unlock_wallet.rs
@@ -37,5 +37,10 @@ pub(crate) async fn call(keystore: &KeyStore, passphrase: SecretString, timeout:
         Err(KeystoreError::MissingRecipients) => Err(LegacyCode::WalletWrongEncState.with_static(
             "Error: running with an unencrypted wallet, but walletpassphrase was called.",
         )),
+        // Recipient-initialization errors cannot occur while unlocking, but map them
+        // faithfully in case that ever changes.
+        Err(e @ (KeystoreError::EmptyRecipients | KeystoreError::RecipientIndirection(_))) => {
+            Err(LegacyCode::Wallet.with_message(format!("Error: {e}")))
+        }
     }
 }

--- a/zallet-core/src/components/keystore.rs
+++ b/zallet-core/src/components/keystore.rs
@@ -418,6 +418,16 @@ impl KeyStore {
         &self,
         recipient_strings: Vec<String>,
     ) -> Result<(), Error> {
+        // Validate up front so a malformed or empty recipient set fails initialization
+        // with a clear error, instead of being stored and then breaking the wallet at
+        // the first attempt to encrypt key material.
+        if recipient_strings.is_empty() {
+            return Err(ErrorKind::Generic
+                .context(KeystoreError::EmptyRecipients)
+                .into());
+        }
+        Encryptor::parse_recipient_strings(recipient_strings.clone())?;
+
         let now = ::time::OffsetDateTime::now_utc();
 
         self.with_db_mut(|conn, _| {
@@ -961,6 +971,27 @@ impl KeyStore {
     }
 }
 
+/// Canonicalizes the contents of an age recipients file into bare recipient strings.
+///
+/// The age recipients-file format permits blank lines and `#`-prefixed comments; neither
+/// is a recipient, so both are dropped rather than stored. `@`-prefixed entries are
+/// rejected: they denote indirection through an external source, which would make the
+/// effective recipient set depend on state outside the stored set itself.
+pub(crate) fn canonicalize_recipients_file(contents: &str) -> Result<Vec<String>, KeystoreError> {
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            if line.starts_with('@') {
+                Err(KeystoreError::RecipientIndirection(line.into()))
+            } else {
+                Ok(line.into())
+            }
+        })
+        .collect()
+}
+
 pub(crate) struct Encryptor {
     recipient_strings: Vec<String>,
     recipients: Vec<Box<dyn age::Recipient + Send>>,
@@ -1252,7 +1283,10 @@ mod tests {
     use secrecy::SecretString;
     use zip32::fingerprint::SeedFingerprint;
 
-    use super::{mnemonic_matches_fingerprint, seed_matches_fingerprint};
+    use super::{
+        KeystoreError, canonicalize_recipients_file, mnemonic_matches_fingerprint,
+        seed_matches_fingerprint,
+    };
 
     proptest! {
         #[test]
@@ -1312,6 +1346,43 @@ mod tests {
         let phrase = SecretString::new("not a mnemonic".into());
         assert!(
             mnemonic_matches_fingerprint(&phrase, &SeedFingerprint::from_bytes([0; 32])).is_err()
+        );
+    }
+
+    #[test]
+    fn recipients_file_canonicalization_keeps_only_recipient_lines() {
+        let contents =
+            "# created: 2026-08-04\n\nage1first\n   \t\n  age1second  \n# trailing comment";
+        assert_eq!(
+            canonicalize_recipients_file(contents),
+            Ok(vec!["age1first".into(), "age1second".into()]),
+        );
+    }
+
+    #[test]
+    fn recipients_file_canonicalization_handles_crlf() {
+        let contents = "# comment\r\nage1first\r\n\r\nage1second\r\n";
+        assert_eq!(
+            canonicalize_recipients_file(contents),
+            Ok(vec!["age1first".into(), "age1second".into()]),
+        );
+    }
+
+    #[test]
+    fn recipients_file_canonicalization_of_only_comments_is_empty() {
+        assert_eq!(
+            canonicalize_recipients_file("# nothing here\n\n"),
+            Ok(vec![]),
+        );
+    }
+
+    #[test]
+    fn recipients_file_canonicalization_rejects_indirection() {
+        assert_eq!(
+            canonicalize_recipients_file("age1first\n  @/etc/age/recipients.txt\n"),
+            Err(KeystoreError::RecipientIndirection(
+                "@/etc/age/recipients.txt".into()
+            )),
         );
     }
 }

--- a/zallet-core/src/components/keystore/error.rs
+++ b/zallet-core/src/components/keystore/error.rs
@@ -28,6 +28,11 @@ macro_rules! wlnfl {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum KeystoreError {
     MissingRecipients,
+    /// The recipient set the keystore was asked to initialize with is empty.
+    EmptyRecipients,
+    /// An age recipients file contained an `@`-prefixed indirection entry, which cannot
+    /// be stored as a recipient.
+    RecipientIndirection(String),
     /// The provided passphrase did not decrypt the keystore's age identities.
     IncorrectPassphrase,
     /// The requested unlock timeout is large enough that the re-lock deadline would
@@ -47,6 +52,14 @@ impl fmt::Display for KeystoreError {
                         "zallet -d {} init-wallet-encryption",
                         APP.config().datadir().display()
                     )
+                )
+            }
+            Self::EmptyRecipients => wfl!(f, "err-keystore-empty-recipients"),
+            Self::RecipientIndirection(entry) => {
+                wfl!(
+                    f,
+                    "err-keystore-recipient-indirection",
+                    entry = entry.as_str()
                 )
             }
             Self::IncorrectPassphrase => wfl!(f, "err-keystore-incorrect-passphrase"),


### PR DESCRIPTION
The recipients stored by `init-wallet-encryption` were obtained by writing an age recipients file to a buffer and splitting it on newlines, storing **every** line as a recipient row. The age recipients-file format permits `#` comments and blank lines, so this was an unvalidated assumption about `IdentityFile::write_recipients_file`'s output. It holds for the identities we generate today (so this is latent rather than live), but nothing guarantees it.

Compounding it, `initialize_recipients` inserted whatever it was handed without parsing it, so any bad entry would make `init-wallet-encryption` report success and the wallet would only break at the first attempt to encrypt key material (e.g. `generate-mnemonic`), with an error pointing at the keystore rather than at initialization.

## What changes

- A `canonicalize_recipients_file` helper in the keystore turns recipients-file contents into bare recipient strings: lines are trimmed, blank lines and `#` comments are dropped, and `@`-prefixed entries are rejected (they denote indirection through an external source, which would make the effective recipient set depend on state outside the stored set itself). `init-wallet-encryption` now stores its output instead of the raw lines.
- `initialize_recipients` validates up front that the recipient set is non-empty and parses via the same path the encryptor uses, so a bad set fails initialization with a clear error instead of deferring the failure to first use.
- New `KeystoreError::{EmptyRecipients, RecipientIndirection}` variants with Fluent messages; the exhaustive match in `walletpassphrase` maps them faithfully even though `unlock` cannot produce them.

## Test evidence

- New unit tests over the canonicalization helper: comments, blank lines, leading/trailing whitespace, CRLF, comment-only input, and `@`-prefixed entries.
- All three workspace legs pass locally: root (`cargo fmt`/`clippy -D warnings`/`test`, 319 tests), zebra backend (including the `generate_encryption_identity_drives_setup` acceptance test, which exercises `init-wallet-encryption` → `generate-mnemonic` end to end), and zaino backend.
- `cargo +beta clippy --tests --all-features --all-targets` introduces no new warnings (the three `useless_format` warnings it reports are preexisting, in files this PR does not touch).

No manifests or lockfiles change, so librustzcash lockstep is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdVA42x8NdPH5mnFVehqJQ